### PR TITLE
Given Followers Roundstart Surgery Bag

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Fun/followers.yml
@@ -44,7 +44,7 @@
   id: FollowersGear
   equipment:
     jumpsuit: N14ClothingUniformJumpsuitFollowers
-    back: N14ClothingBackpackWastelanderFilled # N14TODO: Doctors Bag
+    back: ClothingBackpackDuffelSurgeryFilled # Bag meant for sugeries, belt already has med supplies so this is a good addition
     shoes: N14ClothingBootsLeather # Forge-Change
     neck: ClothingNeckStethoscope # Forge-Change
     id: N14IDDoctorFollower


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
For the guys meant to be all in for healing people you'd imagine theyd be more prepped for surgery no?

## Technical details
Edited back from normal packpack to the surgery duffel filled with tools

🆑 Bradysgaming

- tweak: Swapped FOTA starting backpack with surgical duffle bag full of tools.