### PR TITLE
Fix Explosives

### DIFF
--- a/Resources/Prototypes/_Misfits/explosion.yml
+++ b/Resources/Prototypes/_Misfits/explosion.yml
@@ -8,8 +8,8 @@
       Blunt: 5
       Piercing: 5
       Structural: 60
-  tileBreakChance: [0, 0.5, 1]
-  tileBreakIntensity: [0, 10, 30]
+  tileBreakChance: [0]
+  tileBreakIntensity: [0]
   tileBreakRerollReduction: 20
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi

--- a/Resources/Prototypes/_Nuclear14/Tiles/floors.yml
+++ b/Resources/Prototypes/_Nuclear14/Tiles/floors.yml
@@ -1752,7 +1752,7 @@
   blendGroup: terrain
   blendPriority: 0
   blendMaskSet: soft-terrain
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -1922,7 +1922,7 @@
   sprite: /Textures/_Nuclear14/Tiles/swampland.png
   variants: 11
   placementVariants: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepWater
@@ -1936,7 +1936,7 @@
   id: FloorSwamplandBottom
   name: tiles-wasteland-swamp-bottom
   sprite: /Textures/_Nuclear14/Tiles/wasteswampbottom.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -1950,7 +1950,7 @@
   id: FloorSwamplandTop
   name: tiles-wasteland-swamp-top
   sprite: /Textures/_Nuclear14/Tiles/wasteswamptop.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -1964,7 +1964,7 @@
   id: FloorSwamplandRight
   name: tiles-wasteland-swamp-right
   sprite: /Textures/_Nuclear14/Tiles/wasteswampright.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -1978,7 +1978,7 @@
   id: FloorSwamplandLeft
   name: tiles-wasteland-swamp-left
   sprite: /Textures/_Nuclear14/Tiles/wasteswampleft.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -1992,7 +1992,7 @@
   id: FloorSwamplandTopRight
   name: tiles-wasteland-swamp-top-right
   sprite: /Textures/_Nuclear14/Tiles/wasteswamptopright.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -2006,7 +2006,7 @@
   id: FloorSwamplandTopLeft
   name: tiles-wasteland-swamp-top-left
   sprite: /Textures/_Nuclear14/Tiles/wasteswamptopleft.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -2020,7 +2020,7 @@
   id: FloorSwamplandTopRightCorner
   name: tiles-wasteland-swamp-top-right-corner
   sprite: /Textures/_Nuclear14/Tiles/wasteswamptoprightcorner.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -2034,7 +2034,7 @@
   id: FloorSwamplandTopLeftCorner
   name: tiles-wasteland-swamp-top-left-corner
   sprite: /Textures/_Nuclear14/Tiles/wasteswamptopleftcorner.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -2048,7 +2048,7 @@
   id: FloorSwamplandBottomRight
   name: tiles-wasteland-swamp-bottom-right
   sprite: /Textures/_Nuclear14/Tiles/wasteswampbottomright.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -2062,7 +2062,7 @@
   id: FloorSwamplandBottomLeft
   name: tiles-wasteland-swamp-bottom-left
   sprite: /Textures/_Nuclear14/Tiles/wasteswampbottomleft.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -2076,7 +2076,7 @@
   id: FloorSwamplandBottomRightCorner
   name: tiles-wasteland-swamp-bottom-right-corner
   sprite: /Textures/_Nuclear14/Tiles/wasteswampbottomrightcorner.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt
@@ -2090,7 +2090,7 @@
   id: FloorSwamplandBottomLeftCorner
   name: tiles-wasteland-swamp-bottom-left-corner
   sprite: /Textures/_Nuclear14/Tiles/wasteswampbottomleftcorner.png
-  baseTurf: space
+  baseTurf: Space
   isSubfloor: true
   footstepSounds:
     collection: N14FootstepDirt

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -7,8 +7,8 @@
       Heat: 5
       Blunt: 5
       Piercing: 5
-  tileBreakChance: [0, 0.5, 1]
-  tileBreakIntensity: [0, 10, 30]
+  tileBreakChance: [0]
+  tileBreakIntensity: [0]
   tileBreakRerollReduction: 20
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
@@ -22,8 +22,8 @@
       Blunt: 3
       Piercing: 3
       Structural: 50
-  tileBreakChance: [ 0, 0.5, 1 ]
-  tileBreakIntensity: [ 0, 10, 30 ]
+  tileBreakChance: [0]
+  tileBreakIntensity: [0]
   tileBreakRerollReduction: 20
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
@@ -37,8 +37,8 @@
       Blunt: 6
       Piercing: 6
       Structural: 20
-  tileBreakChance: [ 0, 0.5, 1 ]
-  tileBreakIntensity: [ 1, 10, 15 ]
+  tileBreakChance: [0]
+  tileBreakIntensity: [0]
   tileBreakRerollReduction: 30
   intensityPerState: 20
   lightColor: Orange
@@ -79,8 +79,8 @@
       Heat: 4
       Blunt: 7
       Piercing: 4
-  tileBreakChance: [0, 0.5, 1]
-  tileBreakIntensity: [0, 10, 30]
+  tileBreakChance: [0]
+  tileBreakIntensity: [0]
   tileBreakRerollReduction: 20
   lightColor: Orange
   texturePath: /Textures/Effects/fire.rsi
@@ -94,8 +94,8 @@
       Blunt: 12
       Piercing: 12
       Structural: 30
-  tileBreakChance: [ 0, 0.5, 1 ]
-  tileBreakIntensity: [ 1, 5, 10 ]
+  tileBreakChance: [0]
+  tileBreakIntensity: [0]
   tileBreakRerollReduction: 3
   intensityPerState: 20
   lightColor: Orange
@@ -110,8 +110,8 @@
       Blunt: 15
       Piercing: 6
       Structural: 40
-  tileBreakChance: [ 0, 0.5, 1 ]
-  tileBreakIntensity: [ 0, 10, 30 ]
+  tileBreakChance: [0]
+  tileBreakIntensity: [0]
   tileBreakRerollReduction: 10
   intensityPerState: 20
   lightColor: Orange
@@ -126,8 +126,8 @@
       Heat: 4
       Blunt: 3
       Piercing: 3
-  tileBreakChance: [0, 0.5, 1]
-  tileBreakIntensity: [0, 10, 30]
+  tileBreakChance: [0]
+  tileBreakIntensity: [0]
   tileBreakRerollReduction: 20
   lightColor: Yellow
   fireColor: Green


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Fixed explosives to properly damage entities and have a visible AOE
Previously, they would explode in a 1x1 (or not at all) area and have no general damage. Dynamite also did not properly detonate after its timer was finished. This fixes that by properly establishing the floor tiles as having space subtiles.

## Technical details
YML slop; removed chances for tile destruction

## Media
<img width="599" height="686" alt="image" src="https://github.com/user-attachments/assets/982c2212-e4d9-4cd3-b9bb-757b81861ff9" />
<img width="576" height="553" alt="image" src="https://github.com/user-attachments/assets/ddb745a1-8512-4207-95ea-e4abbb1aaf9c" />


# Changelog
:cl: Fox
- fix: Fixed a capitalization error in the tiles to let explosives have effect
- fix: Removed tile break chance to not leave a void after an explosive detonates