### PR TITLE
Midwest PA for Head Paladin

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/bos_rank_loadoutkits.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/bos_rank_loadoutkits.yml
@@ -57,6 +57,69 @@
 #    - ScribeMedicWashingtonBoSSet
 
 - type: entity
+  name: Brotherhood Midwest Power Armor Kit
+  parent: KitBase
+  id: KitPowerArmorMidwest
+  description: A crate containing a set of power armor.
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: rifleman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14ClothingOuterPowerArmorMidwestCommander
+      
+- type: UndecidedLoadoutBackpackSet
+  id: PowerArmorMidwestSet
+  name: Midwest Power Armor
+  description: This kit contains a pristine set of midwestern power armor.
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: rifleman
+  content:
+  - KitPowerArmorMidwest
+      
+- type: entity
+  name: Brotherhood Power Armor Kit
+  parent: KitBase
+  id: KitBoSPowerArmor
+  description: A crate containing a set of power armor.
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: rifleman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14ClothingOuterPowerArmorWashT51Elite
+      
+- type: UndecidedLoadoutBackpackSet
+  id: BoSPowerArmorSet
+  name: T-51b Power Armor
+  description: This kit contains a pristine set of T-51b Power Armor.
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: rifleman
+  content:
+  - KitBoSPowerArmor
+
+- type: entity
+  id: BoSPowerArmorKit
+  name: Undecided Brotherhood Power Armor Kit
+  parent: BaseLoadoutKit
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: rifleman
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - BoSPowerArmorSet
+    - PowerArmorMidwestSet
+
+- type: entity
   id: BoSBrotherhoodSeniorPaladinKits
   name: Undecided Brotherhood Senior Paladin Kit
   parent: BaseLoadoutKit
@@ -66,7 +129,8 @@
     state: rifleman
   - type: UndecidedLoadoutBackpack
     possibleSets:
-    - MBoS_KniLas_Set  #Misfits Tweak: AER-14 replaced with AER-9 (KniLas)
+    - MBoS_KniLas_Set 
+    #Misfits Tweak: AER-14 replaced with AER-9 (KniLas)
     - MBoS_PalLas_Set
     - MBoS_PalBal_Set
     #- MBoS_PalSni_Set  #Misfits Remove: Bozar removed from all Paladin ranks

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
@@ -38,10 +38,10 @@
     jumpsuit: N14ClothingUniformBosRecon  #Misfits Change /Tweak/: New consolidated BoS gear
     back: N14ClothingBackpackMilitary
     shoes: N14ClothingBootsLeatherFilled
-    head: N14ClothingHeadHatBeretknighBoS
-    outerClothing: N14ClothingOuterPowerArmorWashT51Elite #Misfits Tweak: Head Paladin wears T-51b (was T-51BC commander)
+    head: N14ClothingHeadHatBeretknighBoS #Misfits Tweak - Head Paladin starts with Power Armor Kit
     hands: N14ClothingHandsGlovesCombat
     pocket1: BoSBrotherhoodHeadPaladinKits
+    pocket2: BoSPowerArmorKit
     id: N14IDBrotherhoodOfSteelHolotagHeadPaladin
     ears: N14ClothingHeadsetBrotherhoodOfSteel
     belt: N14ClothingBeltBoSWebbing


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Added a loadout kit to Head Paladin in order to allow them to pick and choose their PA model of choice.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Primarily cosmetic, no balance purpose

## Technical details
<!-- Summary of code changes for easier review. --> Created an additional power armor kit for head paladin in the bos_rank_loadoutkits.yml file, as well as changing their role to include spawning with it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: qevie
- add: Added Midwest Power Armor to Head Paladin.
