### PR TITLE
Gave Shopkeep Helper an Actual Headset

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Townsfolk/townshopkeeperhelper.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Townsfolk/townshopkeeperhelper.yml
@@ -34,6 +34,7 @@
 - type: startingGear
   id: TownShopkeeperHelperGear
   equipment:
+    ears: MisfitsClothingHeadsetWastelandScrap
     jumpsuit: N14ClothingUniformJumpsuitMerchant
     back: N14ClothingBackpackHiking
     shoes: N14ClothingShoesBlack


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
They need it to talk to people

## Technical details
added MisfitsClothingHeadsetWastelandScrap to ears on rounstart

🆑 Bradysgaming

Fix: Fixed Shopkeeper helpers not getting a headset