### PR TITLE
Mass Townie Death

### DIFF
--- a/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
@@ -649,7 +649,7 @@ undecided-loadout-category-misfits-ncra-staff-sergeant-line-description =
 undecided-loadout-category-misfits-ncra-first-sergeant-veteran-name = Sergeant First Class Veteran Kit
 undecided-loadout-category-misfits-ncra-first-sergeant-veteran-description =
     Includes an NCR trench coat, a loaded revolver belt,
-    a master sergeant pin, a battle rifle with 6 clips,
+    a master sergeant pin, a 5.56 carbine with 3 mags,
     a handheld radio, 2 smoke grenades, a stick of dynamite,
     a C ration MRE, a stimpak, a super stimpak,
     a RadAway blood bag, 2 gauze packs, and a flare.

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/ncr_rank_loadoutkits.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/ncr_rank_loadoutkits.yml
@@ -166,9 +166,9 @@
       - id: MisfitsClothingOuterNCRTrenchCoat
       - id: ClothingBeltRevolverfilled
       - id: ClothingNeckPinNCRSergeant1st # #Misfits Change - sergeant first class pin for SFC rank
-      - id: N14WeaponRifle308Battle
-      - id: ClipMagazine308Rifle
-        amount: 6
+      - id: N14WeaponRifle556Carbine
+      - id: LongMagazine556Rifle
+        amount: 3
       - id: RadioHandheld
       - id: SmokeGrenade
         amount: 2

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/UndecidedLoadout.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/UndecidedLoadout.yml
@@ -386,7 +386,7 @@
     possibleSets:
     - TownGuard_Cere_Set
     - TownGuard_Patr_Set
-    - TownGuard_Lawb_Set
+    # - TownGuard_Lawb_Set
     - TownGuard_Brea_Set
     - TownGuard_Riot_Set
 

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -484,7 +484,7 @@
       - !type:ChemVomit
         conditions:
         - !type:ReagentThreshold
-          min: 25
+          min: 26
 
 - type: reagent
   id: Bitterdrink


### PR DESCRIPTION
Townie guards lose canadian HMG kit for free. Idk why they even got a canadian HMG for free for 4 kits + their riot gear armor.
NCRA vet sarge gets 5.56 carbine buff so that he feels less homeless.
I fucked up poultice and this fixes it by increasing OD from 25 to 26.

## Technical details
yml changes

## Media

https://github.com/user-attachments/assets/06a3eb06-300f-4912-abb2-f19f0fe35fba

# Changelog

:cl: Bill Clinton
- tweak: gave veteran sarge NCR kit a 5.56 carbine
- tweak: Town guard lose HMG millions must die
- fix: poultice doesn't make you vomit every time you take it now
