### PR TITLE
Legion MGs 

### DIFF
--- a/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
@@ -396,14 +396,14 @@ undecided-loadout-category-corvax-auxilia-medic-description =
 
 undecided-loadout-category-corvax-veteran-decanus-command-name = Veteran Decanus Command
 undecided-loadout-category-corvax-veteran-decanus-command-description =
-    Includes a Legion shield, a Chinese LMG with spare LMG belt,
+    Includes a Legion shield, a M240B HMG with spare HMG belt,
     a rope belt, a .45 Colt pistol, 2 .45 magazines,
     a box of .45 ammo, a handcuff box, a bola,
     2 healing poultice, 2 K rations, and a ceramic flask.
 
 undecided-loadout-category-corvax-veteran-decanus-hunter-name = Veteran Decanus Hunter
 undecided-loadout-category-corvax-veteran-decanus-hunter-description =
-    Includes a Legion buckler, a chinese LMG with a spare LMG belt,
+    Includes a Legion buckler, a M240B HMG with spare HMG belt,
     a .45 Colt pistol, 2 .45 magazines, a rope belt,
     a short shotgun, a box of 12 gauge shells,
     2 healing poultices, a healing powder,

--- a/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
@@ -547,7 +547,7 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14LegionnaireShield
-      - id: N14WeaponLMGchinese # #Misfits Change by BILL CLINTON!: Parity with NCR specialist kits. they get lmgs why doesn't legion?
+      - id: N14WeaponUSHMG # #Misfits Change by BILL CLINTON!: Parity with NCR specialist kits. they get lmgs why doesn't legion?
       - id: Magazine762AmmoBelt # #Misfits Change by bill - one belt of LMG is more than enough
         amount: 1
       - id: ClothingBeltRope
@@ -581,7 +581,7 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14LegionnaireBuckler
-      - id: N14WeaponLMGchinese # #Misfits Change by BILL CLINTON!: Parity with NCR specialist kits. they get lmgs why doesn't legion?
+      - id: N14WeaponUSHMG # #Misfits Change by BILL CLINTON!: Parity with NCR specialist kits. they get lmgs why doesn't legion?
       - id: Magazine762AmmoBelt # #Misfits Change by bill - one belt of LMG is more than enough.
         amount: 1
       - id: ClothingBeltRope

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/PriestessOfMars/priestess_of_mars_clothing.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/PriestessOfMars/priestess_of_mars_clothing.yml
@@ -53,10 +53,10 @@
     soundHit:
       collection: MetalThud
     range: 1.2
-    attackRate: 1.0
+    attackRate: 1.5
     damage:
       types:
-        Slash: 8
+        Slash: 20
     animation: WeaponArcFist
     wideAnimation: WeaponArcFist
     mustBeEquippedToUse: true


### PR DESCRIPTION
## About the PR
Legion vet decanus given Legion M240B instead of chinese LMG in their kit.
Priestess gauntlets buffed from fairly dogshittium to being ok.

## Why / Balance
Told by cyth that the legion does have their own HMG model and thats frankly better for them than the chinese one.
Brought the gauntlets up to snuff with the rest of the melee buffs.

## Technical details
yml and ftl changes

## Media
![corn-cat](https://github.com/user-attachments/assets/d94bfe21-740c-4b11-8ea2-079664eefae4)
# Changelog

:cl: Bill Clinton

- tweak: gave decanus the legion HMG instead of chinese HMG and buffed priestess gauntlets to be on par with the other melees.