### PR TITLE
Scribes Using Only Melee

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
@@ -28,7 +28,6 @@
         factions:
           - BrotherhoodOfSteel
       - type: CPRTraining
-      - type: Pacified # #Misfits Add - Scribes are Pacifist by role
       - type: LanguageKnowledge # #Misfits Add: Scribes speak and understand Brotherhood binary code by default.
         speaks:
           - English
@@ -36,6 +35,10 @@
         understands:
           - English
           - N14BrotherBeep
+      - type: RobotWeaponPickupBlacklist # #Misfits Add: Scribes use robot's no weapon pickup component as an alternative to pacifism.
+        blacklist:
+          components:
+          - Gun
 
 - type: startingGear
   id: BoSWestScribeGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_scribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_scribe.yml
@@ -81,7 +81,6 @@
         factions:
           - BrotherhoodOfSteel
       - type: CPRTraining
-      - type: Pacified # #Misfits Add - Scribes are Pacifist by role
       - type: LanguageKnowledge # #Misfits Add: Scribes speak and understand Brotherhood binary code by default.
         speaks:
           - English
@@ -89,6 +88,10 @@
         understands:
           - English
           - N14BrotherBeep
+      - type: RobotWeaponPickupBlacklist # #Misfits Add: Scribes use robot's no weapon pickup component as an alternative to pacifism.
+        blacklist:
+          components:
+          - Gun
 
 - type: startingGear
   id: BoSScribeGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorscribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorscribe.yml
@@ -32,7 +32,6 @@
         factions:
           - BrotherhoodOfSteel
       - type: CPRTraining
-      - type: Pacified # #Misfits Add - Scribes are Pacifist by role
       - type: LanguageKnowledge # #Misfits Add: Scribes speak and understand Brotherhood binary code by default.
         speaks:
           - English
@@ -40,6 +39,10 @@
         understands:
           - English
           - N14BrotherBeep
+      - type: RobotWeaponPickupBlacklist # #Misfits Add: Scribes use robot's no weapon pickup component as an alternative to pacifism.
+        blacklist:
+          components:
+          - Gun
 
 - type: startingGear
   id: BoSMidScribeGear

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -1128,9 +1128,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponLaserPistol
-      - id: N14PowerCellSmall
-        amount: 2
       - id: N14HandheldHealthAnalyzer # #Misfits Add - BoS medics should spawn with health analyzer
       - id: N14CleanGauze10
       - id: N14Ointment10
@@ -1154,9 +1151,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponLaserPistol
-      - id: N14PowerCellSmall
-        amount: 2
       - id: N14CleanGauze10
       - id: N14Ointment10
       - id: N14ClothingHandsGlovesCombat
@@ -1177,9 +1171,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponLaserPistol
-      - id: N14PowerCellSmall
-        amount: 2
       - id: N14CleanGauze10
       - id: N14Ointment10
       - id: N14ClothingOuterMidwestBoSCoat


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Removed scribe pacification and replaced it with an inability to pick up guns. Also removed laser pistols from their kits.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Alternative of fully removing pacifism was declined, this was offered as a compromise. Should make them less viable in combat situations whilst still allowing physical reprimand in command situations as well as basic self-defense. Removed the laser pistols from their kits to go along with this.

## Technical details
<!-- Summary of code changes for easier review. --> Removed pacified trait & replaced it with a component that disallows picking up guns.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: qevie
- tweak: Scribe pacifism reworked! Now, scribes can't pick up firearms, but can still use melee!
- tweak: AEP-7s removed from scribe kit.
