### PR TITLE
Remove the Wasteland Radio From Vault Dwellers

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
@@ -63,7 +63,6 @@
     containers:
       key_slots:
       - EncryptionKeyVault
-      - EncryptionKeyWastelandGlobal
   - type: Sprite
     sprite: Clothing/Ears/Headsets/cargo.rsi
   - type: Clothing


### PR DESCRIPTION
Seeing as all headsets are the same it would be for absolutely everyone in the vault, the overseer would also hear nothing from the wasteland but it makes more sense for the dwellers to only hear vault radio cause yk there was no wasteland radio back before the bombs hit

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Removed Wasteland radio from vaulties

## Why / Balance
It would more properly isolate the faction meant for isolation. And along with this the radios are pre war, the wasteland radio channel is not pre war, so why would it come preinstalled

The plan WAS to give overseer wasteland but every radio is just dweller now so

## Technical details
Removed one line of code

:cl:  Bradysgaming
- tweak: Removed the Dwellers abillity to communicate with the outside world
