### PR TITLE
No ID = No Name

### DIFF
--- a/Content.Server/IdentityManagement/IdentitySystem.cs
+++ b/Content.Server/IdentityManagement/IdentitySystem.cs
@@ -45,6 +45,7 @@ public sealed class IdentitySystem : SharedIdentitySystem
         SubscribeLocalEvent<IdentityComponent, WearerMaskToggledEvent>((uid, _, _) => QueueIdentityUpdate(uid));
         SubscribeLocalEvent<IdentityComponent, EntityRenamedEvent>((uid, _, _) => QueueIdentityUpdate(uid));
         SubscribeLocalEvent<IdentityComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<IdentityComponent, TransformSpeakerNameEvent>(OnTransformSpeakerName);
 
         SubscribeLocalEvent<IdentityBlockerComponent, ComponentInit>(BlockerUpdateIdentity); // Goobstation - Update component state on component toggle
         SubscribeLocalEvent<IdentityBlockerComponent, ComponentRemove>(BlockerUpdateIdentity); // Goobstation - Update component state on component toggle
@@ -129,7 +130,9 @@ public sealed class IdentitySystem : SharedIdentitySystem
         var ev = new SeeIdentityAttemptEvent();
 
         RaiseLocalEvent(target, ev);
-        return representation.ToStringKnown(!ev.Cancelled);
+        // #Misfits Change - No-ID policy: without an ID name, identity is always descriptive and never a personal name.
+        var canRevealPersonalName = !ev.Cancelled && representation.PresumedName != null;
+        return representation.ToStringKnown(canRevealPersonalName);
     }
 
     /// <summary>
@@ -191,6 +194,13 @@ public sealed class IdentitySystem : SharedIdentitySystem
             target = containing.Value;
 
         QueueIdentityUpdate(target);
+    }
+
+    // #Misfits Change /Fix/: identity-blocking masks should obfuscate spoken names the same way they already obfuscate emotes.
+    private void OnTransformSpeakerName(EntityUid uid, IdentityComponent component, ref TransformSpeakerNameEvent args)
+    {
+        // #Misfits Fix - Speech should use identity representation so no-ID speakers show description instead of true name.
+        args.VoiceName = Identity.Name(uid, EntityManager);
     }
 
     // #Misfits Change /Fix/: identity-blocking masks should obfuscate spoken names the same way they already obfuscate emotes.

--- a/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
@@ -9,6 +9,8 @@
     size: Small
   - type: Clothing
     slots: [mask]
+  # #Misfits Change - Enforce repo-wide policy: all mask face coverings block identification.
+  - type: IdentityBlocker
   - type: HideLayerClothing # Corvax-Change
     force: true
     slots:

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/bandanas.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/bandanas.yml
@@ -11,6 +11,8 @@
     sprite: _Nuclear14/Clothing/Mask/Bandanas/redscarf.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face coverings should block identification.
+  - type: IdentityBlocker
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -28,6 +30,8 @@
     sprite: _Nuclear14/Clothing/Mask/Bandanas/desertmask.rsi
   - type: BreathMask
   - type: IngestionBlocker
+  # #Misfits Fix - Face coverings should block identification.
+  - type: IdentityBlocker
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -45,6 +49,8 @@
     sprite: _Nuclear14/Clothing/Mask/Bandanas/bluescarf.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face coverings should block identification.
+  - type: IdentityBlocker
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -62,6 +68,8 @@
     sprite: _Nuclear14/Clothing/Mask/Bandanas/greenscarf.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face coverings should block identification.
+  - type: IdentityBlocker
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -79,6 +87,8 @@
     sprite: _Nuclear14/Clothing/Mask/Bandanas/orangescarf.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face coverings should block identification.
+  - type: IdentityBlocker
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -96,6 +106,8 @@
     sprite: _Nuclear14/Clothing/Mask/Bandanas/brownscarf.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face coverings should block identification.
+  - type: IdentityBlocker
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -113,6 +125,8 @@
     sprite: _Nuclear14/Clothing/Mask/Bandanas/patriotscarf.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face coverings should block identification.
+  - type: IdentityBlocker
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/gasmasks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/gasmasks.yml
@@ -34,6 +34,7 @@
     sprite: _Nuclear14/Clothing/Mask/fallouthazmatsuit.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/Mask/fallouthazmatsuit.rsi
+  # #Misfits Fix - Any face covering should block identification.
   - type: IdentityBlocker
   - type: BreathMask
   - type: GasFilterMask # Misfits Change

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Mask/masks.yml
@@ -10,6 +10,8 @@
     sprite: _Nuclear14/Clothing/Mask/hockeymask.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face-covering masks should block identification.
+  - type: IdentityBlocker
   - type: Armor
     modifiers:
       coefficients:
@@ -33,6 +35,8 @@
     sprite: _Nuclear14/Clothing/Mask/platemask.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face-covering masks should block identification.
+  - type: IdentityBlocker
   - type: Armor
     modifiers:
       coefficients:
@@ -56,6 +60,8 @@
     sprite: _Nuclear14/Clothing/Mask/grillmask.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face-covering masks should block identification.
+  - type: IdentityBlocker
   - type: Armor
     modifiers:
       coefficients:
@@ -83,6 +89,8 @@
     slots:
     - Hair
     - Snout
+  # #Misfits Fix - Brown balaclava should hide identity like other balaclavas.
+  - type: IdentityBlocker
 
 - type: entity
   parent: ClothingMaskBase
@@ -132,6 +140,8 @@
     sprite: _Nuclear14/Clothing/Mask/mountiemask.rsi
   - type: Mask
   - type: IngestionBlocker
+  # #Misfits Fix - Face-covering masks should block identification.
+  - type: IdentityBlocker
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION

:cl:
fix: Characters without an ID now show only descriptive identity text instead of their true name, including in speech/chat.
tweak: All mask-slot face coverings now block identification by default (repo-wide, including N14 masks/bandanas/hazmat masks).