### PR TITLE
Update Stimpak Recipe Ratio's to Not Suck

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Reactions/medicine.yml
@@ -102,13 +102,13 @@
   id: Stimpak
   reactants:
     ExtractBroc:
-      amount: 2
+      amount: 1
     ExtractXander:
-      amount: 2
+      amount: 1
     Blood:
-      amount: 2
+      amount: 1
   products:
-    HealingMixture: 1
+    HealingMixture: 2
 
 - type: reaction
   id: StimpakConversion
@@ -133,7 +133,7 @@
     WastelandBlood:
       amount: 1
   products:
-    DirtyStimpak: 1
+    DirtyStimpak: 3
 
 - type: reaction
   id: DirtyStimpakConversion


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Changed the Ratio on chemically made stimpaks from
6:1 to 3:2 
and for dirty stimpaks from 3:1 and to 3:3

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It would made chemically made stimpaks viable vs just crafting a million with a ratio of 1 broc fruit 1 doctors syringe 1 xander root for 25u which is still chemically cheaper due to 1 broc flower and xander root only having 10 units of juice in them 

## Technical details
<!-- Summary of code changes for easier review. -->
 Changed 6 Numbers

# Changelog 

:cl: Leaf
- tweak: Changed Ratio on stimpak recipes to be chemically viable.
