### PR TITLE
Add Keycode to Vault Security Radio Channel

### DIFF
--- a/Resources/Prototypes/_Nuclear14/radio_channels.yml
+++ b/Resources/Prototypes/_Nuclear14/radio_channels.yml
@@ -41,6 +41,7 @@
 - type: radioChannel
   id: VaultSecurity
   name: chat-radio-vault-security
+  keycode: "s"
   frequency: 1354
   color: "#A32B2B"
 


### PR DESCRIPTION

## About the PR
Added the "s" key to the options for using the radio

## Why / Balance
prevously the encryption keys gave you accsess to nothing making them literally useless

## Technical details
Added one line where the s key was assigned

<!--
🆑 Bradysgaming
-->

<!--
- fix: Gave the Vaultsec radio a keybind
-->
