### PR TITLE
Added Map Credits In Lobby. Nerfed Cazador. Fixed More Loc.

### DIFF
--- a/Content.Client/Credits/CreditsWindow.xaml.cs
+++ b/Content.Client/Credits/CreditsWindow.xaml.cs
@@ -27,11 +27,15 @@ namespace Content.Client.Credits
         [Dependency] private readonly IResourceManager _resourceManager = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
 
+        // #Misfits Change - Updated patron tiers to match Misfits Patreon tiers
         private static readonly Dictionary<string, int> PatronTierPriority = new()
         {
-            ["Central Commander"] = 1,
-            ["Captain"] = 2,
-            ["Assistant"] = 3
+            // ["Central Commander"] = 1,
+            // ["Captain"] = 2,
+            // ["Assistant"] = 3
+            ["Nuclear"] = 1,
+            ["Gold"] = 2,
+            ["Silver"] = 3
         };
 
         public CreditsWindow()
@@ -84,7 +88,8 @@ namespace Content.Client.Credits
             }
 
             var first = true;
-            foreach (var tier in patrons.GroupBy(p => p.Tier).OrderBy(p => PatronTierPriority[p.Key]))
+            // #Misfits Fix - Use TryGetValue to avoid crash on unknown tiers
+            foreach (var tier in patrons.GroupBy(p => p.Tier).OrderBy(p => PatronTierPriority.TryGetValue(p.Key, out var prio) ? prio : int.MaxValue))
             {
                 if (!first)
                 {

--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -33,6 +33,10 @@ namespace Content.Client.GameTicking.Managers
         [ViewVariables] public TimeSpan StartTime { get; private set; }
         [ViewVariables] public new bool Paused { get; private set; }
 
+        // #Misfits Add - Map credit info for lobby display
+        [ViewVariables] public string? MapName { get; private set; }
+        [ViewVariables] public string? MapAuthor { get; private set; }
+
         [ViewVariables] public IReadOnlyDictionary<NetEntity, Dictionary<string, uint?>> JobsAvailable => _jobsAvailable;
         [ViewVariables] public IReadOnlyDictionary<NetEntity, string> StationNames => _stationNames;
 
@@ -121,6 +125,9 @@ namespace Content.Client.GameTicking.Managers
             AreWeReady = message.YouAreReady;
             LobbyBackground = message.LobbyBackground;
             Paused = message.Paused;
+            // #Misfits Add - Store map credit info from server
+            MapName = message.MapName;
+            MapAuthor = message.MapAuthor;
 
             LobbyStatusUpdated?.Invoke();
         }

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -143,6 +143,7 @@ namespace Content.Client.Lobby
         {
             UpdateLobbyBackground();
             UpdateLobbyUi();
+            UpdateMapCredit(); // #Misfits Add - update map credit when lobby status changes
         }
 
         private void LobbyLateJoinStatusUpdated()
@@ -226,6 +227,32 @@ namespace Content.Client.Lobby
             _sawmill.Warning("_gameTicker.LobbyBackground was null! No lobby background selected.");
             Lobby!.Background.Texture = null;
             Lobby!.LobbyBackground.SetMarkup(Loc.GetString("lobby-state-background-no-background-text"));
+        }
+
+        // #Misfits Add - Display map name and author credit in the lobby bottom bar
+        private void UpdateMapCredit()
+        {
+            var mapName = _gameTicker.MapName;
+            var mapAuthor = _gameTicker.MapAuthor;
+
+            if (!string.IsNullOrEmpty(mapName))
+            {
+                if (!string.IsNullOrEmpty(mapAuthor))
+                {
+                    Lobby!.MapCredit.SetMarkup(Loc.GetString("lobby-state-map-text",
+                        ("mapName", mapName),
+                        ("mapAuthor", mapAuthor)));
+                }
+                else
+                {
+                    Lobby!.MapCredit.SetMarkup(Loc.GetString("lobby-state-map-no-author-text",
+                        ("mapName", mapName)));
+                }
+            }
+            else
+            {
+                Lobby!.MapCredit.SetMarkup(Loc.GetString("lobby-state-map-no-map-text"));
+            }
         }
 
         private void SetReady(bool newReady)

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -58,6 +58,10 @@
                         <PanelContainer StyleClasses="AngleRect">
                             <RichTextLabel Name="LobbyBackground" Access="Public" HorizontalAlignment="Center" />
                         </PanelContainer>
+                        <!-- #Misfits Add - Map credit display in lobby bottom bar -->
+                        <PanelContainer StyleClasses="AngleRect">
+                            <RichTextLabel Name="MapCredit" Access="Public" HorizontalAlignment="Center" />
+                        </PanelContainer>
                     </BoxContainer>
                 </Control>
                 <!-- Character setup state -->

--- a/Content.Client/Lobby/UI/LobbyGui.xaml.cs
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml.cs
@@ -23,6 +23,7 @@ namespace Content.Client.Lobby.UI
 
             LobbySong.SetMarkup(Loc.GetString("lobby-state-song-no-song-text"));
             LobbyBackground.SetMarkup(Loc.GetString("lobby-state-background-no-background-text"));
+            MapCredit.SetMarkup(Loc.GetString("lobby-state-map-no-map-text")); // #Misfits Add - map credit default
 
             LeaveButton.OnPressed += _ => _consoleHost.ExecuteCommand("disconnect");
             OptionsButton.OnPressed += _ => UserInterfaceManager.GetUIController<OptionsUIController>().ToggleWindow();

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -74,6 +74,9 @@ namespace Content.Server.GameTicking
 
             var gmTitle = Loc.GetString(preset.ModeTitle);
             var desc = Loc.GetString(preset.Description);
+            // #Misfits Add - Include map author in lobby info text
+            var selectedMap = _gameMapManager.GetSelectedMap();
+            var mapAuthor = selectedMap?.MapAuthor ?? Loc.GetString("game-ticker-unknown-map-author");
             return Loc.GetString(
                 RunLevel == GameRunLevel.PreRoundLobby
                     ? "game-ticker-get-info-preround-text"
@@ -82,6 +85,7 @@ namespace Content.Server.GameTicking
                 ("playerCount", playerCount),
                 ("readyCount", readyCount),
                 ("mapName", stationNames.ToString()),
+                ("mapAuthor", mapAuthor),
                 ("gmTitle", gmTitle),
                 ("desc", desc));
         }
@@ -94,7 +98,9 @@ namespace Content.Server.GameTicking
         private TickerLobbyStatusEvent GetStatusMsg(ICommonSession session)
         {
             _playerGameStatuses.TryGetValue(session.UserId, out var status);
-            return new TickerLobbyStatusEvent(RunLevel != GameRunLevel.PreRoundLobby, LobbyBackground, status == PlayerGameStatus.ReadyToPlay, _roundStartTime, RoundPreloadTime, RoundStartTimeSpan, Paused);
+            // #Misfits Add - Include map name/author for lobby credit display
+            var selectedMap = _gameMapManager.GetSelectedMap();
+            return new TickerLobbyStatusEvent(RunLevel != GameRunLevel.PreRoundLobby, LobbyBackground, status == PlayerGameStatus.ReadyToPlay, _roundStartTime, RoundPreloadTime, RoundStartTimeSpan, Paused, selectedMap?.MapName, selectedMap?.MapAuthor);
         }
 
         private void SendStatusToAll()

--- a/Content.Server/_Misfits/Maps/GameMapPrototype.Misfits.cs
+++ b/Content.Server/_Misfits/Maps/GameMapPrototype.Misfits.cs
@@ -1,0 +1,17 @@
+// #Misfits Add - Map author/credit field for lobby display
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Maps;
+
+/// <summary>
+/// Misfits extension: adds an optional author credit to the game map prototype
+/// so it can be displayed in the lobby UI.
+/// </summary>
+public sealed partial class GameMapPrototype
+{
+    /// <summary>
+    /// The author/creator of this map, displayed in the lobby.
+    /// </summary>
+    [DataField("mapAuthor")]
+    public string? MapAuthor { get; private set; }
+}

--- a/Content.Server/_Misfits/OreCluster/MisfitsOreClusterSpawnerComponent.cs
+++ b/Content.Server/_Misfits/OreCluster/MisfitsOreClusterSpawnerComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class MisfitsOreClusterSpawnerComponent : Component
     /// so per-ore randomisation still happens at MapInit.
     /// </summary>
     [DataField(required: true)]
-    public EntProtoId WallEntity = "N14WallRockDroughtSlantedMining";
+    public EntProtoId WallEntity = "N14WallRockMammothSlanted"; // Misfits Tweak - switched from DroughtSlanted to MammothSlanted for visual consistency
 
     /// <summary>
     /// Minimum blob radius in tiles.

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -86,7 +86,11 @@ namespace Content.Shared.GameTicking
         public TimeSpan RoundStartTimeSpan { get; }
         public bool Paused { get; }
 
-        public TickerLobbyStatusEvent(bool isRoundStarted, LobbyBackgroundPrototype? lobbyBackground, bool youAreReady, TimeSpan startTime, TimeSpan preloadTime, TimeSpan roundStartTimeSpan, bool paused)
+        // #Misfits Add - Map credit info sent to lobby clients
+        public string? MapName { get; }
+        public string? MapAuthor { get; }
+
+        public TickerLobbyStatusEvent(bool isRoundStarted, LobbyBackgroundPrototype? lobbyBackground, bool youAreReady, TimeSpan startTime, TimeSpan preloadTime, TimeSpan roundStartTimeSpan, bool paused, string? mapName = null, string? mapAuthor = null)
         {
             IsRoundStarted = isRoundStarted;
             LobbyBackground = lobbyBackground;
@@ -94,6 +98,8 @@ namespace Content.Shared.GameTicking
             StartTime = startTime;
             RoundStartTimeSpan = roundStartTimeSpan;
             Paused = paused;
+            MapName = mapName;
+            MapAuthor = mapAuthor;
         }
     }
 

--- a/Resources/ConfigPresets/MNW14/mnw.toml
+++ b/Resources/ConfigPresets/MNW14/mnw.toml
@@ -61,7 +61,7 @@ id_job_length = 50
 discord = "https://discord.com/invite/8a6y8esphP"
 #forum = "https://forum.rouny-ss14.com"
 github = "https://github.com/Misfit-Sanctuary/nuclear-14"
-patreon = "https://www.patreon.com/15572862/join"
+#patreon = "https://www.patreon.com/15572862/join" # Misfits Change - blanked, Valve TOS conflict on Steam builds
 #website = ""
 wiki = "https://ss14.misfitsystems.net/wiki/index.php/Main_Page"
 

--- a/Resources/Locale/en-US/_Misfits/job-supervisors.ftl
+++ b/Resources/Locale/en-US/_Misfits/job-supervisors.ftl
@@ -7,7 +7,8 @@ job-supervisors-supermutant = your instincts and the strongest among you
 
 # #Misfits Add — New consolidated Brotherhood of Steel supervisor strings.
 job-supervisors-bos-west-elder = no one, but your duty to the Brotherhood
-job-supervisors-bos-west = the Elder # #Misfits Add: missing key — used by bos_headscribe.yml (Head Scribe reports to Elder)
+# #Misfits Add: missing key — used by bos_headscribe.yml (Head Scribe reports to Elder)
+job-supervisors-bos-west = the Elder
 job-supervisors-bos-headknight = the Elder
 job-supervisors-bos-paladin = the Head Paladin and Elder
 job-supervisors-bos-knight = the Head Knight, Head Paladin, and Elder

--- a/Resources/Locale/en-US/_Misfits/lobby/lobby-state.ftl
+++ b/Resources/Locale/en-US/_Misfits/lobby/lobby-state.ftl
@@ -1,0 +1,4 @@
+# Misfits Add - Map credit display in lobby bottom bar
+lobby-state-map-text = Map: [color=white]{$mapName}[/color] by [color=white]{$mapAuthor}[/color]
+lobby-state-map-no-author-text = Map: [color=white]{$mapName}[/color]
+lobby-state-map-no-map-text = No map selected.

--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -11,7 +11,7 @@ game-ticker-player-join-game-message = Welcome to Misfits: Nuclear Wasteland! If
 game-ticker-get-info-text = Hi and welcome to [color=white]Misfits: Nuclear Wasteland![/color]
                             The current round is: [color=white]#{$roundId}[/color]
                             The current player count is: [color=white]{$playerCount}[/color]
-                            The current map is: [color=white]{$mapName}[/color]
+                            The current map is: [color=white]{$mapName}[/color] by [color=white]{$mapAuthor}[/color]
                             The current game mode is: [color=white]{$gmTitle}[/color]
                             >[color=yellow]{$desc}[/color]
 game-ticker-get-info-preround-text = Hi and welcome to [color=white]Misfits: Nuclear Wasteland![/color]
@@ -20,10 +20,11 @@ game-ticker-get-info-preround-text = Hi and welcome to [color=white]Misfits: Nuc
                                 [one] is
                                 *[other] are
                             } ready)
-                            The current map is: [color=white]{$mapName}[/color]
+                            The current map is: [color=white]{$mapName}[/color] by [color=white]{$mapAuthor}[/color]
                             The current game mode is: [color=white]{$gmTitle}[/color]
                             >[color=yellow]{$desc}[/color]
 game-ticker-no-map-selected = [color=yellow]Map not yet selected![/color]
+game-ticker-unknown-map-author = Unknown
 game-ticker-player-no-jobs-available-when-joining = When attempting to join to the game, no jobs were available.
 game-ticker-welcome-to-the-station = You wake up somewhere in Utah.
 

--- a/Resources/Locale/en-US/materials/materials.ftl
+++ b/Resources/Locale/en-US/materials/materials.ftl
@@ -32,7 +32,9 @@ materials-normality = normality
 
 # Ores
 materials-raw-iron = raw iron
-materials-raw-quartz = quartz # Misfits Change - Fallout relevance, renamed from "raw quartz"
+materials-raw-diamond = raw diamond
+# #Misfits Change: Fallout relevance, renamed from "raw quartz"
+materials-raw-quartz = quartz
 materials-raw-gold = raw gold
 materials-raw-silver = raw silver
 materials-raw-plasma = raw plasma

--- a/Resources/Locale/en-US/power/components/generator.ftl
+++ b/Resources/Locale/en-US/power/components/generator.ftl
@@ -23,8 +23,10 @@ portable-generator-ui-eject = Eject
 portable-generator-ui-eta = (~{ $minutes } min)
 portable-generator-ui-unanchored = Unanchored
 portable-generator-ui-current-output = Current output: {$voltage}
-portable-generator-ui-power-switch = Power: # #Misfits Add: was missing — used as initial label for the status row in GeneratorWindow.xaml
-portable-generator-ui-switch = Output: # #Misfits Add: was missing — used as initial label for the output-voltage switch row in GeneratorWindow.xaml
+# #Misfits Add: was missing — used as initial label for the status row in GeneratorWindow.xaml
+portable-generator-ui-power-switch = Power:
+# #Misfits Add: was missing — used as initial label for the output-voltage switch row in GeneratorWindow.xaml
+portable-generator-ui-switch = Output:
 portable-generator-ui-network-stats = Network:
 portable-generator-ui-network-stats-value = { POWERWATTS($supply) } / { POWERWATTS($load) }
 portable-generator-ui-network-stats-not-connected = Not connected

--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -12,6 +12,7 @@
 - type: gameMap
   id: Wendover
   mapName: 'Wendover'
+  mapAuthor: 'mc_rainbow32' # Misfits Add - map credit displayed in lobby
   mapPath: /Maps/Misfits/Wendover.yml
   minPlayers: 0
   stations:

--- a/Resources/Prototypes/_Misfits/Entities/Markers/Spawners/ore_cluster_spawner.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Markers/Spawners/ore_cluster_spawner.yml
@@ -32,10 +32,10 @@
 - type: entity
   id: MisfitsOreClusterSpawner
   parent: MisfitsOreClusterSpawnerBase
-  suffix: Drought Rock
+  suffix: Mammoth Rock
   components:
   - type: MisfitsOreClusterSpawner
-    wallEntity: N14WallRockDroughtSlantedMining
+    wallEntity: N14WallRockMammothSlanted # Misfits Tweak - switched from DroughtSlanted
     minRadius: 4
     maxRadius: 9
     fillChance: 0.65
@@ -44,10 +44,10 @@
 - type: entity
   id: MisfitsOreClusterSpawnerSmall
   parent: MisfitsOreClusterSpawnerBase
-  suffix: Drought Rock Small
+  suffix: Mammoth Rock Small
   components:
   - type: MisfitsOreClusterSpawner
-    wallEntity: N14WallRockDroughtSlantedMining
+    wallEntity: N14WallRockMammothSlanted # Misfits Tweak - switched from DroughtSlanted
     minRadius: 2
     maxRadius: 5
     fillChance: 0.70
@@ -56,10 +56,10 @@
 - type: entity
   id: MisfitsOreClusterSpawnerDense
   parent: MisfitsOreClusterSpawnerBase
-  suffix: Drought Rock Dense
+  suffix: Mammoth Rock Dense
   components:
   - type: MisfitsOreClusterSpawner
-    wallEntity: N14WallRockDroughtSlantedMining
+    wallEntity: N14WallRockMammothSlanted # Misfits Tweak - switched from DroughtSlanted
     minRadius: 5
     maxRadius: 9
     fillChance: 0.85

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/insects.yml
@@ -406,7 +406,7 @@
   components:
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
-    baseSprintSpeed : 6
+    baseSprintSpeed : 5 #Misfits Tweak - reduced from 6, cazadors were too fast to outrun
   - type: Sprite
     drawdepth: Mobs
     layers:
@@ -471,7 +471,7 @@
         Quantity: 0.25
   - type: MeleeChemicalInjector
     solution: melee
-    transferAmount: 1.5
+    transferAmount: 0.5 #Misfits Tweak - reduced from 1.5, less venom per sting
   - type: Butcherable
     spawned:
     - id: N14FoodMeatRadRaw
@@ -482,7 +482,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead # Corvax-Change
+      75: Dead #Misfits Tweak - reduced from 100, cazadors were too tanky
   - type: AggroSound #Misfits Change
     sound:
       collection: N14CazadorAttack

--- a/Resources/Prototypes/_Nuclear14/Reagents/toxins.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/toxins.yml
@@ -70,6 +70,6 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: 3
+            Poison: 1 #Misfits Tweak - reduced from 3, cazador venom was too lethal
           groups:
-            Airloss: 3.5
+            Airloss: 1.5 #Misfits Tweak - reduced from 3.5, cazador venom was too lethal


### PR DESCRIPTION
:cl: cythisiax

add: Wendover credits to mc_rainbow32 publicly facing.
add: Notifications to new objectives in 'Lore' tab, provided to faction leaders.
tweak: Nerfed cazador. Venom > 0.5. Poison > 1. Air > 1.5.
tweak: Removed #Misfits Add comments from .ftl localization files.
tweak: MisfitsOre used same sprite prototype for walls as indestructible. Changed to bassalt/grey prototype sooo you can see it easier.
:tweak: forgetting something, oh right re-enabled credits tab, blanked our patreon tab.