### PR TITLE
Fix MissingMetadataException: Remove [NetworkedComponent] From 27 Components without AutoGenerateComponentState

### DIFF
--- a/Content.Shared/_Misfits/Augments/AugmentArmComponent.cs
+++ b/Content.Shared/_Misfits/Augments/AugmentArmComponent.cs
@@ -10,5 +10,5 @@ namespace Content.Shared._Misfits.Augments;
 /// Indicates this organ is a cybernetic arm augment.
 /// Companion to AugmentComponent; used to identify arm-slot augments in surgery.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class AugmentArmComponent : Component;

--- a/Content.Shared/_Misfits/Augments/AugmentComponent.cs
+++ b/Content.Shared/_Misfits/Augments/AugmentComponent.cs
@@ -12,14 +12,14 @@ namespace Content.Shared._Misfits.Augments;
 /// Marks an organ entity as a cybernetic augment.
 /// The body containing this organ can be found via <see cref="AugmentSystem.GetBody"/>.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class AugmentComponent : Component;
 
 /// <summary>
 /// Tracks all augments currently installed in this body.
 /// Added/removed automatically by AugmentSystem when organs are added/removed.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class InstalledAugmentsComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Misfits/Augments/AugmentStrengthComponent.cs
+++ b/Content.Shared/_Misfits/Augments/AugmentStrengthComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._Misfits.Augments;
 /// Multiplies all melee damage dealt by the body this augment is installed in
 /// while the augment is active (or always, if it has no ItemToggleComponent).
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 [Access(typeof(AugmentStrengthSystem))]
 public sealed partial class AugmentStrengthComponent : Component
 {

--- a/Content.Shared/_Misfits/Buckle/NoSelfUnbuckleComponent.cs
+++ b/Content.Shared/_Misfits/Buckle/NoSelfUnbuckleComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Misfits.Buckle;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class NoSelfUnbuckleComponent : Component
 {
     [DataField]

--- a/Content.Shared/_Misfits/Campfire/CampfireFuelComponent.cs
+++ b/Content.Shared/_Misfits/Campfire/CampfireFuelComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._Misfits.Campfire;
 /// <summary>
 /// Marks an item as valid fuel for campfires. Add it to wood planks, scrap, etc.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class CampfireFuelComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Misfits/Clothing/LegionSlaveCollarComponent.cs
+++ b/Content.Shared/_Misfits/Clothing/LegionSlaveCollarComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._Misfits.Clothing;
 /// <summary>
 /// Marks a slave collar as lock-restricted equipment with rescue-cut and crafted-key behavior.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class LegionSlaveCollarComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Misfits/Clothing/NCRPrisonerBraceletComponent.cs
+++ b/Content.Shared/_Misfits/Clothing/NCRPrisonerBraceletComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._Misfits.Clothing;
 /// with wire cutters after a 20-second DoAfter.
 /// Crafted bracelets produce a unique paired key that also unlocks them if re-applied.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class NCRPrisonerBraceletComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Misfits/DrugEffects/HealingPowderHazeComponent.cs
+++ b/Content.Shared/_Misfits/DrugEffects/HealingPowderHazeComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._Misfits.DrugEffects;
 /// <summary>
 ///     Status effect marker for a mild healing powder haze overlay.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class HealingPowderHazeComponent : Component
 {
 }

--- a/Content.Shared/_Misfits/DrugEffects/HydraTintComponent.cs
+++ b/Content.Shared/_Misfits/DrugEffects/HydraTintComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._Misfits.DrugEffects;
 /// <summary>
 ///     Status effect marker for the hydra red-screen overlay.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class HydraTintComponent : Component
 {
 }

--- a/Content.Shared/_Misfits/DrugEffects/MedXProtectionComponent.cs
+++ b/Content.Shared/_Misfits/DrugEffects/MedXProtectionComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._Misfits.DrugEffects;
 /// <summary>
 ///     Applies a temporary damage modifier set while the status effect is active.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class MedXProtectionComponent : Component
 {
     [DataField("modifier")]

--- a/Content.Shared/_Misfits/Entrenching/BarricadeComponent.cs
+++ b/Content.Shared/_Misfits/Entrenching/BarricadeComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._Misfits.Entrenching;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class BarricadeComponent : Component
 {
     // Marker — logic lives in BarricadeSystem

--- a/Content.Shared/_Misfits/Execution/GunExecutionBlacklistComponent.cs
+++ b/Content.Shared/_Misfits/Execution/GunExecutionBlacklistComponent.cs
@@ -10,5 +10,5 @@ namespace Content.Shared._Misfits.Execution;
 /// <summary>
 /// Prevents this gun from being used to perform a point-blank execution.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class GunExecutionBlacklistComponent : Component;

--- a/Content.Shared/_Misfits/FactionTerminal/Components/FactionBankTerminalComponent.cs
+++ b/Content.Shared/_Misfits/FactionTerminal/Components/FactionBankTerminalComponent.cs
@@ -25,7 +25,7 @@ public enum BankFaction : byte
 /// Attached to every faction bank terminal entity.
 /// Opening the terminal wallet UI is handled entirely by <c>FactionBankTerminalSystem</c>.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class FactionBankTerminalComponent : Component
 {
     /// <summary>Which faction owns/maintains this terminal.</summary>

--- a/Content.Shared/_Misfits/Movement/NoPullComponent.cs
+++ b/Content.Shared/_Misfits/Movement/NoPullComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._Misfits.Movement;
 /// The system subscribes to <see cref="Content.Shared.Movement.Pulling.Events.BeingPulledAttemptEvent"/>
 /// and cancels it. Intended for heavy robots such as the Sentry Bot.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class NoPullComponent : Component
 {
 }

--- a/Content.Shared/_Misfits/Robot/AssaultronBeamChargeComponent.cs
+++ b/Content.Shared/_Misfits/Robot/AssaultronBeamChargeComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared._Misfits.Robot;
 /// After the charge completes the next shot attempt succeeds. A cooldown then
 /// prevents further shots for a configured duration.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class AssaultronBeamChargeComponent : Component
 {
     /// <summary>How long the charge-up phase lasts before the weapon can fire.</summary>

--- a/Content.Shared/_Misfits/Robot/RobotGunPowerDrainComponent.cs
+++ b/Content.Shared/_Misfits/Robot/RobotGunPowerDrainComponent.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Serialization.Manager.Attributes;
 
 namespace Content.Shared._Misfits.Robot;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class RobotGunPowerDrainComponent : Component
 {
     /// <summary>Charge drained from the cell_slot battery per shot fired.</summary>

--- a/Content.Shared/_Misfits/Silicon/RobotDownedVisualsComponent.cs
+++ b/Content.Shared/_Misfits/Silicon/RobotDownedVisualsComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._Misfits.Silicon;
 /// Configures the base sprite states to use while a robot is standing versus lying down.
 /// This is client-driven off networked standing and mob state data.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class RobotDownedVisualsComponent : Component
 {
     [DataField]

--- a/Content.Shared/_Misfits/StatusIcon/ShowAggroIconsComponent.cs
+++ b/Content.Shared/_Misfits/StatusIcon/ShowAggroIconsComponent.cs
@@ -6,5 +6,5 @@ namespace Content.Shared._Misfits.StatusIcon;
 /// <summary>
 /// Allows the player to see aggro/combat-entry exclamation icons above hostile mobs.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class ShowAggroIconsComponent : Component { }

--- a/Content.Shared/_Misfits/Surgery/Anesthesia/AnesthesiaComponent.cs
+++ b/Content.Shared/_Misfits/Surgery/Anesthesia/AnesthesiaComponent.cs
@@ -7,5 +7,5 @@ namespace Content.Shared._Misfits.Surgery.Anesthesia;
 ///     Exists as a status effect. When present, surgical operations cause reduced pain and screaming.
 ///     Can be applied by anesthetic reagents or specialized operating tables.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class AnesthesiaComponent : Component;

--- a/Content.Shared/_Misfits/Surgery/Anesthesia/AnesthesiaOnBuckleComponent.cs
+++ b/Content.Shared/_Misfits/Surgery/Anesthesia/AnesthesiaOnBuckleComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._Misfits.Surgery.Anesthesia;
 ///     Exists for strap entities (operating tables) to apply surgical anesthesia to a patient upon being buckled.
 ///     Removes the anesthesia when the patient unbuckles unless they already had it.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class AnesthesiaOnBuckleComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Misfits/Surgery/Contamination/SurgeryCleansDirtComponent.cs
+++ b/Content.Shared/_Misfits/Surgery/Contamination/SurgeryCleansDirtComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._Misfits.Surgery.Contamination;
 /// <summary>
 ///     For items that can clean up surgical dirtiness.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class SurgeryCleansDirtComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Misfits/Surgery/Contamination/SurgeryContaminableComponent.cs
+++ b/Content.Shared/_Misfits/Surgery/Contamination/SurgeryContaminableComponent.cs
@@ -11,7 +11,7 @@ namespace Content.Shared._Misfits.Surgery.Contamination;
 ///     Component that indicates how an entity should respond to unsanitary surgery conditions.
 ///     It also causes surgery tools to become dirty/cross contaminated when operated on.
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(SharedSurgerySystem))]
+[RegisterComponent, Access(typeof(SharedSurgerySystem))] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class SurgeryContaminableComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Misfits/Surgery/Contamination/SurgerySelfDirtyComponent.cs
+++ b/Content.Shared/_Misfits/Surgery/Contamination/SurgerySelfDirtyComponent.cs
@@ -7,5 +7,5 @@ namespace Content.Shared._Misfits.Surgery.Contamination;
 ///     Marker component that indicates the entity should become dirtied instead of its tools during surgery.
 ///     Used for patients with cybernetic or synthetic parts that self-contaminate.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class SurgerySelfDirtyComponent : Component;

--- a/Content.Shared/_Misfits/Surgery/Contamination/SurgeryStepDirtinessComponent.cs
+++ b/Content.Shared/_Misfits/Surgery/Contamination/SurgeryStepDirtinessComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._Misfits.Surgery.Contamination;
 /// <summary>
 ///     Component that allows a surgery step to increase tools and gloves' dirtiness.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class SurgeryStepDirtinessComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Misfits/Throwing/Components/SpearBlockComponent.cs
+++ b/Content.Shared/_Misfits/Throwing/Components/SpearBlockComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._Misfits.Throwing.Components;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class SpearBlockComponent : Component
 {
 }

--- a/Content.Shared/_Misfits/Throwing/Components/SpearBlockUserComponent.cs
+++ b/Content.Shared/_Misfits/Throwing/Components/SpearBlockUserComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._Misfits.Throwing.Components;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class SpearBlockUserComponent : Component
 {
 }

--- a/Content.Shared/_Misfits/Throwing/Components/ThrowSpeedModifierComponent.cs
+++ b/Content.Shared/_Misfits/Throwing/Components/ThrowSpeedModifierComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._Misfits.Throwing.Components;
 /// <summary>
 /// Scales throw speed for a held item when it is thrown normally.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent] // #Misfits Fix - Removed NetworkedComponent: no AutoGenerateComponentState → MissingMetadataException
 public sealed partial class ThrowSpeedModifierComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
:cl: cythisiax

fix: Server state is missing the metadata component for a new entity, spamming client console every tick on live server, and crashing.