### PR TITLE
Remove Scribe Pacifism

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
@@ -28,7 +28,6 @@
         factions:
           - BrotherhoodOfSteel
       - type: CPRTraining
-      - type: Pacified # #Misfits Add - Scribes are Pacifist by role
       - type: LanguageKnowledge # #Misfits Add: Scribes speak and understand Brotherhood binary code by default.
         speaks:
           - English

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_scribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_scribe.yml
@@ -81,7 +81,6 @@
         factions:
           - BrotherhoodOfSteel
       - type: CPRTraining
-      - type: Pacified # #Misfits Add - Scribes are Pacifist by role
       - type: LanguageKnowledge # #Misfits Add: Scribes speak and understand Brotherhood binary code by default.
         speaks:
           - English

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorscribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorscribe.yml
@@ -32,7 +32,6 @@
         factions:
           - BrotherhoodOfSteel
       - type: CPRTraining
-      - type: Pacified # #Misfits Add - Scribes are Pacifist by role
       - type: LanguageKnowledge # #Misfits Add: Scribes speak and understand Brotherhood binary code by default.
         speaks:
           - English


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Most recent PR added forced pacifism on scribes, so i removed it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> No lore basis for scribe pacifism. It fundamentally removes their lore as support personnel for paladins and knights, and also means that command roles (such as head scribes) cannot dish out reprimand. Considered unnecessary by a great portion of the community.

## Technical details
<!-- Summary of code changes for easier review. --> Removed the pacified trait from the scribe role .yml files.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: qevie
- fix: Gave scribes the ability to fight back again.
