### PR TITLE
Mr. Handy Surgery Fix

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
@@ -139,6 +139,8 @@
         Heat: -0.5
         Shock: -0.5
   - type: RobotSelfRepairAnnouncer # #Misfits Change: hull integrity warnings + self-repair popups
+  
+  - type: Sanitized # #Misfits Change: makes mr handy not do damage in surgery
 
   - type: Gun # #Misfits Add: built-in flamer — right-click in combat mode to fire
     cameraRecoilScalar: 0


### PR DESCRIPTION

## About the PR
Gave Mr. Handy cyborgs the sanitized component, making them not do damage when doing surgery.

## Why / Balance
Lack of sanitized component previously was unfun and made Mr. Handy unviable in medical scenarios without extensive preparations.

## Technical details
added the sanitized component to the Mr. Handy entity

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Made Mr. Handy not deal toxin damage in surgery
