### PR TITLE
FoTA Headset Fix | CPR Fix (While Dead) | Buff Powerarmor Against Grenades | Bonfire Fix

### DIFF
--- a/Content.Server/Temperature/Systems/BonfireHeaterSystem.cs
+++ b/Content.Server/Temperature/Systems/BonfireHeaterSystem.cs
@@ -3,7 +3,9 @@ using Content.Server.Chemistry.Components;
 using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Temperature.Components;
 using Content.Shared.Audio;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Placeable;
+using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Temperature;
 
 namespace Content.Server.Temperature.Systems;
@@ -20,6 +22,20 @@ public sealed class BonfireHeaterSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
+        // Gate the step-trigger so it only fires when the bonfire is actually lit,
+        // and only on mobs — not dropped items or placed food sitting on the surface.
+        SubscribeLocalEvent<BonfireHeaterComponent, ref StepTriggerAttemptEvent>(OnStepTriggerAttempt);
+    }
+
+    // #Misfits Add: Cancel step-trigger attempts if the bonfire is not on fire or the tripper
+    // is not a mob; prevents unconditional burning on an unlit bonfire and avoids igniting
+    // food items placed on the surface.
+    private void OnStepTriggerAttempt(EntityUid uid, BonfireHeaterComponent comp, ref StepTriggerAttemptEvent args)
+    {
+        var isHotEvent = new IsHotEvent();
+        RaiseLocalEvent(uid, isHotEvent);
+        if (!isHotEvent.IsHot || !HasComp<MobStateComponent>(args.Tripper))
+            args.Cancelled = true;
     }
 
     public override void Update(float deltaTime)
@@ -46,6 +62,11 @@ public sealed class BonfireHeaterSystem : EntitySystem
             var heatToAdd = comp.BaseHeatMultiplier;
             foreach (var ent in placer.PlacedEntities)
             {
+                // #Misfits Fix: Propagate external heat into InternalTemperatureComponent BEFORE
+                // ChangeHeat fires OnTemperatureChangeEvent. Cooking construction graphs check
+                // internal temperature first, so internal temp must be up-to-date at the moment
+                // the event is handled — the upstream conduction loop is disabled in this fork.
+                _temperature.ConductToInternalTemperature(ent, deltaTime);
                 _temperature.ChangeHeat(ent, heatToAdd, true);
             }
         }

--- a/Content.Server/Temperature/Systems/BonfireHeaterSystem.cs
+++ b/Content.Server/Temperature/Systems/BonfireHeaterSystem.cs
@@ -24,7 +24,7 @@ public sealed class BonfireHeaterSystem : EntitySystem
         base.Initialize();
         // Gate the step-trigger so it only fires when the bonfire is actually lit,
         // and only on mobs — not dropped items or placed food sitting on the surface.
-        SubscribeLocalEvent<BonfireHeaterComponent, ref StepTriggerAttemptEvent>(OnStepTriggerAttempt);
+        SubscribeLocalEvent<BonfireHeaterComponent, StepTriggerAttemptEvent>(OnStepTriggerAttempt);
     }
 
     // #Misfits Add: Cancel step-trigger attempts if the bonfire is not on fire or the tripper

--- a/Content.Server/Temperature/Systems/TemperatureSystem.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.cs
@@ -177,6 +177,28 @@ public sealed class TemperatureSystem : EntitySystem
         else return comp.SpecificHeat * physics.FixturesMass;
     }
 
+    // #Misfits Add: Conduct heat from an entity's external TemperatureComponent into its
+    // InternalTemperatureComponent using Fourier's law. Called by BonfireHeaterSystem each tick
+    // for items placed on a lit bonfire, so cooking construction graphs (which check internal
+    // temperature) can actually trigger. The upstream conduction loop is disabled for this fork,
+    // so this targeted per-item call replaces it for the bonfire use-case only.
+    public void ConductToInternalTemperature(EntityUid uid, float deltaTime,
+        TemperatureComponent? temperature = null, InternalTemperatureComponent? internalTemp = null)
+    {
+        if (!Resolve(uid, ref temperature, false) || !Resolve(uid, ref internalTemp, false))
+            return;
+
+        var diff = temperature.CurrentTemperature - internalTemp.Temperature;
+        if (Math.Abs(diff) < 0.1f)
+            return;
+
+        // q = conductivity * diff / thickness (W/m²), converted to K via heat capacity
+        var q = internalTemp.Conductivity * diff / internalTemp.Thickness;
+        var joules = q * internalTemp.Area * deltaTime;
+        var degrees = joules / GetHeatCapacity(uid, temperature);
+        internalTemp.Temperature += degrees;
+    }
+
     private void OnInit(EntityUid uid, InternalTemperatureComponent comp, MapInitEvent args)
     {
         if (!TryComp<TemperatureComponent>(uid, out var temp))

--- a/Content.Server/_Misfits/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_Misfits/Medical/CPR/CPRSystem.cs
@@ -2,7 +2,9 @@
 // Inspired by CPR concepts in stalker-14-EN, designed and built independently for N14.
 // Allows a player to perform CPR on a critically-injured target to stabilise them and
 // partially reverse damage, giving medics a meaningful emergency tool.
+// #Misfits Fix - extended to support CPR on dead targets (requires N14CPRTraining trait).
 using Content.Server.Atmos.EntitySystems;
+using Content.Server.Medical.CPR; // for CPRTrainingComponent (N14CPRTraining trait gate)
 using Content.Shared._Misfits.Medical.CPR;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
@@ -30,6 +32,7 @@ public sealed class CPRSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThreshold = default!; // #Misfits Fix - needed for dead-threshold check
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -76,9 +79,19 @@ public sealed class CPRSystem : EntitySystem
         if (user == target)
             return;
 
-        // Target must be in critical state.
-        if (!_mobState.IsCritical(target))
+        // #Misfits Fix - accept both critical and dead targets.
+        var isTargetCritical = _mobState.IsCritical(target);
+        var isTargetDead = _mobState.IsDead(target);
+
+        if (!isTargetCritical && !isTargetDead)
             return;
+
+        // CPR on a dead target is gated behind the N14CPRTraining trait.
+        if (isTargetDead && !HasComp<CPRTrainingComponent>(user))
+        {
+            _popup.PopupEntity(Loc.GetString("cpr-no-training-for-dead"), user, user, PopupType.Small);
+            return;
+        }
 
         // Performer must not be on cooldown.
         if (HasComp<CPRCooldownComponent>(user))
@@ -89,12 +102,24 @@ public sealed class CPRSystem : EntitySystem
 
         args.Handled = true;
 
-        _popup.PopupEntity(
-            Loc.GetString("cpr-start-performer", ("target", target)),
-            user, user, PopupType.Medium);
-        _popup.PopupEntity(
-            Loc.GetString("cpr-start-target", ("user", user)),
-            target, target, PopupType.Medium);
+        if (isTargetDead)
+        {
+            _popup.PopupEntity(
+                Loc.GetString("cpr-start-performer-dead", ("target", target)),
+                user, user, PopupType.Medium);
+            _popup.PopupEntity(
+                Loc.GetString("cpr-start-target-dead", ("user", user)),
+                target, target, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(
+                Loc.GetString("cpr-start-performer", ("target", target)),
+                user, user, PopupType.Medium);
+            _popup.PopupEntity(
+                Loc.GetString("cpr-start-target", ("user", user)),
+                target, target, PopupType.Medium);
+        }
 
         var doAfterArgs = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(8f), new CPRDoAfterEvent(), user, target)
         {
@@ -114,10 +139,12 @@ public sealed class CPRSystem : EntitySystem
         var user = args.User;
         var target = args.Target.Value;
 
-        // Re-validate: target must still be critical.
-        if (!_mobState.IsCritical(target))
+        // #Misfits Fix - re-validate for both critical and dead states.
+        var isTargetCritical = _mobState.IsCritical(target);
+        var isTargetDead = _mobState.IsDead(target);
+
+        if (!isTargetCritical && !isTargetDead)
         {
-            // Misfits Fix: pass target argument to match FTL string "{ $target } no longer needs CPR."
             _popup.PopupEntity(Loc.GetString("cpr-target-no-longer-critical", ("target", target)), user, user, PopupType.Small);
             return;
         }
@@ -131,14 +158,42 @@ public sealed class CPRSystem : EntitySystem
         healSpec.DamageDict.Add("Asphyxiation", -CPRAsphyxiationHeal);
         _damageable.TryChangeDamage(target, healSpec, true, origin: user);
 
-        _popup.PopupEntity(
-            Loc.GetString("cpr-success-performer", ("target", target)),
-            user, user, PopupType.Medium);
-        _popup.PopupEntity(
-            Loc.GetString("cpr-success-target", ("user", user)),
-            target, target, PopupType.Medium);
-
         _audio.PlayPvs(CPRSound, target, AudioParams.Default.WithVolume(-2f));
+
+        if (isTargetDead)
+        {
+            // #Misfits Fix - attempt to revive: if healing pushed total damage below the death threshold,
+            // transition the target from Dead → Critical. This mirrors the ResuscitationSystem pattern.
+            if (TryComp<MobStateComponent>(target, out var mobState) &&
+                _mobThreshold.TryGetThresholdForState(target, MobState.Dead, out var threshold) &&
+                TryComp<DamageableComponent>(target, out var damageable) &&
+                damageable.TotalDamage < threshold)
+            {
+                _mobState.ChangeMobState(target, MobState.Critical, mobState, user);
+                _popup.PopupEntity(
+                    Loc.GetString("cpr-revive-performer", ("target", target)),
+                    user, user, PopupType.Large);
+                _popup.PopupEntity(
+                    Loc.GetString("cpr-revive-target", ("user", user)),
+                    target, target, PopupType.Large);
+            }
+            else
+            {
+                // Damage still above death threshold — CPR wasn't enough to revive.
+                _popup.PopupEntity(
+                    Loc.GetString("cpr-failed-revive-performer", ("target", target)),
+                    user, user, PopupType.Medium);
+            }
+        }
+        else
+        {
+            _popup.PopupEntity(
+                Loc.GetString("cpr-success-performer", ("target", target)),
+                user, user, PopupType.Medium);
+            _popup.PopupEntity(
+                Loc.GetString("cpr-success-target", ("user", user)),
+                target, target, PopupType.Medium);
+        }
 
         // Apply cooldown: performer cannot immediately repeat.
         var cooldown = EnsureComp<CPRCooldownComponent>(user);

--- a/Content.Server/_N14/PortalAutoLink/PortalAutoLinkComponent.cs
+++ b/Content.Server/_N14/PortalAutoLink/PortalAutoLinkComponent.cs
@@ -10,7 +10,9 @@ public sealed partial class PortalAutoLinkComponent : Component
 {
     /// <summary>
     /// A key used to locate another entity with a matching link in the world.
+    /// Null or empty means "do not auto-link" — the previous default of "IgnoreMe"
+    /// was a footgun because all keyless stairs would link to each other.
     /// </summary>
     [DataField]
-    public string? LinkKey { get; set; } = "IgnoreMe";
+    public string? LinkKey { get; set; } = null;
 }

--- a/Content.Server/_N14/PortalAutoLink/PortalAutoLinkSystem.cs
+++ b/Content.Server/_N14/PortalAutoLink/PortalAutoLinkSystem.cs
@@ -1,4 +1,3 @@
-using Content.Shared.Interaction;
 using Content.Shared.Teleportation.Systems;
 
 namespace Content.Server._N14.PortalAutoLink
@@ -10,7 +9,10 @@ namespace Content.Server._N14.PortalAutoLink
         public override void Initialize()
         {
             base.Initialize();
+            // #Misfits Fix — also subscribe to ComponentInit so that re-adding the component
+            // in-game (e.g. via admin verbs) re-triggers linking, not just initial map load.
             SubscribeLocalEvent<PortalAutoLinkComponent, MapInitEvent>(HandleMapInitialization);
+            SubscribeLocalEvent<PortalAutoLinkComponent, ComponentInit>(HandleComponentInit);
         }
 
         private void HandleMapInitialization(Entity<PortalAutoLinkComponent> entity, ref MapInitEvent eventArgs)
@@ -18,24 +20,48 @@ namespace Content.Server._N14.PortalAutoLink
             PerformAutoLink(entity, out _);
         }
 
+        // #Misfits Add — triggered when the component is added to an already map-inited entity
+        // (e.g. admin panel component add on a live server).
+        private void HandleComponentInit(Entity<PortalAutoLinkComponent> entity, ref ComponentInit eventArgs)
+        {
+            // MapInitEvent fires first on initial load, so only run here if the map is already running.
+            if (MetaData(entity).EntityLifeStage >= EntityLifeStage.MapInitialized)
+                PerformAutoLink(entity, out _);
+        }
+
         public bool PerformAutoLink(Entity<PortalAutoLinkComponent> entity, out EntityUid? linkedEntityId)
         {
             linkedEntityId = null;
 
+            // #Misfits Fix — null/empty LinkKey means "do not link"; previously the default
+            // "IgnoreMe" caused all keyless stairs to pair with each other arbitrarily.
+            if (string.IsNullOrEmpty(entity.Comp.LinkKey))
+                return false;
+
             var entityEnumerator = EntityQueryEnumerator<PortalAutoLinkComponent>();
             while (entityEnumerator.MoveNext(out var currentEntityUid, out var currentAutoLinkComponent))
             {
-                if (entity.Owner == currentEntityUid) // Forge-Change
+                if (entity.Owner == currentEntityUid)
+                    continue;
+
+                // #Misfits Fix — skip partner candidates with no key too.
+                if (string.IsNullOrEmpty(currentAutoLinkComponent.LinkKey))
                     continue;
 
                 if (entity.Comp.LinkKey == currentAutoLinkComponent.LinkKey)
                 {
-                    if (_linkedEntitySystem.TryLink(entity, currentEntityUid, false))
-                    {
-                        RemComp<PortalAutoLinkComponent>(currentEntityUid);
-                        RemComp<PortalAutoLinkComponent>(entity);
-                        return true;
-                    }
+                    var linked = _linkedEntitySystem.TryLink(entity, currentEntityUid, false);
+
+                    // #Misfits Fix — always remove PortalAutoLink after a TryLink attempt
+                    // (success or failure) so a bad state doesn't leave the component stuck
+                    // forever and cause repeated mis-links on subsequent map init events.
+                    RemComp<PortalAutoLinkComponent>(currentEntityUid);
+                    RemComp<PortalAutoLinkComponent>(entity);
+
+                    if (linked)
+                        linkedEntityId = currentEntityUid;
+
+                    return linked;
                 }
             }
             return false;

--- a/Resources/Locale/en-US/_Misfits/medical/cpr.ftl
+++ b/Resources/Locale/en-US/_Misfits/medical/cpr.ftl
@@ -13,3 +13,11 @@ cpr-success-performer = You successfully perform CPR on { $target }!
 cpr-success-target = { $user } performs CPR on you — your heart pounds back to life!
 cpr-on-cooldown = You're too exhausted to perform CPR again so soon.
 cpr-target-no-longer-critical = { $target } no longer needs CPR.
+
+# Dead-target CPR strings (requires N14CPRTraining trait)
+cpr-no-training-for-dead = You don't have the training to attempt CPR on someone who has already died.
+cpr-start-performer-dead = You desperately begin performing emergency CPR on { $target }!
+cpr-start-target-dead = { $user } desperately performs emergency CPR on you!
+cpr-revive-performer = You successfully revive { $target }! They're back in critical condition!
+cpr-revive-target = { $user } revives you! Your heart pounds back to life!
+cpr-failed-revive-performer = Your CPR couldn't revive { $target } — they're too far gone.

--- a/Resources/Locale/en-US/_Nuclear14/headset-component.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/headset-component.ftl
@@ -21,3 +21,4 @@ chat-radio-pbs = Broadcast
 chat-radio-bazaar = Bazaar
 chat-radio-wasteland = Wasteland
 chat-radio-wasteland-global = Wasteland
+chat-radio-followers = Followers

--- a/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_ncr.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_ncr.yml
@@ -20,6 +20,7 @@
     - NCRFirstSergeant
     - NCRLT
     - NCRCaptain
+    - NCRMajor # Misfits Add: NCRMajor was missing from NCR armor loadout
     - NCRMPinvestigator
     - NCRRanger
     - RangerVeteran #Misfits Change - consolidated NCRRangerVeteran into RangerVeteran
@@ -51,6 +52,7 @@
     - NCRFirstSergeant
     - NCRLT
     - NCRCaptain
+    - NCRMajor # Misfits Add: NCRMajor was missing from NCR armor loadout
     - NCRMPinvestigator
     - NCRRanger
     - RangerVeteran #Misfits Change - consolidated NCRRangerVeteran into RangerVeteran
@@ -82,6 +84,7 @@
     - NCRFirstSergeant
     - NCRLT
     - NCRCaptain
+    - NCRMajor # Misfits Add: NCRMajor was missing from NCR armor loadout
     - NCRMPinvestigator
     - NCRRanger
     - RangerVeteran #Misfits Change - consolidated NCRRangerVeteran into RangerVeteran
@@ -104,9 +107,12 @@
     - NCRFirstSergeant
     - NCRLT
     - NCRCaptain
+    - NCRMajor # Misfits Add: NCRMajor authority warrants access to combat veteran armor
   - !type:CharacterPlaytimeRequirement
     tracker: NCRNCO
     min: 72000 # 20 hours veterancy unlock
+    # Misfits Note: Only NCRSGT accumulates NCRNCO time; StaffSgt/FirstSgt/NCRLT/Captain/Major use their own trackers.
+    # TODO: Split into per-tracker entries so each senior role can unlock via their own playtime.
   items:
   - N14ClothingOuterNCRCombatVeteranArmorDesert
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
@@ -211,3 +211,19 @@
     sprite: Clothing/Ears/Headsets/security.rsi
   - type: Clothing
     sprite: Clothing/Ears/Headsets/security.rsi
+
+# #Misfits Add — Followers of the Apocalypse headset; grants both faction and wasteland channels
+- type: entity
+  parent: N14ClothingHeadsetAlt
+  id: N14ClothingHeadsetFollowers
+  name: Followers radio earpiece
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyFollowers
+      - EncryptionKeyWastelandGlobal
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/security.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/security.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -64,7 +64,7 @@
   - type: FireProtection
     reduction: 0.9
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.15 # #Misfits Tweak: PA shrugs off most grenade blast — ~18 HP at ground zero vs 120 unarmored
   - type: HeldSpeedModifier
     mirrorClothingModifier: false
     walkModifier: 0.5
@@ -131,7 +131,7 @@
       shoes: N14ClothingPABoots
       back: N14ClothingPowerSystemsBack
   - type: ExplosionResistance
-    damageCoefficient: 0.55
+    damageCoefficient: 0.12 # #Misfits Tweak: T-51 blast resistance — ~14 HP at ground zero
 
 - type: entity
   parent: N14ClothingOuterPowerArmorT51
@@ -239,7 +239,7 @@
         Caustic: 0.75
         Radiation: 0.6
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.08 # #Misfits Tweak: X-01 advanced plating — ~10 HP at ground zero
   - type: UserInterface
     interfaces:
       enum.ToggleClothingUiKey.Key:
@@ -286,7 +286,7 @@
         Caustic: 0.75
         Radiation: 0.6
   - type: ExplosionResistance
-    damageCoefficient: 0.55
+    damageCoefficient: 0.10 # #Misfits Tweak: X-02 blast resistance — ~12 HP at ground zero
   - type: UserInterface
     interfaces:
       enum.ToggleClothingUiKey.Key:
@@ -342,7 +342,7 @@
         Caustic: 0.75
         Radiation: 0.5
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.06 # #Misfits Tweak: Hellfire designed for combat — best blast resistance, ~7 HP at ground zero
   - type: UserInterface
     interfaces:
       enum.ToggleClothingUiKey.Key:
@@ -380,7 +380,7 @@
         Caustic: 0.75
         Radiation: 0.65
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.20 # #Misfits Tweak: Raider PA cobbled together — weakest blast protection, ~24 HP at ground zero
   - type: UserInterface
     interfaces:
       enum.ToggleClothingUiKey.Key:
@@ -427,7 +427,7 @@
         Caustic: 0.75
         Radiation: 0.6
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.12 # #Misfits Tweak: Midwest BoS blast resistance — ~14 HP at ground zero
   - type: UserInterface
     interfaces:
       enum.ToggleClothingUiKey.Key:
@@ -534,7 +534,7 @@
   - type: TemperatureProtection
     coefficient: 0.5
   - type: ExplosionResistance
-    damageCoefficient: 0.55
+    damageCoefficient: 0.10 # #Misfits Tweak: T-51bc Paladin blast resistance — ~12 HP at ground zero
   - type: UserInterface
     interfaces:
       enum.ToggleClothingUiKey.Key:
@@ -591,7 +591,7 @@
   - type: TemperatureProtection
     coefficient: 0.55
   - type: ExplosionResistance
-    damageCoefficient: 0.65
+    damageCoefficient: 0.20 # #Misfits Tweak: NCR salvaged PA — weakest blast protection after raider, ~24 HP at ground zero
   - type: UserInterface
     interfaces:
       enum.ToggleClothingUiKey.Key:
@@ -627,7 +627,7 @@
         Caustic: 0.75
         Radiation: 0.6
   - type: ExplosionResistance
-    damageCoefficient: 0.55
+    damageCoefficient: 0.12 # #Misfits Tweak: Canadian Shield blast resistance — ~14 HP at ground zero
   - type: Reflect # #Misfits Change Tweak: T-51bc "Canadian Shield" ricochets small-caliber rounds at 30% (innate).
     reflects:
       - SmallCaliber
@@ -661,7 +661,7 @@
         Caustic: 0.75
         Radiation: 0.6
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.12 # #Misfits Tweak: Washington BoS T-51 blast resistance — ~14 HP at ground zero
   - type: UserInterface
     interfaces:
       enum.ToggleClothingUiKey.Key:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
@@ -136,3 +136,19 @@
     layers:
     - state: crypt_gray
     - state: common_label
+
+# #Misfits Add — Followers of the Apocalypse private encryption key
+- type: entity
+  parent: EncryptionKey
+  id: EncryptionKeyFollowers
+  name: Followers encryption key
+  description: An encryption key used by the Followers of the Apocalypse.
+  components:
+  - type: EncryptionKey
+    channels:
+    - FollowersOfApocalypse
+    defaultChannel: FollowersOfApocalypse
+  - type: Sprite
+    layers:
+    - state: crypt_gray
+    - state: med_label

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Decoration/bonfire.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Decoration/bonfire.yml
@@ -90,6 +90,15 @@
         - MidImpassable
         - LowImpassable
         hard: false
-  # Misfits Change /Fix/ Removed StepTrigger and TileEntityEffect (Ignite) — they fired unconditionally
-  # regardless of lit state, burning players/items walking over an unlit bonfire.
-  # Heating is handled by BonfireHeaterSystem, which is already gated behind IsHotEvent.
+  # Misfits Change /Fix/ StepTrigger + TileEntityEffect restored. Unconditional ignition is
+  # prevented by BonfireHeaterSystem.OnStepTriggerAttempt, which cancels the attempt when the
+  # bonfire is unlit or the tripper is not a mob (so placed food items are not set on fire).
+  - type: StepTrigger
+    requiredTriggeredSpeed: 0
+    intersectRatio: 0.2
+  - type: TileEntityEffect
+    effects:
+    - !type:FlammableReaction
+      multiplier: 1.5
+      multiplierOnExisting: 0.5
+    - !type:Ignite

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
@@ -269,6 +269,8 @@
   items:
     - ClothingNeckPinNCRDoctor
 
+# Misfits Change /Fix/: Split into two entries — NCRMedic and NCRDoctor use different trackers;
+# the original single entry used NCRDoctor tracker, blocking NCRMedic players who never accumulate NCRDoctor time.
 - type: loadout
   id: LoadoutNCRPinChiefPhysician
   category: Roles
@@ -277,10 +279,24 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRMedic # Forge-Change
-        - NCRDoctor # Misfits Change /Add/: NCRDoctor is a separate job, should also qualify
+        - NCRDoctor # NCRDoctor earns Chief Physician pin through NCRDoctor tracker
     - !type:CharacterPlaytimeRequirement
-      tracker: NCRDoctor # Forge-Change
+      tracker: NCRDoctor
+      min: 72000 # 20 hours veterancy unlock
+  items:
+    - ClothingNeckPinNCRChiefPhysician
+
+- type: loadout
+  id: LoadoutNCRPinChiefPhysicianMedic
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRMedic # NCRMedic earns Chief Physician pin through their own NCRMedic tracker
+    - !type:CharacterPlaytimeRequirement
+      tracker: NCRMedic
       min: 72000 # 20 hours veterancy unlock
   items:
     - ClothingNeckPinNCRChiefPhysician
@@ -335,6 +351,7 @@
         - NCRFirstSergeant
         - NCRLT
         - NCRCaptain
+        - NCRMajor # Misfits Add: NCRMajor was missing from shared NCR cosmetics
         - NCRMPinvestigator
         - NCRRanger
         - RangerVeteran
@@ -361,6 +378,7 @@
         - NCRFirstSergeant
         - NCRLT
         - NCRCaptain
+        - NCRMajor # Misfits Add: NCRMajor was missing from shared NCR cosmetics
         - NCRMPinvestigator
         - NCRRanger
         - RangerVeteran
@@ -402,6 +420,7 @@
         - NCRFirstSergeant
         - NCRLT
         - NCRCaptain
+        - NCRMajor # Misfits Add: NCRMajor was missing from shared NCR cosmetics
         - NCRMPinvestigator
         - NCRRanger
         - RangerVeteran
@@ -428,6 +447,7 @@
         - NCRFirstSergeant
         - NCRLT
         - NCRCaptain
+        - NCRMajor # Misfits Add: NCRMajor was missing from shared NCR cosmetics
         - NCRMPinvestigator
         - NCRRanger
         - RangerVeteran
@@ -454,6 +474,7 @@
         - NCRFirstSergeant
         - NCRLT
         - NCRCaptain
+        - NCRMajor # Misfits Add: NCRMajor was missing from shared NCR cosmetics
         - NCRMPinvestigator
         - NCRRanger
         - RangerVeteran
@@ -506,6 +527,7 @@
         - NCRFirstSergeant
         - NCRLT
         - NCRCaptain
+        - NCRMajor # Misfits Add: NCRMajor was missing from shared NCR cosmetics
         - NCRMPinvestigator
         - NCRRanger
         - RangerVeteran
@@ -532,6 +554,7 @@
         - NCRFirstSergeant
         - NCRLT
         - NCRCaptain
+        - NCRMajor # Misfits Add: NCRMajor was missing from shared NCR cosmetics
         - NCRMPinvestigator
         - NCRRanger
         - RangerVeteran
@@ -558,6 +581,7 @@
         - NCRFirstSergeant
         - NCRLT
         - NCRCaptain
+        - NCRMajor # Misfits Add: NCRMajor was missing from shared NCR cosmetics
         - NCRMPinvestigator
         - NCRRanger
         - RangerVeteran
@@ -584,6 +608,7 @@
         - NCRFirstSergeant
         - NCRLT
         - NCRCaptain
+        - NCRMajor # Misfits Add: NCRMajor was missing from shared NCR cosmetics
         - NCRMPinvestigator
         - NCRRanger
         - RangerVeteran
@@ -639,3 +664,15 @@
         - NCRCaptain
   items:
     - ClothingNeckPinNCRCaptain
+
+- type: loadout
+  id: LoadoutNCRPinMajorMisfits
+  category: Roles
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - NCRMajor # Base rank pin for the NCRMajor job — selectable without a time gate since it is their starting rank
+  items:
+    - ClothingNeckPinNCRMajor

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
@@ -40,6 +40,7 @@
     shoes: N14ClothingBootsLeather # Forge-Change
     neck: ClothingNeckStethoscope # Forge-Change
     id: N14IDDoctorFollower
+    ears: N14ClothingHeadsetFollowers # #Misfits Add - Followers need FoTA + wasteland radio access
     outerClothing: N14ClothingOuterCoatFollowerLab # Forge-Change
     belt: N14ClothingBeltMedicalFilled
     pocket1: SurgicalSterilanSpray # #Misfits Change - Followers are surgeons; sterile spray prevents cross-contamination

--- a/Resources/Prototypes/_Nuclear14/radio_channels.yml
+++ b/Resources/Prototypes/_Nuclear14/radio_channels.yml
@@ -102,6 +102,14 @@
   color: "#c44508"
   longRange: true
 
+# #Misfits Add — Followers of the Apocalypse private radio channel
+- type: radioChannel
+  id: FollowersOfApocalypse
+  name: chat-radio-followers
+  keycode: 'f'
+  frequency: 1700
+  color: "#5cbf82"
+
 # Zetan
 
 # - type: radioChannel


### PR DESCRIPTION
:cl: cythisiax

add: FoTA headsets, encryption, their own radio, wasteland radio
fix: CPR fix to work while dead with no defib presence
fix: bonfires not able to be used as a cooking device
tweak: powerarmor damage reduction versus grenades/explosives

