### PR TITLE
Loadout Adjustment Adds Rest of Tribal Clothes to Loadout

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/uniform.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/uniform.yml
@@ -409,6 +409,66 @@
         - Tribe
         - Wastelander
 
+- type: loadout
+  id: N14ClothingUniformJumpsuittribalpantsm
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuittribalpantsm
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Tribe
+        - Wastelander
+
+- type: loadout
+  id: N14ClothingUniformJumpsuittribalpantsf
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuittribalpantsf
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Tribe
+        - Wastelander
+
+- type: loadout
+  id: N14ClothingUniformJumpsuittribalpantsnecklace
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuittribalpantsnecklace
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Tribe
+        - Wastelander
+
+- type: loadout
+  id: N14ClothingUniformJumpsuitdrylanderTribal
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuitdrylanderTribal
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Tribe
+        - Wastelander
+
 #jumpskirts
 - type: loadout
   id: N14LoadoutUniformJumpskirtFalloutBlack


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
What this PR does is adds the four rest of the tribal clothing to the loadout menu. I do not know why they werent there. AT the moment they appear at the top. I dont know how to fix it but I do know it works. 
<img width="867" height="640" alt="image" src="https://github.com/user-attachments/assets/8670c22e-99ba-4150-b34e-817f3e4a44fa" />

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Oli
- add: FOUR tribal clothes to the loadout menu
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

