### PR TITLE
Melee-Ening 2, Electric Boogaloo.

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Objects/Specific/specific.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Specific/specific.yml
@@ -12,6 +12,6 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 4
+        Blunt: 25
     soundHit:
         collection: MetalThud

--- a/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Melee/longblades.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Melee/longblades.yml
@@ -17,11 +17,11 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 48
+        Slash: 25
   - type: MeleeWeapon
     damage:
       types:
-        Slash: 34
+        Slash: 44
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
@@ -19,9 +19,9 @@
     attackRate: .25
     damage:
       types:
-        Slash: 2
-        Blunt: 2
-        Structural: 4
+        Slash: 20
+        Blunt: 6
+        Structural: 20
     heavyRateModifier: 2
     heavyDamageBaseModifier: 1.0
     heavyStaminaCost: 15
@@ -34,8 +34,8 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Slash: 4
-        Structural: 4
+        Slash: 10
+        Structural: 8
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/chainsaw.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -157,8 +157,8 @@
     attackRate: 1.25
     damage:
       types:
-        Slash: 11
-        Piercing: 4
+        Slash: 34
+        Piercing: 5
     heavyRateModifier: 1.25
     heavyRangeModifier: 1.25
     heavyDamageBaseModifier: 1.2

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Weapons/Melee/legion_powerfist.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Weapons/Melee/legion_powerfist.yml
@@ -20,11 +20,11 @@
     soundHit:
       collection: MetalThud
     range: 1.3
-    attackRate: 1.0
+    attackRate: 0.8
     damage:
       types:
-        Blunt: 20
-        Structural: 10
+        Blunt: 35
+        Structural: 15
     animation: WeaponArcFist
     wideAnimation: WeaponArcFist
     mustBeEquippedToUse: true

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/axes.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/axes.yml
@@ -29,8 +29,8 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 6
-        Slash: 20
+        Blunt: 8
+        Slash: 28
   - type: Item
     sprite: _Nuclear14/Objects/Weapons/Melee/hatchet.rsi
     size: Normal
@@ -69,7 +69,7 @@
     damage:
       types:
         Blunt: 8
-        Slash: 22
+        Slash: 30
   - type: Item
     sprite: _Nuclear14/Objects/Weapons/Melee/tribalhatchet.rsi
     size: Normal
@@ -129,7 +129,7 @@
     damage:
       types:
         Blunt: 8
-        Slash: 30
+        Slash: 40
   - type: Clothing
     sprite: _Nuclear14/Objects/Weapons/Melee/axe.rsi
     quickEquip: false

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/hammer.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/hammer.yml
@@ -18,7 +18,7 @@
     damage:
       types:
         Blunt: 45
-        Structural: 45
+        Structural: 60 #This is for utility and resource harvesting! -Bill
   - type: Item
     size: Large
   - type: Clothing
@@ -114,8 +114,8 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 25 # #Misfits Tweak - cap wield bonus to prevent near-1-crit on Glowing Ghoul (90 crit, 1.1x modifier; max safe raw = 70)
-        Piercing: 10
+        Blunt: 30 # #Misfits Tweak - cap wield bonus to prevent near-1-crit on Glowing Ghoul (90 crit, 1.1x modifier; max safe raw = 70)
+        Piercing: 15
         Slash: 15
         Structural: 30
   - type: Clothing
@@ -141,7 +141,7 @@
     damage:
       types:
         Blunt: 20
-        Piercing: 10
+        Piercing: 15
   - type: Item
     size: Normal
   - type: Clothing

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/longblades.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/longblades.yml
@@ -52,8 +52,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Slash: 11
-        Piercing: 5
+        Slash: 32
+        Piercing: 6
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/spear.yml
@@ -129,8 +129,8 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Piercing: 20
-        Slash: 8
+        Piercing: 24
+        Slash: 10
     angle: 0
     animation: WeaponArcThrust
     soundHit:
@@ -215,8 +215,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Piercing: 25
-        Slash: 16
+        Piercing: 28
+        Slash: 18
   - type: DamageOtherOnHit
     damage:
       types:
@@ -242,8 +242,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Piercing: 24
-        Slash: 16
+        Piercing: 26
+        Slash: 38
   - type: DamageOtherOnHit
     damage:
       types:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/sports.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/sports.yml
@@ -110,7 +110,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 16
+        Blunt: 25
   - type: Item
     size: Large
   - type: Clothing

--- a/Resources/Prototypes/_Nuclear14/Reagents/chems.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/chems.yml
@@ -158,6 +158,9 @@
           groups:
             Brute: 0.2
         withdrawalStaminaDrain: 6.0
+      - !type:MovespeedModifier
+        walkSpeedModifier: 1.30
+        sprintSpeedModifier: 1.30
       - !type:HealthChange #Misfits Change /Add:/ Overdose — suffocates the player when stacking too much Psycho
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -171,8 +171,8 @@
       - !type:HealthChange
         damage:
           groups:
-            Burn: -1
-            Brute: -1
+            Burn: -1.5
+            Brute: -2.5
             Airloss: -2
           types:
             Poison: -1
@@ -473,11 +473,11 @@
       - !type:HealthChange
         damage:
           groups:
-            Burn: -3
-            Brute: -3
+            Burn: -4.5
+            Brute: -4.5
             Airloss: -1
       - !type:ModifyBleedAmount
-        amount: -1
+        amount: -2
       # !type:Drunk — #Misfits Tweak: Removed. TryAddTime accumulates per metabolism tick, causing ~10 min overlay.
       # HealingPoultice is a medicine not a drink; Jitter below already signals discomfort without screen distortion.
       - !type:Jitter
@@ -508,7 +508,7 @@
           groups:
             Toxin: -2.5
           types:
-            Radiation: -1
+            Radiation: -2
       - !type:ChemVomit
         probability: 0.05
         conditions:


### PR DESCRIPTION
## About the PR
Buffed some underperforming melees that I was informed about. Buffed healing power and poultice and bitter since I have noticed they are horribly shit against anyone using stims (they are still not on par just better now). Also a bugfix for some of the melees which didn't really get their buffs. Also buffed psycho after being told in VC about its pitiful performance (being none at all).

## Why / Balance
See previous Melee-ening PR. Melee should punish the foolish and reward the risks.
Buffed tribal meds because they were woefully outperformed by even basic stims which made drugs like Hydra required for Legion and unga mixes for tribals. This hopefully makes them more useful and closer up to speed.
Buffed psycho because it lacks a use right now. Typically it would buff your STR stat but we no longer have SPECIAL, so hopefully the 30% speed buff gives the pre-war combat drug a good use.

## Technical details
Simple yaml changes. Buffed poultice by 1.5 on burn and brute and 1 on bleed. Buffed powder by .5 on burn and 1.5 on brute. Buffed bitterdrink by 1 on rads. Buffed psycho with a 30% movespeed increase.

## Media
![You should do it](https://github.com/user-attachments/assets/32b2df41-9d80-4319-8157-2fe2f138f7be)
They whisper in my ears in VC about what needs buffing.

# Changelog

:cl: Bill Clinton

- tweak: buffed tribal meds like bitterdrink, poultice, and powder.
- tweak: melee tuning pass V2
- tweak: buffed psycho with a 30% movespeed increase. It now has a use.