### PR TITLE
California Dreaming.

### DIFF
--- a/Resources/Locale/en-US/_Misfits/job-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/job-names.ftl
@@ -1,6 +1,6 @@
 # #Misfits Add - NCR Heavy Trooper job locale.
 job-name-ncr-heavy-trooper = NCR Heavy Trooper
-job-description-ncr-heavy-trooper = You are the NCR's walking artillery. Strapped into a salvaged T-45 suit and armed with an Avenger minigun, your job is simple: hold the line and lay down fire until there is nothing left standing.
+job-description-ncr-heavy-trooper = You are the NCR's walking artillery. Strapped into a salvaged T-45 suit and armed with an LMG, your job is simple: hold the line and lay down fire until there is nothing left standing.
 
 # #Misfits Add - Enclave job locale (expanded 8-role hierarchy). Reformer is admin-only apex role.
 job-name-enclave-reformer = The Reformer

--- a/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
@@ -111,15 +111,15 @@ undecided-loadout-category-med-combat-description =
 
 undecided-loadout-category-ws-gunner-name = Specialist Gunner Kit
 undecided-loadout-category-ws-gunner-description =
-    Includes 1 NCR belt, 1 metal helmet, 1 NCR cloak, 1 LMG,
-    3 LMG magazines, 1 9mm pistol, 2 9mm pistol magazines,
+    Includes 1 NCR belt, 1 metal helmet, 1 NCR cloak, 1 Automatic rifle,
+    2 .308 magazines, 1 9mm pistol, 2 9mm pistol magazines,
     1 C ration MRE, 1 stimpak, 1 RadAway blood bag, 1 gauze pack, and 1 flare.
 
 undecided-loadout-category-ws-grenadier-name = Specialist Grenadier Kit
 # #Misfits Fix - Updated description: grenade rifle + 40mm rounds added to replace the orphaned frag grenades
 undecided-loadout-category-ws-grenadier-description =
-    Includes 1 NCR belt, 1 metal helmet, 1 NCR cloak, 1 grenade rifle, 4 40mm frag grenades,
-    1 smoke grenade, 1 .45 pistol, 2 .45 pistol magazines, 1 C ration MRE,
+    Includes 1 NCR belt, 1 metal helmet, 1 NCR cloak, 1 grenade rifle, 5 40mm frag grenades,
+    1 smoke grenade, 1 12.7 SMG, 2 12.7 SMG magazines, 1 C ration MRE,
     1 stimpak, 1 RadAway blood bag, 1 gauze pack, and 1 flare.
 
 undecided-loadout-category-ws-sniper-name = Specialist Sniper Kit

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
@@ -36,7 +36,6 @@
         factions:
           - Wastelander
           - NCR
-      - type: PowerArmorProficiency # Bill clinton misfits change: For sierra armor use within NCR.
 
 - type: startingGear
   id: NCRCaptainGear
@@ -51,7 +50,7 @@
     eyes: ClothingEyesGlassesSunglasses
     ears: N14ClothingHeadsetNCR
     pocket1: NCRcaptainloadoutkits
-    pocket2: RadioHandheld
+    pocket2: TrainingManualPowerArmorOperation
     id: N14IDNCRDogtagCaptain
   innerClothingSkirt: N14ClothingOfficerUniformNCRDesert # Corvax-Change
   satchel: N14ClothingBackpackSatchelNCRFilled

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
@@ -36,6 +36,7 @@
         factions:
           - Wastelander
           - NCR
+      - type: PowerArmorProficiency # Bill clinton misfits change: For sierra armor use within NCR.
 
 - type: startingGear
   id: NCRCaptainGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_heavy_trooper.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_heavy_trooper.yml
@@ -47,14 +47,14 @@
     ears: N14ClothingHeadsetNCR               # NCR radio earpiece
     neck: ClothingNeckPinNCRSpecialist        # enlisted heavy weapons rank
     belt: ClothingBeltNCR
-    pocket1: N14WeaponMinigun                  # #Misfits Tweak - downgraded to standard minigun (Avenger was too strong for this tier)
+    pocket1: N14WeaponLMG                  # #Misfits Tweak - Upgraded to LMG -bill
     pocket2: RadioHandheld
     id: N14IDNCRDogtagWS                      # Specialist-tier dogtag
   innerClothingSkirt: N14ClothingOfficerUniformNCRDesert
   satchel: N14ClothingBackpackSatchelNCRFilled
   storage:
     back:
-    - N14MagazineMinigun5mm                   # extra 5mm belt box
+    - LMGMagazine556Rifle                   # extra 5.56 box -bill 
 
 - type: playTimeTracker
   id: NCRHeavyTrooper

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -453,9 +453,9 @@
       - id: ClothingBeltNCR
       - id: N14ClothingHeadHatNCRHelmetMetalDesert # Forge-Change
       - id: N14ClothingNeckCloakNCR # Forge-Change
-      - id: N14WeaponLMG
-      - id: LMGMagazine556Rifle
-        amount: 3
+      - id: N14WeaponLMGAutoRifle
+      - id: Magazine308Rifle
+        amount: 2
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
         amount: 2
@@ -486,10 +486,10 @@
       # #Misfits Fix - Added grenade rifle + 40mm rounds so the Grenadier kit actually has a primary weapon
       - id: N14WeaponRifleGrenade
       - id: 40mmGrenadeFrag
-        amount: 4
+        amount: 5
       - id: SmokeGrenade
-      - id: N14WeaponPistol45Colt
-      - id: N14MagazinePistol45
+      - id: N14WeaponSMG12mm
+      - id: N14MagazineSMG12mm
         amount: 2
       - id: N14BoxCardboardMREBoxCFilled
       - id: N14Stimpak


### PR DESCRIPTION
## About the PR
Legion got love, now its NCR's turn
One extra grenade for specialist gren and a 12.7 SMG instead of his .45 colt.
HT gets a 5.56 LMG instead of the 5mm minigun, which was struggling heavy against bigguns from legion and hoodies.
Specialist gunner kit upgraded from the 5.56 LMG to the automatic rifle. Only gave them 2 spare mags.
NCR captain is given power armor training manual so that someone in NCR can actually use sierra PA.
Yes the FTL was changed to reflect such changes.

## Why / Balance
Legion is stomping too hard and while I personally as a yml chud believe it is an NCR skill issue, I am still beholden to data. Enjoy your moderate buffs to specialist infantry little bears.

## Technical details
Yml and ftl shits. braindead simple. any issues is usually human error and fixable in 10 minutes.

## Media
https://github.com/user-attachments/assets/30a14ab8-6521-438e-91c4-27ddb8b06016

# Changelog

:cl: Bill Clinton
- tweak: Heavy Troopers given roundstart LMG instead of minigun. this makes them more capable against PA and heavier troops.
- tweak: NCR specialist kits have been modified, in a good way. extra GL shot/12.7 SMG for grenadier and BAR for the gunner. 
- tweak: NCRA captain now has power armor training manual for use with sierra or any captured power armor. He can give it off to someone else or use it himself. 