### PR TITLE
Playtime Requirements

### DIFF
--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -83,8 +83,6 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
         if (_adminManager.IsAdmin(player))
         {
             trackers.Add(PlayTimeTrackingShared.TrackerAdmin);
-            trackers.Add(PlayTimeTrackingShared.TrackerOverall);
-            return;
         }
 
         if (!IsPlayerAlive(player))

--- a/Resources/Prototypes/Corvax/Roles/Jobs/Townfolk/Townshopkeeperhelper.yml
+++ b/Resources/Prototypes/Corvax/Roles/Jobs/Townfolk/Townshopkeeperhelper.yml
@@ -1,6 +1,7 @@
 - type: job
   id: TownShopkeeperHelper
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 45
   overrideConsoleVisibility: false
   canBeAntag: false
@@ -14,7 +15,7 @@
       - Ghoul
     - !type:CharacterDepartmentTimeRequirement
       department: Townsfolk
-      min: 0 # 2 hours
+      min: 18000 # 5 hours
   startingGear: TownShopkeeperHelperGear
   icon: "JobIconTownShopKeeper"
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headknight.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headknight.yml
@@ -67,12 +67,9 @@
     - !type:CharacterSpeciesRequirement
       species:
       - Human
-    - !type:CharacterDepartmentTimeRequirement
-      department: BrotherhoodOfSteel
-      min: 0 # #Misfits Tweak - gated by Senior Knight role time instead
-    - !type:CharacterPlaytimeRequirement # #Misfits Tweak - 20 hours as Senior Knight to unlock Head Knight
+    - !type:CharacterPlaytimeRequirement
       tracker: BoSMidKnight
-      min: 72000 # 20 hours
+      min: 144000 # 40 hours
   startingGear: BoSHeadKnightGear
   alwaysUseSpawner: true
   icon: "JobIconBosMKnight"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
@@ -15,18 +15,9 @@
     - !type:CharacterSpeciesRequirement
       species:
       - Human
-    - !type:CharacterDepartmentTimeRequirement
-      department: BrotherhoodOfSteel
-      min: 0 # #Misfits Tweak - gated by Senior Paladin role time instead
-    - !type:CharacterPlaytimeRequirement # #Misfits Tweak - 20 hours as Senior Paladin to unlock Head Paladin
+    - !type:CharacterPlaytimeRequirement
       tracker: BoSMidPaladin
-      min: 72000 # 20 hours
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterSpeciesRequirement
-          species:
-            - Human
-            - Ghoul
+      min: 216000 # 60 hours
   startingGear: BoSMidPaladinCommanderGear
   alwaysUseSpawner: true
   icon: "JobIconBosMCommander" # Corvax-Change

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
@@ -12,12 +12,9 @@
     - !type:CharacterSpeciesRequirement
       species:
       - Human
-    - !type:CharacterDepartmentTimeRequirement
-      department: BrotherhoodOfSteel
-      min: 0 # #Misfits Tweak - gated by Senior Scribe role time instead
-    - !type:CharacterPlaytimeRequirement # #Misfits Tweak - 20 hours as Senior Scribe to unlock Head Scribe
+    - !type:CharacterPlaytimeRequirement
       tracker: BoSMidScribe
-      min: 72000 # 20 hours
+      min: 108000 # 30 hours
   startingGear: BoSWestScribeGear
   alwaysUseSpawner: true
   icon: "JobIconBosMScriptor"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_knight.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_knight.yml
@@ -65,9 +65,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: BrotherhoodOfSteel
-      min: 0 # #Misfits Tweak - BoS unlocked up to Senior
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSMidSquire
+      min: 36000 # 10 hours
   startingGear: BoSKnightGear
   alwaysUseSpawner: true
   icon: "JobIconBosMKnight"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_paladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_paladin.yml
@@ -65,9 +65,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: BrotherhoodOfSteel
-      min: 0 # #Misfits Tweak - BoS unlocked up to Senior
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSMidSquire
+      min: 72000 # 20 hours
   startingGear: BoSPaladinGear
   alwaysUseSpawner: true
   icon: "JobIconBosMPaladin"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_scribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_scribe.yml
@@ -63,9 +63,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: BrotherhoodOfSteel
-      min: 0 # #Misfits Tweak - BoS unlocked up to Senior
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSMidSquire
+      min: 18000 # 5 hours
   startingGear: BoSScribeGear
   alwaysUseSpawner: true
   icon: "JobIconBosMScriptor"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorknight.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorknight.yml
@@ -14,9 +14,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: BrotherhoodOfSteel
-      min: 0 # 5 hours
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSKnight
+      min: 72000 # 20 hours
   startingGear: BoSMidKnightGear
   alwaysUseSpawner: true
   icon: "JobIconBosMKnight" # Corvax-Change

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorpaladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorpaladin.yml
@@ -15,9 +15,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: BrotherhoodOfSteel
-      min: 0 # 15 hours
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSPaladin
+      min: 144000 # 40 hours
   startingGear: BoSMidPaladinGear
   alwaysUseSpawner: true
   icon: "JobIconBosMPaladin" # Corvax-Change

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorscribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorscribe.yml
@@ -14,9 +14,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: BrotherhoodOfSteel
-      min: 0 # 5 hours
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSScribe
+      min: 72000 # 20 hours
   startingGear: BoSMidScribeGear
   alwaysUseSpawner: true
   icon: "JobIconBosMScriptor" # Corvax-Change

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_squire.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_squire.yml
@@ -17,8 +17,9 @@
           species:
             - Human
             - Ghoul
-    - !type:CharacterOverallTimeRequirement
-      min: 0
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSInitiate
+      min: 18000 # 5 hours
   startingGear: BoSMidSquireGear
   alwaysUseSpawner: true
   icon: "JobIconBosMSquire" # Forge-Change

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_auxilia.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_auxilia.yml
@@ -9,12 +9,17 @@
   description: job-description-caesar-legion-auxilia
   playTimeTracker: CaesarLegionAuxilia
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-      department: CaesarLegion
-      min: 0
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterPlaytimeRequirement
+          tracker: CaesarLegionRecruit
+          min: 10800 # 3 hours
+        - !type:CharacterPlaytimeRequirement
+          tracker: CaesarLegionSlave
+          min: 10800 # 3 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
   startingGear: CaesarLegionAuxiliaGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerRecruit"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_centurion.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_centurion.yml
@@ -9,19 +9,16 @@
   description: job-description-caesar-legion-centurion
   playTimeTracker: CaesarLegionCenturion
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-      department: CaesarLegion
-      min: 0 # #Misfits Tweak - gated by Veteran Decanus role time instead
-  - !type:CharacterPlaytimeRequirement # #Misfits Tweak - 20 hours as Veteran Decanus to unlock Centurion
+    - !type:CharacterPlaytimeRequirement
       tracker: CaesarLegionVeteranDecanus
-      min: 72000 # 20 hours
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionCenturionGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerCenturion"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_decanus.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_decanus.yml
@@ -8,19 +8,16 @@
   description: job-description-caesar-legion-dean
   playTimeTracker: CaesarLegionDean
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: CaesarLegion
-    min: 0 # #Misfits Tweak - accessible up to Vet Decanus
-  - !type:CharacterPlaytimeRequirement
+    - !type:CharacterPlaytimeRequirement
       tracker: CaesarLegionLegionnaireVeteran
-      min: 0 # #Misfits Tweak - accessible up to Vet Decanus
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionDeanGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerDean"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_explorer.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_explorer.yml
@@ -8,16 +8,16 @@
   description: job-description-caesar-legion-explorer
   playTimeTracker: CaesarLegionExplorer
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-      department: CaesarLegion
-      min: 0 # #Misfits Tweak - accessible up to Vet Decanus
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionOrator
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionExplorerGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerVenator"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_houndmaster.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_houndmaster.yml
@@ -9,16 +9,16 @@
   description: job-description-caesar-legion-houndmaster
   playTimeTracker: CaesarLegionHoundmaster
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-      department: CaesarLegion
-      min: 0
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionOrator
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionHoundmasterGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerWarrior"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_legionnaire_recruit.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_legionnaire_recruit.yml
@@ -8,15 +8,16 @@
   description: job-description-caesar-legionnaire-recruit
   playTimeTracker: CaesarLegionLegionnaireRecruit
   requirements:
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
-  - !type:CharacterOverallTimeRequirement
-    min: 0 # 1 hour
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionFrumentarii
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionLegionnaireRecruitGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerRecruit"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_legionnaire_veteran.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_legionnaire_veteran.yml
@@ -9,16 +9,16 @@
   description: job-description-caesar-legion-legionnaire-veteran
   playTimeTracker: CaesarLegionLegionnaireVeteran
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: CaesarLegion
-    min: 0 # 10 hours
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionLegionnaireWarrior
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionLegionnaireVeteranGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerVeteran"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_legionnaire_warrior.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_legionnaire_warrior.yml
@@ -8,16 +8,16 @@
   description: job-description-caesar-legion-legionnaire-warrior
   playTimeTracker: CaesarLegionLegionnaireWarrior
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-    department: CaesarLegion
-    min: 0 # 3 hours
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionLegionnaireRecruit
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionLegionnaireWarriorGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerWarrior"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_orator.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_orator.yml
@@ -8,17 +8,21 @@
   description: job-description-caesar-legion-orator
   playTimeTracker: CaesarLegionOrator
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-      department: CaesarLegion
-      min: 0 # #Misfits Tweak - accessible up to Vet Decanus
-  #- !type:CharacterWhitelistRequirement # #Misfits Tweak - whitelist removed, accessible up to Vet Decanus
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterPlaytimeRequirement
+          tracker: CaesarLegionRecruit
+          min: 18000 # 5 hours
+        - !type:CharacterPlaytimeRequirement
+          tracker: CaesarLegionSlave
+          min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionOratorGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerVenator"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_prime_decanus.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_prime_decanus.yml
@@ -8,19 +8,16 @@
   description: job-description-caesar-legion-prime-decanus
   playTimeTracker: CaesarLegionPrimeDecanus
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-      department: CaesarLegion
-      min: 0 # #Misfits Tweak - accessible up to Vet Decanus
-  - !type:CharacterPlaytimeRequirement
+    - !type:CharacterPlaytimeRequirement
       tracker: CaesarLegionDean
-      min: 0 # #Misfits Tweak - accessible up to Vet Decanus
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionPrimeDecanusGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerDean"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_venator.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_venator.yml
@@ -8,17 +8,16 @@
   description: job-description-caesar-legion-frumentarii
   playTimeTracker: CaesarLegionFrumentarii
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-     department: CaesarLegion
-     min: 0 #12 hours test
-  #- !type:CharacterWhitelistRequirement # #Misfits Tweak - whitelist removed, accessible up to Vet Decanus
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionVexillarius
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionFrumentariiGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerVenator"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_veteran_decanus.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_veteran_decanus.yml
@@ -10,19 +10,16 @@
   description: job-description-caesar-legion-veteran-decanus
   playTimeTracker: CaesarLegionVeteranDecanus
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-      department: CaesarLegion
-      min: 0 # #Misfits Tweak - accessible up to Vet Decanus
-  - !type:CharacterPlaytimeRequirement
-      tracker: CaesarLegionDean
-      min: 0 # #Misfits Tweak - accessible up to Vet Decanus
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionPrimeDecanus
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionVeteranDecanusGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerDean"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_vexillarius.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_vexillarius.yml
@@ -8,16 +8,16 @@
   description: job-description-caesar-legion-vexillarius
   playTimeTracker: CaesarLegionVexillarius
   requirements:
-  - !type:CharacterDepartmentTimeRequirement
-      department: CaesarLegion
-      min: 0
-  - !type:CharacterSpeciesRequirement
-    species:
-    - Human
-  - !type:CharacterSexRequirement
-    sex: Male
-  - !type:CharacterGenderRequirement
-    gender: Male
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionExplorer
+      min: 18000 # 5 hours
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+    - !type:CharacterSexRequirement
+      sex: Male
+    - !type:CharacterGenderRequirement
+      gender: Male
   startingGear: CaesarLegionVexillariusGear
   alwaysUseSpawner: true
   icon: "JobIconlegionerVenator"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
@@ -14,12 +14,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: NCR
-      min: 216000
     - !type:CharacterPlaytimeRequirement
-      tracker: NCRNCO
-      min: 43200
+      tracker: NCROfficer
+      min: 18000 # 5 hours
   weight: 120
   startingGear: NCRCaptainGear
   icon: "JobIconNcrLeader"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_corporal.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_corporal.yml
@@ -15,12 +15,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: NCR
-      min: 0 # 10 hours Corvax-Change
-    - !type:CharacterPlaytimeRequirement # Corvax-Add
-      tracker: NCRSoldier
-      min: 0 # 5 hours
+    - !type:CharacterPlaytimeRequirement
+      tracker: NCRPrivateFirstClass
+      min: 18000 # 5 hours
   startingGear: NCRWSGear
   icon: "JobIconNcrSpec" # Corvax-Change
   supervisors: job-supervisors-ncr-sergeant

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_doctor.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_doctor.yml
@@ -17,10 +17,7 @@
       - Ghoul
     - !type:CharacterDepartmentTimeRequirement
       department: NCR
-      min: 0
-    - !type:CharacterPlaytimeRequirement
-      tracker: NCRMedic
-      min: 0
+      min: 36000 # 10 hours
   startingGear: NCRDoctorGear
   icon: "JobIconNcrMedic"
   supervisors: job-supervisors-ncr-lt

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_first_sergeant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_first_sergeant.yml
@@ -16,12 +16,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: NCR
-      min: 0
     - !type:CharacterPlaytimeRequirement
       tracker: NCRStaffSergeant
-      min: 0
+      min: 18000 # 5 hours
   startingGear: NCRFirstSergeantGear
   icon: "JobIconNcrSerg"
   supervisors: job-supervisors-ncr-lt

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_lieutenant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_lieutenant.yml
@@ -14,12 +14,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: NCR
-      min: 0 # #Misfits Tweak - NCR LT accessible to all
-    - !type:CharacterPlaytimeRequirement # Corvax-Add
-      tracker: NCRNCO
-      min: 0 # #Misfits Tweak - NCR LT accessible to all
+    - !type:CharacterPlaytimeRequirement
+      tracker: NCRFirstSergeant
+      min: 18000 # 5 hours
   weight: 110
   startingGear: NCRLTGear
   icon: "JobIconNcrLeader" # Corvax-Change

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_private.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_private.yml
@@ -14,9 +14,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: NCR
-      min: 0 # 3 hours Corvax-Change
+    - !type:CharacterPlaytimeRequirement
+      tracker: NCRCadet
+      min: 18000 # 5 hours
   startingGear: NCRSoldierGear
   icon: "JobIconNcrSoldier" # Corvax-Change
   supervisors: job-supervisors-ncr

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_private_first_class.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_private_first_class.yml
@@ -14,12 +14,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: NCR
-      min: 0
     - !type:CharacterPlaytimeRequirement
       tracker: NCRSoldier
-      min: 0
+      min: 18000 # 5 hours
   startingGear: NCRPrivateFirstClassGear
   icon: "JobIconNcrSoldier"
   supervisors: job-supervisors-ncr-sergeant

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_sergeant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_sergeant.yml
@@ -14,12 +14,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: NCR
-      min: 0 # 20 hours Corvax-Change
-    - !type:CharacterPlaytimeRequirement # Corvax-Add
-      tracker: NCRSoldier
-      min: 0 # 10 hours
+    - !type:CharacterPlaytimeRequirement
+      tracker: NCRWS
+      min: 18000 # 5 hours
   startingGear: NCRSGTGear
   icon: "JobIconNcrSerg" # Corvax-Change
   supervisors: job-supervisors-ncr-staff-sergeant

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_staff_sergeant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_staff_sergeant.yml
@@ -14,12 +14,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: NCR
-      min: 0
     - !type:CharacterPlaytimeRequirement
       tracker: NCRNCO
-      min: 0
+      min: 18000 # 5 hours
   startingGear: NCRStaffSergeantGear
   icon: "JobIconNcrSerg"
   supervisors: job-supervisors-ncr-first-sergeant

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
@@ -1,6 +1,7 @@
 - type: job
   id: Followers
   setPreference: true # Forge-Change
+  jobWhitelistBypassesRoleTimers: true
   name: job-name-followers
   description: job-description-followers
   playTimeTracker: Followers
@@ -9,7 +10,15 @@
   supervisors: job-supervisors-followers
   accessGroups:
   - FollowersApocalypse
-  requirements: # Misfits Change: block non-human species
+  requirements:
+  - !type:CharacterLogicOrRequirement
+    requirements:
+      - !type:CharacterPlaytimeRequirement
+        tracker: Survivor
+        min: 18000 # 5 hours
+      - !type:CharacterPlaytimeRequirement
+        tracker: Wastelander
+        min: 18000 # 5 hours
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger.yml
@@ -1,6 +1,7 @@
 - type: job
   id: Ranger
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   name: job-name-ranger-field
   description: job-description-ranger-field
   playTimeTracker: Ranger
@@ -19,7 +20,9 @@
         factions:
           - Rangers
   requirements:
-    - !type:CharacterWhitelistRequirement
+    - !type:CharacterPlaytimeRequirement
+      tracker: RangerRecruit
+      min: 72000 # 20 hours
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots and super mutants cannot be Rangers
       inverted: true
       species:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -1,6 +1,7 @@
 - type: job
   id: RangerRecruit
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   name: job-name-ranger-patrol
   description: job-description-ranger-patrol
   playTimeTracker: RangerRecruit
@@ -18,7 +19,9 @@
         factions:
           - Rangers
   requirements:
-    - !type:CharacterWhitelistRequirement
+    - !type:CharacterDepartmentTimeRequirement
+      department: NCR
+      min: 72000 # 20 hours
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots and super mutants cannot be Rangers
       inverted: true
       species:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger_veteran.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Rangers/ranger_veteran.yml
@@ -1,6 +1,7 @@
 - type: job
   id: RangerVeteran
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   name: job-name-ranger-veteran-n14
   description: job-description-ranger-veteran-n14
   playTimeTracker: RangerVeteran
@@ -19,7 +20,9 @@
         factions:
           - Rangers
   requirements:
-    - !type:CharacterWhitelistRequirement
+    - !type:CharacterPlaytimeRequirement
+      tracker: Ranger
+      min: 144000 # 40 hours
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots and super mutants cannot be Rangers
       inverted: true
       species:

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Towndoctor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Towndoctor.yml
@@ -1,6 +1,7 @@
 - type: job
   id: TownDoctor
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 60
   showBorder: true
   overrideConsoleVisibility: false
@@ -15,7 +16,7 @@
       - Ghoul
     - !type:CharacterDepartmentTimeRequirement
       department: Townsfolk
-      min: 0
+      min: 18000 # 5 hours
   startingGear: TownDoctorGear
   icon: "JobIconTownMedic" # Corvax-Change
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townshopkeeper.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townshopkeeper.yml
@@ -1,6 +1,7 @@
 - type: job
   id: TownShopkeeper
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 50
   showBorder: true
   overrideConsoleVisibility: false
@@ -13,12 +14,9 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: Townsfolk
-      min: 0 # 2 hours
-    - !type:CharacterPlaytimeRequirement # Forge-Add
+    - !type:CharacterPlaytimeRequirement
       tracker: TownShopkeeperHelper
-      min: 0 # 4 hours
+      min: 18000 # 5 hours
   startingGear: TownShopkeeperGear
   icon: "JobIconTownShopKeeper" # Corvax-Change
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/bartender.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/bartender.yml
@@ -1,6 +1,7 @@
 - type: job
   id: WastelandBartender
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 25
   overrideConsoleVisibility: false
   canBeAntag: false
@@ -14,7 +15,7 @@
       - Ghoul
     - !type:CharacterDepartmentTimeRequirement
       department: Townsfolk
-      min: 0 # 2 hours
+      min: 18000 # 5 hours
   startingGear: WastelandBartenderGear
   icon: "JobIconBartender"
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/reporter.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/reporter.yml
@@ -12,9 +12,6 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: Townsfolk
-      min: 0 # 2 hours
   startingGear: WastelandReporterGear
   icon: "JobIconTownReporter" # Corvax-Change
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/towndeputy.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/towndeputy.yml
@@ -1,6 +1,7 @@
 - type: job
   id: TownDeputy # Renamed to "Guard", don't touch the prototype ID
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 70
   overrideConsoleVisibility: true
   canBeAntag: false
@@ -14,7 +15,7 @@
       - Ghoul
     - !type:CharacterDepartmentTimeRequirement
       department: Townsfolk
-      min: 0 # 4 hours
+      min: 36000 # 10 hours
   startingGear: TownDeputyGear
   icon: "JobIconTownDeputy" # Forge-Change
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townmayor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townmayor.yml
@@ -17,7 +17,7 @@
       - Ghoul
     - !type:CharacterDepartmentTimeRequirement
       department: Townsfolk
-      min: 0 # #Misfits Tweak - was 36000 (10 hours); set to 0 so anyone can join
+      min: 216000 # 60 hours
   startingGear: TownMayorGear
   icon: "JobIconTownMayor" # Corvax-Change
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townsheriff.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townsheriff.yml
@@ -1,6 +1,7 @@
 - type: job
   id: TownSheriff # Renamed to "Marshal", don't touch the prototype ID
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 80
   showBorder: true
   overrideConsoleVisibility: false
@@ -15,10 +16,7 @@
       - Ghoul
     - !type:CharacterDepartmentTimeRequirement
       department: Townsfolk
-      min: 0 # 8 hours
-    - !type:CharacterPlaytimeRequirement # Corvax-Add
-      tracker: TownDeputy
-      min: 0 # 4 hours
+      min: 72000 # 20 hours
   startingGear: TownSheriffGear
   icon: "JobIconTownSheriff" # Corvax-Change
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribal.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribal.yml
@@ -1,6 +1,7 @@
 - type: job
   id: Tribal
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 10
   showBorder: true
   overrideConsoleVisibility: false
@@ -13,8 +14,14 @@
       species:
       - Human
       - Ghoul
-    - !type:OverallTimeRequirement
-      min: 0 # 1 hour
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterPlaytimeRequirement
+          tracker: Wastelander
+          min: 18000 # 5 hours
+        - !type:CharacterPlaytimeRequirement
+          tracker: Survivor
+          min: 18000 # 5 hours
   startingGear: TribalGear
   alwaysUseSpawner: true
   icon: "JobIconTribal" # Corvax-Change

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalelder.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalelder.yml
@@ -1,6 +1,7 @@
 - type: job
   id: TribalElder
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 60
   overrideConsoleVisibility: false
   canBeAntag: false
@@ -14,7 +15,7 @@
       - Ghoul
     - !type:CharacterDepartmentTimeRequirement
       department: Tribe
-      min: 14400 # 4 hours
+      min: 216000 # 60 hours
   startingGear: TribalElderGear
   alwaysUseSpawner: true
   icon: "JobIconTribalLeader" # Corvax-Change

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalfarmer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalfarmer.yml
@@ -1,6 +1,7 @@
 - type: job
   id: TribalFarmer
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 30
   overrideConsoleVisibility: false
   canBeAntag: false
@@ -12,9 +13,14 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: Tribe
-      min: 0 # 2 hours
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterPlaytimeRequirement
+          tracker: Wastelander
+          min: 18000 # 5 hours
+        - !type:CharacterPlaytimeRequirement
+          tracker: Survivor
+          min: 18000 # 5 hours
   startingGear: TribalFarmerGear
   alwaysUseSpawner: true
   icon: "JobIconTribalFarmer" # Corvax-Change

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalhealer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Tribal/tribalhealer.yml
@@ -1,6 +1,7 @@
 - type: job
   id: TribalHealer
   setPreference: true
+  jobWhitelistBypassesRoleTimers: true
   weight: 40
   showBorder: true
   overrideConsoleVisibility: false
@@ -13,9 +14,14 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement
-      department: Tribe
-      min: 0 # 2 hours
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterPlaytimeRequirement
+          tracker: Wastelander
+          min: 18000 # 5 hours
+        - !type:CharacterPlaytimeRequirement
+          tracker: Survivor
+          min: 18000 # 5 hours
   startingGear: TribalHealerGear
   alwaysUseSpawner: true
   icon: "JobIconTribalMedic" # Corvax-Change

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/overseer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/overseer.yml
@@ -11,7 +11,7 @@
     - Human
   - !type:CharacterDepartmentTimeRequirement
     department: Vault
-    min: 0 # #Misfits Tweak - was 36000 (10 hours); open to all
+    min: 216000 # 60 hours
   playTimeTracker: Overseer
   weight: 100
   startingGear: OverseerGear

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultdoctor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultdoctor.yml
@@ -10,9 +10,9 @@
   - !type:CharacterSpeciesRequirement
     species:
     - Human
-  - !type:CharacterDepartmentTimeRequirement
-    department: Vault
-    min: 0 # 2 hours
+  - !type:CharacterPlaytimeRequirement
+    tracker: VaultDweller
+    min: 18000 # 5 hours
   setPreference: true
   overrideConsoleVisibility: true
   canBeAntag: false

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultengineer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultengineer.yml
@@ -10,9 +10,9 @@
   - !type:CharacterSpeciesRequirement
     species:
     - Human
-  - !type:CharacterDepartmentTimeRequirement
-    department: Vault
-    min: 0 # 2 hours
+  - !type:CharacterPlaytimeRequirement
+    tracker: VaultDweller
+    min: 18000 # 5 hours
   setPreference: true
   overrideConsoleVisibility: true
   canBeAntag: false

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultsecurity.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/VaultDwellers/vaultsecurity.yml
@@ -14,7 +14,7 @@
     - Human
   - !type:CharacterDepartmentTimeRequirement
     department: Vault
-    min: 0 # 5 hours
+    min: 36000 # 10 hours
   setPreference: true
   overrideConsoleVisibility: true
   canBeAntag: false

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/chaplain.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/chaplain.yml
@@ -13,9 +13,6 @@
       species:
       - Human
       - Ghoul
-    - !type:CharacterDepartmentTimeRequirement # Forge-Add
-      department: Townsfolk
-      min: 0 # 2 hours
   startingGear: WastelandChaplainGear
   icon: "JobIconWastelandChaplain" # Forge-Change
   supervisors: job-supervisors-townsfolk


### PR DESCRIPTION
:cl:
- add: Added playtime requirements for all faction roles (NCR, Legion, Brotherhood, Vault, Tribal, Townsfolk, Rangers, Followers)
- add: Whitelisted players can bypass playtime requirements on all roles
- tweak: NCR roles now require 5hrs of the previous rank to unlock
- tweak: Legion roles follow a branching progression chain with 3-5hr requirements per rank
- tweak: Brotherhood roles require escalating playtime from Squire through Head Paladin (5-60hrs)
- tweak: Rangers now use playtime requirements (20-40hrs) instead of whitelist-only access
- tweak: Vault, Tribal, and Townsfolk roles have tiered playtime gates (5-60hrs)
- tweak: Followers and Tribal entry roles require 5hrs of Wastelander or Survivor
- fix: Admins now properly accumulate playtime for their active job role instead of only tracking Admin and Overall time