### PR TITLE
Removed Rad-Away Phial Recipe

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Reactions/medicine.yml
@@ -65,17 +65,6 @@
     RadAway: 3
 
 - type: reaction
-  id: RadAwayPhialConversion
-  reactants:
-    RadAway:
-      amount: 30
-    Silicon:
-      amount: 10
-  effects:
-    - !type:CreateEntityReactionEffect
-      entity: N14RadAwayPhial
-
-- type: reaction
   id: RadAwayDiluted
   reactants:
     RadAway:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Removed the rad-away phial recipe from reactions.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Recipe was interacting and subsequently preventing promethine recipe, causing reagent waste (It also removes the chems even if the amount is insufficient - resulting in there being no product made). Phial itself is not very functional - having no ability to remove the chemical contents within it.

## Technical details
<!-- Summary of code changes for easier review. --> Adjusted medicine.yml in _nuclear14/recipes/reactions

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: qevie
- fix: Promethine recipe fixed!
