### PR TITLE
Optimizations

### DIFF
--- a/Content.Server/_Misfits/Cleanup/MisfitsWorldCleanupSystem.cs
+++ b/Content.Server/_Misfits/Cleanup/MisfitsWorldCleanupSystem.cs
@@ -1,0 +1,82 @@
+// #Misfits Add - Automatic despawn for puddles, footprints, and giblets to prevent entity accumulation
+
+using Content.Shared.Body.Organ;
+using Content.Shared.Body.Part;
+using Content.Shared.Fluids.Components;
+using Content.Shared.Throwing;
+using Robust.Shared.Spawners;
+
+namespace Content.Server._Misfits.Cleanup;
+
+/// <summary>
+/// Adds <see cref="TimedDespawnComponent"/> to entity types that would otherwise
+/// persist forever and silently accumulate over a long round:
+/// <list type="bullet">
+///   <item>Blood puddles — created every bleed tick, blood never evaporates.</item>
+///   <item>Footprints — spawned every step through a puddle.</item>
+///   <item>Giblets (body parts + organs) — dropped when mobs are gibbed.</item>
+/// </list>
+/// </summary>
+public sealed class MisfitsWorldCleanupSystem : EntitySystem
+{
+    // Puddles (blood, chemicals, water) — 10 minutes gives plenty of time
+    // for gameplay interaction (slip, forensics, mopping) before cleanup.
+    private const float PuddleLifetime = 600f;
+
+    // Body parts and organs scattered during gibbing — 10 minutes.
+    private const float GibletLifetime = 600f;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // Covers both regular puddles AND footprint entities (Footstep prototype
+        // also carries PuddleComponent).
+        SubscribeLocalEvent<PuddleComponent, ComponentStartup>(OnPuddleStartup);
+
+        // Giblets are thrown with impulse during gibbing. When they land, we tag
+        // them for cleanup. This handles the vast majority of gib scenarios.
+        SubscribeLocalEvent<BodyPartComponent, LandEvent>(OnBodyPartLand);
+        SubscribeLocalEvent<OrganComponent, LandEvent>(OnOrganLand);
+    }
+
+    private void OnPuddleStartup(EntityUid uid, PuddleComponent comp, ComponentStartup args)
+    {
+        if (TerminatingOrDeleted(uid))
+            return;
+
+        var despawn = EnsureComp<TimedDespawnComponent>(uid);
+
+        // Only upgrade lifetime; don't shorten an existing shorter timer.
+        if (despawn.Lifetime < PuddleLifetime)
+            despawn.Lifetime = PuddleLifetime;
+    }
+
+    private void OnBodyPartLand(EntityUid uid, BodyPartComponent comp, ref LandEvent args)
+    {
+        // Part is still attached to a living body — don't despawn (e.g. held limbs).
+        if (comp.Body != null)
+            return;
+
+        AddGibletDespawn(uid);
+    }
+
+    private void OnOrganLand(EntityUid uid, OrganComponent comp, ref LandEvent args)
+    {
+        // Organ is still inside a body — don't despawn.
+        if (comp.Body != null)
+            return;
+
+        AddGibletDespawn(uid);
+    }
+
+    private void AddGibletDespawn(EntityUid uid)
+    {
+        if (TerminatingOrDeleted(uid))
+            return;
+
+        var despawn = EnsureComp<TimedDespawnComponent>(uid);
+        if (despawn.Lifetime < GibletLifetime)
+            despawn.Lifetime = GibletLifetime;
+    }
+}

--- a/Content.Server/_Misfits/OreBox/MisfitsOreBoxMagnetSystem.cs
+++ b/Content.Server/_Misfits/OreBox/MisfitsOreBoxMagnetSystem.cs
@@ -38,6 +38,10 @@ public sealed class MisfitsOreBoxMagnetSystem : EntitySystem
             if (!xform.Anchored)
                 continue;
 
+            // Skip ore boxes on deleted/unloading maps to avoid broadphase queries on stale trees.
+            if (xform.MapID == MapId.Nullspace)
+                continue;
+
             magnet.Accumulator += frameTime;
             if (magnet.Accumulator < magnet.ScanInterval)
                 continue;

--- a/Content.Server/_Misfits/PersistentSpawn/MisfitsPersistentSpawnSystem.cs
+++ b/Content.Server/_Misfits/PersistentSpawn/MisfitsPersistentSpawnSystem.cs
@@ -479,7 +479,7 @@ public sealed class MisfitsPersistentSpawnSystem : EntitySystem
             return;
 
         RemovePersistentRecord(uid);
-        EntityManager.DeleteEntity(uid);
+        QueueDel(uid); // #Misfits Fix - Deferred delete prevents broadphase corruption if physics system is mid-iteration.
     }
 
     // ── Standard erase from the engine's PlacementManager ──────────────────────

--- a/Content.Server/_Misfits/TribalHunt/LegendaryCreatureSpawnerSystem.cs
+++ b/Content.Server/_Misfits/TribalHunt/LegendaryCreatureSpawnerSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared._Misfits.TribalHunt;
-using Content.Shared.Destructible;
 using Content.Shared.Maps;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -27,10 +26,14 @@ public sealed partial class LegendaryCreatureSpawnerSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
 
+    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
+
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<LegendaryCreatureComponent, DestructionEventArgs>(OnCreatureDestroyed);
+        // Subscribe to MobStateChanged instead of DestructionEventArgs so the entity
+        // still has a valid TransformComponent when we spawn loot and raise events.
+        SubscribeLocalEvent<LegendaryCreatureComponent, MobStateChangedEvent>(OnCreatureMobStateChanged);
     }
 
     /// <summary>
@@ -106,13 +109,24 @@ public sealed partial class LegendaryCreatureSpawnerSystem : EntitySystem
         return true;
     }
 
-    private void OnCreatureDestroyed(EntityUid uid, LegendaryCreatureComponent comp, DestructionEventArgs args)
+    /// <summary>
+    /// Fires when the creature transitions to Dead. The entity still has a valid
+    /// TransformComponent here, so physics queries and loot spawns are safe.
+    /// </summary>
+    private void OnCreatureMobStateChanged(EntityUid uid, LegendaryCreatureComponent comp, MobStateChangedEvent args)
     {
+        if (args.NewMobState != MobState.Dead)
+            return;
+
+        // Cache coordinates while the entity is still fully intact.
+        var coords = _transformSystem.GetMoverCoordinates(uid);
+
         RaiseLocalEvent(uid, new LegendaryCreatureKilledEvent());
 
-        for (int i = 0; i < comp.LeatherDropCount; i++)
+        // Spawn loot at the cached position instead of querying the dying entity's physics.
+        for (var i = 0; i < comp.LeatherDropCount; i++)
         {
-            SpawnNextToOrDrop("TribalLegendaryLeather", uid);
+            Spawn("TribalLegendaryLeather", coords);
         }
     }
 }

--- a/Content.Server/_Misfits/TribalHunt/TribalHuntSystem.cs
+++ b/Content.Server/_Misfits/TribalHunt/TribalHuntSystem.cs
@@ -105,8 +105,21 @@ public sealed class TribalHuntSystem : EntitySystem
         if (_timing.CurTime >= _lastUiHeartbeat + TimeSpan.FromSeconds(1))
         {
             _lastUiHeartbeat = _timing.CurTime;
+
+            // Prune hunters that no longer exist or are dead — prevents stale UID accumulation.
+            PruneStaleHunters();
+
             BroadcastUiToDepartment(_targetDepartment, BuildStatusText());
         }
+    }
+
+    /// <summary>
+    /// Remove deleted or dead entities from the joined hunters set so we don't
+    /// waste time sending UI updates or awarding buffs to garbage UIDs.
+    /// </summary>
+    private void PruneStaleHunters()
+    {
+        _joinedHunters.RemoveWhere(uid => !Exists(uid) || _mobState.IsDead(uid));
     }
 
     private void OnLeaderStartup(EntityUid uid, TribalHuntLeaderComponent component, ComponentStartup args)
@@ -299,7 +312,7 @@ public sealed class TribalHuntSystem : EntitySystem
         _joinedHunters.Clear();
 
         if (cleanupLegendary && legendary != null && Exists(legendary.Value))
-            Del(legendary.Value);
+            QueueDel(legendary.Value); // Deferred delete — prevents broadphase corruption if physics is mid-iteration.
 
         BroadcastUiToDepartment(department, statusText);
     }
@@ -344,6 +357,19 @@ public sealed class TribalHuntSystem : EntitySystem
 
     private void BroadcastUiToDepartment(string departmentId, string statusText)
     {
+        if (_stage == TribalHuntStage.Active)
+        {
+            // During Active hunt, only joined hunters need updates — skip the expensive
+            // full participant query + IsInDepartment call (3 component lookups each).
+            foreach (var uid in _joinedHunters)
+            {
+                SendUiUpdate(uid, statusText);
+            }
+            return;
+        }
+
+        // During Gathering (or other stages), broadcast to all tribe participants
+        // so they can see the join window.
         var query = EntityQueryEnumerator<TribalHuntParticipantComponent>();
         while (query.MoveNext(out var uid, out _))
         {
@@ -371,6 +397,12 @@ public sealed class TribalHuntSystem : EntitySystem
 
         var isJoined = _joinedHunters.Contains(uid);
 
+        // Only call IsInDepartment for the CanJoin flag during Gathering — during Active,
+        // all recipients are already validated joined hunters so skip the 3x component lookup.
+        var canJoin = _stage == TribalHuntStage.Gathering
+                      && !isJoined
+                      && IsInDepartment(uid, _targetDepartment);
+
         var state = new TribalHuntUiState
         {
             Active = _stage == TribalHuntStage.Active,
@@ -381,7 +413,7 @@ public sealed class TribalHuntSystem : EntitySystem
             CoordinatesKnown = _stage == TribalHuntStage.Active && _hasKnownCoordinates,
             CoordinatesText = _lastKnownCoordinates,
             JoinWindowOpen = _stage == TribalHuntStage.Gathering,
-            CanJoin = _stage == TribalHuntStage.Gathering && !isJoined && IsInDepartment(uid, _targetDepartment),
+            CanJoin = canJoin,
             IsJoined = isJoined,
             JoinedHunters = _joinedHunters.Count,
         };

--- a/Content.Server/_Misfits/Weapons/Guns/CasingPhysicsOptSystem.cs
+++ b/Content.Server/_Misfits/Weapons/Guns/CasingPhysicsOptSystem.cs
@@ -1,70 +1,96 @@
 using Content.Shared.Throwing;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Spawners;
 
-// #Misfits Add - Remove physics from spent casings on landing to avoid accumulating 1000+ dynamic physics bodies during war
+// #Misfits Add - Remove physics from spent casings on landing + enforce a global casing entity cap
 
 namespace Content.Server._Misfits.Weapons.Guns;
 
 /// <summary>
-/// Server-side optimisation system that drops spent bullet casings out of the
-/// physics simulation the moment they land.
+/// Server-side optimisation system for spent bullet casings:
+///
+/// <list type="number">
+///   <item>Strips <see cref="PhysicsComponent"/> on landing so casings leave
+///         the broadphase immediately (the original behaviour).</item>
+///   <item>Enforces a global cap on concurrent casing entities. When the cap
+///         is exceeded the oldest casings are deleted, preventing runaway
+///         accumulation during sustained 20v20 firefights even with the
+///         30-second <see cref="TimedDespawnComponent"/> timer.</item>
+/// </list>
 ///
 /// <para>
-/// During large war scenarios casings accumulate rapidly (easily 1000+ entities).
-/// Each casing carries a <see cref="PhysicsComponent"/> with a dynamic body that
-/// remains "awake" in the physics engine until it fully comes to rest.  With many
-/// casings this creates expensive constraint islands and broadphase queries every
-/// tick.  Removing <see cref="PhysicsComponent"/> via
-/// <c>RemCompDeferred</c> takes the entity out of the simulation entirely;
-/// RobustToolbox's <c>SharedPhysicsSystem.OnPhysicsRemoved</c> cascades the
-/// fixture / broadphase cleanup automatically so we do not need to touch
-/// <c>FixturesComponent</c> directly.
-/// </para>
-///
-/// <para>
-/// <b>Known limitation:</b> casings ejected without a throw angle (e.g. manual
-/// chamber cycling, revolver ejection — the <c>angle == null</c> branch in
-/// <c>SharedGunSystem.EjectCartridge</c>) never receive a
-/// <c>ThrownItemComponent</c>, so <c>LandEvent</c> is never raised for them.
-/// Those casings retain their physics body for the full
-/// <see cref="TimedDespawnComponent"/> lifetime (90 s after the Misfits tweak).
-/// This edge case affects a small minority of weapons and is considered
-/// acceptable.
+/// The no-throw-angle edge case (revolver eject, manual cycling) is now handled
+/// in <c>SharedGunSystem.EjectCartridge</c> which strips physics immediately
+/// when <c>angle == null</c>.
 /// </para>
 /// </summary>
 public sealed class CasingPhysicsOptSystem : EntitySystem
 {
+    /// <summary>
+    /// Maximum number of spent casing entities allowed to exist at once.
+    /// Beyond this, the oldest are deleted. 500 is generous — a 20-player
+    /// war with automatic weapons peaks around 300-600 concurrent casings
+    /// at 30 s lifetime.
+    /// </summary>
+    private const int MaxCasings = 500;
+
+    // FIFO queue of tracked casing UIDs for cap enforcement.
+    private readonly Queue<EntityUid> _casingQueue = new();
+
     public override void Initialize()
     {
         base.Initialize();
 
-        // Filter to entities that carry CartridgeAmmoComponent so the handler
-        // is never invoked for unrelated thrown items (tools, grenades, etc.).
+        // Strip physics on landing (existing behaviour).
         SubscribeLocalEvent<CartridgeAmmoComponent, LandEvent>(OnCasingLand);
+
+        // Track casings for the global cap when their despawn timer is attached.
+        // This fires for ALL spent casings — both thrown and no-throw variants.
+        SubscribeLocalEvent<CartridgeAmmoComponent, ComponentStartup>(OnCartridgeStartup);
     }
 
     /// <summary>
     /// Raised by <c>ThrownItemSystem</c> when a thrown entity comes to rest.
-    /// If the cartridge is already spent we remove its physics body so the
-    /// entity becomes a pure visual/timer entity and exits the physics
-    /// simulation immediately.
+    /// Strips the physics body so the entity becomes a pure visual/timer entity.
     /// </summary>
     private void OnCasingLand(EntityUid uid, CartridgeAmmoComponent cartridge, ref LandEvent args)
     {
-        // Only optimise spent casings. Live cartridges that are thrown
-        // (e.g. thrown by hand) must keep physics so they can still be
-        // picked up and used.
         if (!cartridge.Spent)
             return;
 
-        // Deferred removal keeps us safely outside the physics engine's own
-        // event stack.  RobustToolbox's SharedPhysicsSystem.OnPhysicsRemoved
-        // handler fires when the component is actually removed and takes care
-        // of unregistering all fixtures from the broadphase automatically —
-        // we must NOT call RemCompDeferred<FixturesComponent> separately as
-        // that would cause a double-teardown when PhysicsComponent removal
-        // then tries to access already-gone fixtures.
+        // Deferred removal keeps us safely outside the physics engine's event stack.
+        // RobustToolbox's SharedPhysicsSystem.OnPhysicsRemoved cascades fixture/broadphase
+        // cleanup automatically.
         RemCompDeferred<PhysicsComponent>(uid);
+    }
+
+    /// <summary>
+    /// Track spent casings for cap enforcement. We piggyback on ComponentStartup
+    /// rather than adding a dedicated marker component.
+    /// </summary>
+    private void OnCartridgeStartup(EntityUid uid, CartridgeAmmoComponent cartridge, ComponentStartup args)
+    {
+        // Only track spent casings that have a despawn timer (i.e. ejected casings,
+        // not cartridges sitting in a magazine).
+        if (!cartridge.Spent || !HasComp<TimedDespawnComponent>(uid))
+            return;
+
+        _casingQueue.Enqueue(uid);
+        TrimCasings();
+    }
+
+    /// <summary>
+    /// Delete the oldest casings when the cap is exceeded.
+    /// Skips already-deleted entities (natural despawn or manual cleanup).
+    /// </summary>
+    private void TrimCasings()
+    {
+        while (_casingQueue.Count > MaxCasings)
+        {
+            var oldest = _casingQueue.Dequeue();
+            if (Exists(oldest) && !TerminatingOrDeleted(oldest))
+                QueueDel(oldest);
+        }
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -513,9 +513,15 @@ public abstract partial class SharedGunSystem : EntitySystem
         if (TryComp<CartridgeAmmoComponent>(entity, out var cartridge2) && cartridge2.Spent)
         {
             var despawn = EnsureComp<TimedDespawnComponent>(entity);
-            despawn.Lifetime = 90f; // #Misfits Tweak - Reduce casing despawn from 5min to 90s to prevent 1000+ entity buildup during war
+            despawn.Lifetime = 30f; // #Misfits Tweak - Reduce casing despawn from 5min to 30s to prevent entity buildup during war
 
             _entManager.RemoveComponent<ItemComponent>(entity);
+
+            // #Misfits Fix - Casings ejected without a throw angle (revolver/manual cycling)
+            // never get ThrownItemComponent, so LandEvent never fires and
+            // CasingPhysicsOptSystem can't strip their physics. Remove it here.
+            if (angle == null)
+                RemCompDeferred<PhysicsComponent>(entity);
         }
     }
 


### PR DESCRIPTION
:cl: cythisiax

fix: Legendary creature loot now spawns at correct coordinates by switching from DestructionEventArgs to MobStateChangedEvent
fix: Casings ejected without a throw angle (revolvers, manual cycling) now have physics stripped immediately instead of persisting
fix: Ore box magnet no longer queries broadphase on nullspace/unloading maps
fix: Persistent spawn erase now uses QueueDel to prevent broadphase corruption during physics iteration
fix: Tribal hunt legendary cleanup now uses QueueDel to prevent broadphase corruption
fix: Stale/dead hunters are now pruned from the joined hunters set each UI tick
tweak: Spent casing despawn reduced from 90s to 30s to further reduce entity count during war
tweak: Tribal hunt UI broadcasts during Active stage now only update joined hunters instead of querying all participants
tweak: Casing IsInDepartment check skipped during Active hunt stage (only computed during Gathering)
add: Global spent casing cap of 500 — oldest casings are deleted when exceeded to prevent runaway accumulation during sustained firefights
add: World cleanup system that auto-despawns blood puddles, footprints, and giblets after 10 minutes