### PR TITLE
Brotherhood Beret Fix & Scribe Recon Armor Removal

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
@@ -38,7 +38,7 @@
     jumpsuit: N14ClothingUniformBosRecon  #Misfits Change /Tweak/: New consolidated BoS gear
     back: N14ClothingBackpackMilitary
     shoes: N14ClothingBootsLeatherFilled
-    head: N14ClothingHeadHatBeretknighBoS
+    head: N14ClothingPaladinBeret
     outerClothing: N14ClothingOuterPowerArmorWashT51Elite #Misfits Tweak: Head Paladin wears T-51b (was T-51BC commander)
     hands: N14ClothingHandsGlovesCombat
     pocket1: BoSBrotherhoodHeadPaladinKits

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
@@ -47,14 +47,13 @@
     # outerClothing: N14ClothingOuterBrotherhoodMidwestFieldScribeCoat # #Misfits Removed - Coat now comes from loadout kit selection
     back: N14ClothingBackpackSatchelMilitary
     shoes: N14ClothingBootsLeatherFilled
-    head: N14ClothingHeadHatBeretknighBoS
+    head: N14ClothingScribeBeret
     pocket1: BoSBrotherhoodHeadScribeKits
     id: N14HeadScribe_PipBoy
     ears: N14ClothingHeadsetBrotherhoodOfSteelScribe
     belt: ClothingBeltMilitary
   storage:
     back:
-    - NCClothingOuterBosReconArmor
     - N14BoxPlasticFilledMilitary
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_scribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_scribe.yml
@@ -106,7 +106,6 @@
     belt: ClothingBeltMilitary
   storage:
     back:
-    - NCClothingOuterBosReconArmor
     - N14BoxPlasticFilledMilitary
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorscribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorscribe.yml
@@ -57,7 +57,6 @@
     belt: ClothingBeltMilitary
   storage:
     back:
-    - NCClothingOuterBosReconArmor
     - N14BoxPlasticFilledMilitary
 
 - type: playTimeTracker


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Added the head paladins and head scribes respective berets. Removed recon armor from starting scribe gear.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Scribes are already support personnel: they shouldnt have 40% resist armor. As for the berets, its a fix for my earlier PR which failed to properly add them to their roles.

## Technical details
<!-- Summary of code changes for easier review. --> Edited brotherhood_berets.yml as well as the respective head_paladin, head_scribe, senior_scribe and scribe yml files.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: qevie
- Tweak: Actually properly gave berets to the respective roles.
- Tweak: Removed recon armor from scribes.
