### PR TITLE
Jukebox Catalogue Fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Catalog/Jukebox/Standard.yml
+++ b/Resources/Prototypes/_Nuclear14/Catalog/Jukebox/Standard.yml
@@ -7,183 +7,182 @@
     path: /Audio/_Nuclear14/Lobby/a_kiss_to_build_a_dream_on.ogg
 
 - type: jukebox
+  id: TexBenekeGuy
+  name: Tex Beneke - A Wonderful Guy
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_texbeneke_guy_mono.ogg
+
+- type: jukebox
   id: AintThatAKickInTheHead
   name: Dean Martin - Ain't That A Kick In The Head
   path:
     path: /Audio/_Nuclear14/Lobby/MUS_Aint_That_A_Kick_In_the_Head.ogg
 
 - type: jukebox
+  id: PatrioticAmerica
+  name: America the Beautiful
+  path:
+    path: /Audio/_Nuclear14/Music/MUS_Patriotic_America.ogg 
+
+- type: jukebox
   id: AmericanSwing
   name: Gerhard Trede - American Swing
   path:
     path: /Audio/_Nuclear14/Lobby/MUS_American_Swing.ogg
-    
+
+- type: jukebox
+  id: ColePorterAnything
+  name: Cole Porter - Anything Goes
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_coleporter_anything_mono.ogg
+
 - type: jukebox
   id: BigIron
   name: Marty Robins - Big Iron
   path:
     path: /Audio/_Nuclear14/Lobby/MUS_Big_Iron.ogg
-    
+
+- type: jukebox
+  id: RoyBrownButcher
+  name: Roy Brown - Butcher Pete (Pt. 1)
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_roybrown_butcher_mono.ogg
+
+- type: jukebox
+  id: DannyKayeCivilization
+  name: Danny Kaye - Civilization
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_dannykaye_civilization_mono.ogg
+
+- type: jukebox
+  id: BillieHolidayCrazy
+  name: Billie Holiday - Crazy He Calls Me
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_billieholiday_crazy_mono.ogg
+
+- type: jukebox
+  id: PatrioticDixie
+  name: Dixie
+  path:
+    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Dixie.ogg
+
+- type: jukebox
+  id: BillieHolidayEasy
+  name: Billie Holiday - Easy Living
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_billieholiday_easy_mono.ogg
+
+- type: jukebox
+  id: GenericFox
+  name: Gerhard Trede - Fox Boggie
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_fox_mono.ogg
+
+- type: jukebox
+  id: PatrioticPresidential
+  name: Hail Columbia
+  path:
+    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Presidential.ogg
+
+- type: jukebox
+  id: PatrioticMontezuma
+  name: Halls of Montezuma
+  path:
+    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Montezuma.ogg
+
+- type: jukebox
+  id: BobCrosbyHappy
+  name: Bob Crosby - Happy Times
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_bobcrosby_happy_mono.ogg
+
+- type: jukebox
+  id: InkspotsIDont
+  name: Inkspots - I Don't Want to Set the World on Fire
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_inkspots_idont_mono.ogg
+
+- type: jukebox
+  id: GenericJazzy
+  name: Billy Munn - Jazzy Interlude
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_jazzy_mono.ogg
+
 - type: jukebox
   id: JingleJangleJingle
   name: Kay Kyser - Jingle Jangle Jingle
   path:
     path: /Audio/_Nuclear14/Lobby/MUS_Jingle_Jangle_Jingle.ogg
-    
+
 - type: jukebox
   id: JoeCool
   name: Georges Tesperin - Joe Cool
   path:
     path: /Audio/_Nuclear14/Lobby/MUS_Joe_Cool_CAS.ogg
-    
+
 - type: jukebox
   id: JohnnyGuitar
   name: Peggy Lee - Johnny Guitar
   path:
     path: /Audio/_Nuclear14/Lobby/MUS_Johnny_Guitar.ogg
-    
+
+- type: jukebox
+  id: GenericSunning
+  name: Jack Shaindlin - Let's Go Sunning
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_sunning_mono.ogg
+
+- type: jukebox
+  id: RoyBrownMighty
+  name: Roy Brown - Mighty Mighty Man
+  path:
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_roybrown_mighty_mono.ogg
+
 - type: jukebox
   id: SomethingsGottaGive
   name: Bing Crosby - Something's Gotta Give
   path:
     path: /Audio/_Nuclear14/Lobby/MUS_Somethings_Gotta_Give.ogg
 
-# Music/Fallout3
 - type: jukebox
-  id: BillieHolidayCrazy
-  name: Billie Holiday - Crazy
+  id: GenericBoogie
+  name: Allan Gray - Swing Dooors
   path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_billieholiday_crazy_mono.ogg
-    
-- type: jukebox
-  id: BillieHolidayEasy
-  name: Billie Holiday - Easy
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_billieholiday_easy_mono.ogg
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_boogie_mono.ogg
 
 - type: jukebox
-  id: BobCrosbyHappy
-  name: Bob Crosby - Happy
+  id: GenericSwing
+  name: Allan Gray - Swing Doors
   path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_bobcrosby_happy_mono.ogg
+    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_swing_mono.ogg
+
+- type: jukebox
+  id: BattleHymn
+  name: The Battle Hymn of the Republic
+  path:
+    path: /Audio/_Nuclear14/Music/MUS_Patriotic_BattleHymn_mono.ogg
+
+- type: jukebox
+  id: PatrioticStars
+  name: The Stars and Stripes Forever
+  path:
+    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Stars.ogg
+
+- type: jukebox
+  id: PatrioticWashington
+  name: The Washington Post
+  path:
+    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Washington.ogg
 
 - type: jukebox
   id: BobCrosbyWay
-  name: Bob Crosby - Way
+  name: Bob Crosby - Way Back Home
   path:
     path: /Audio/_Nuclear14/Music/Fallout3/mus_bobcrosby_way_mono.ogg
-    
-- type: jukebox
-  id: ColePorterAnything
-  name: Cole Porter - Anything
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_coleporter_anything_mono.ogg
-    
-- type: jukebox
-  id: DannyKayeCivilization
-  name: Danny Kaye - Civilization
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_dannykaye_civilization_mono.ogg
-    
-- type: jukebox
-  id: GenericBoogie
-  name: Generic Boogie
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_boogie_mono.ogg
-    
-- type: jukebox
-  id: GenericFox
-  name: Generic Fox
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_fox_mono.ogg
-    
-- type: jukebox
-  id: GenericJazzy
-  name: Generic Jazzy
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_jazzy_mono.ogg
-    
-- type: jukebox
-  id: GenericSunning
-  name: Generic Sunning
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_sunning_mono.ogg
-    
-- type: jukebox
-  id: GenericSwing
-  name: Generic Swing
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_swing_mono.ogg
-    
-- type: jukebox
-  id: InkspotsIDont
-  name: Inkspots - I Don't
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_inkspots_idont_mono.ogg
-    
-- type: jukebox
-  id: RoyBrownButcher
-  name: Roy Brown - Butcher
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_roybrown_butcher_mono.ogg
-    
-- type: jukebox
-  id: RoyBrownMighty
-  name: Roy Brown - Mighty
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_roybrown_mighty_mono.ogg
-    
-- type: jukebox
-  id: TexBenekeGuy
-  name: Tex Beneke - Guy
-  path:
-    path: /Audio/_Nuclear14/Music/Fallout3/mus_texbeneke_guy_mono.ogg
-    
-# Music - Enclave
-- type: jukebox
-  id: PatrioticAmerica
-  name: Patriotic America
-  path:
-    path: /Audio/_Nuclear14/Music/MUS_Patriotic_America.ogg 
-    
-- type: jukebox
-  id: BattleHymn
-  name: Battle Hymn
-  path:
-    path: /Audio/_Nuclear14/Music/MUS_Patriotic_BattleHymn_mono.ogg
-    
-- type: jukebox
-  id: PatrioticDixie
-  name: Patriotic Dixie
-  path:
-    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Dixie.ogg
-    
-- type: jukebox
-  id: PatrioticMontezuma
-  name: Patriotic Montezuma
-  path:
-    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Montezuma.ogg
-    
-- type: jukebox
-  id: PatrioticPresidential
-  name: Patriotic Presidential
-  path:
-    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Presidential.ogg
-    
-- type: jukebox
-  id: PatrioticStars
-  name: Patriotic Stars
-  path:
-    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Stars.ogg
-    
-- type: jukebox
-  id: PatrioticWashington
-  name: Patriotic Washington
-  path:
-    path: /Audio/_Nuclear14/Music/MUS_Patriotic_Washington.ogg
-    
+
 - type: jukebox
   id: PatrioticYankee
-  name: Patriotic Yankee
+  name: Yankee Doodle
   path:
     path: /Audio/_Nuclear14/Music/MUS_Patriotic_Yankee.ogg
+ 


### PR DESCRIPTION
fix: Updated the jukebox catalogue to display the full song titles, rather than the partially complete or inaccurate ones previously displayed. They are also sorted alphabetically now!