### PR TITLE
Brought Back Frumentarii Latin

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_frumentarii.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_frumentarii.yml
@@ -33,8 +33,8 @@
           - CaesarLegion
 #      - type: ReplacementAccent  # #Misfits Removed - forced latin speech replacement removed per request; Frumentarii should be able to speak normally
 #        accent: latin
-#  - !type:AddTraitSpecial  # #Misfits Removed - LanguageLatin tied to forced accent, removed alongside it
-#    traits: [ LanguageLatin ]
+  - !type:AddTraitSpecial
+    traits: [ LanguageLatin ]
 
 - type: startingGear
   id: CaesarLegionFrumentariiGear


### PR DESCRIPTION

## About the PR
Gave frumen back their latin, it also is working without the accent needing to be forced which helps with the inital reason it was disabled

## Why / Balance
Now they can both talk to their allies and sneak into factions

## Technical details
removed two hastags.

🆑 Bradysgaming

- tweak: Gave frumen back latin
