### PR TITLE
Hunting Rifle Fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -10,6 +10,9 @@
     sprite: _Nuclear14/Objects/Weapons/Guns/Snipers/hunting.rsi
   - type: Wieldable
     wieldedSpeedModifier: 0.75
+  - type: GunWieldBonus
+    minAngle: -23
+    maxAngle: -104
   - type: Gun
     minAngle: 24
     maxAngle: 105


### PR DESCRIPTION
## About the PR
Fixed hunting rifle spread by giving it the GunWieldBonus

## Why / Balance
70-80% of legion kits basically rely on hunting rifle. Having a rifle with 105 degrees of max spread with no way to decrease it is genuinely unplayable at range beyond point blank.

## Technical details
Copied the GunWieldBonus from the Enfield to the Hunting Rifle, which it needed to be useful.

## Media
![Three_times_already](https://github.com/user-attachments/assets/04ad5da9-d7d5-44a8-a69c-cd72f136db67)

# Changelog

:cl: Bill Clinton

- fix: Hunting rifle accuracy is fixed, millions must hunt.