### PR TITLE
Make Electrolyzer Units Craftable, as Well as Basic Machine Parts.

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -107,7 +107,9 @@
     - LandMineExplosive  # Explosive Mine (~4 tile radius)
     - LandMineModular    # Modular Mine (empty casing, add payload)
     # #Misfits Add: Expose vanilla centrifuge machine board so players can rebuild MachineCentrifuge via machine frame.
-    - CentrifugeMachineCircuitboard
+    - CentrifugeMachineCircuitboard 
+    # #Misfits Add: Electrolyzer machine board so players can make electrolyzers via machine frame.
+    - ElectrolysisUnitMachineCircuitboard
 
 - type: entity
   parent: N14WorkbenchBase
@@ -345,6 +347,9 @@
     - N14GlowstickRed
     - N14CleanGauze1
     - DoorElectronics
+    - CapacitorStockPart
+    - MicroManipulatorStockPart
+    - MatterBinStockPart
 
 - type: entity
   parent: BaseStructure


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Added the ability to make Electrolyzer machine boards at the weapons workbench, same as centrifuge. Also added manipulators, capacitors and matter bins to the tinker bench.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Vault has access to every base game chemical as well as an electrolyzer and centrifuge, so this will allow other factions to be able to make similar quality chems to vault, whilst still allowing vault to have an edge in that.

## Technical details
<!-- Summary of code changes for easier review. --> Added electrolyzer as well as machine part tags to the workbench yaml file in _Nuclear14 proto.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: qevie
- tweak: Made electrolyzers and basic machine parts craftable!
