### PR TITLE
Re Enabled Species Reqs for NCR Prisoner

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_prisoner.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_prisoner.yml
@@ -10,15 +10,15 @@
   name: job-name-ncr-prisoner #Misfits Change
   description: job-description-ncr-prisoner
   playTimeTracker: NCRPisoner
-  #requirements: # TEMP REMOVED - all requirements removed
-  #  - !type:MinPlayersRequirement
-  #    min: 55
-  #  - !type:CharacterSpeciesRequirement
-  #    species:
-  #    - Human
-  #    - Ghoul
-  #  - !type:CharacterOverallTimeRequirement
-  #    min: 3600
+  requirements: # TEMP REMOVED - all requirements removed
+   # - !type:MinPlayersRequirement
+   #   min: 55
+    - !type:CharacterSpeciesRequirement
+      species:
+      - Human
+      - Ghoul
+   # - !type:CharacterOverallTimeRequirement
+   #   min: 3600
   startingGear: NCRPisonerGear
   icon: "JobIconNCRPrisoner"
   supervisors: job-supervisors-ncr-prisoners


### PR DESCRIPTION
## About the PR
Title
## Why / Balance
This would make the role limit on mr gutsies useless and disallow actual non robots from being a prisoner, also it removes glowing ghouls from being able to spawn as one too, which would be unfair for anyone interacting with prisoners as theyd take rad damage.
## Technical details
Readd'd the species req

🆑  Bradysgaming

fix: The abillity for robots and glowing ghouls to spawn as NCR Prisoners