### PR TITLE
Vault Clothing Reworked

### DIFF
--- a/Resources/Locale/en-US/_Misfits/loadout-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/loadout-names.ftl
@@ -67,6 +67,9 @@ loadout-name-N14LoadoutUniformJumpskirtDressLongSleeve = long sleeve dress
 loadout-name-N14LoadoutUniformJumpskirtDressFormalRed = formal red dress
 
 # Outer clothing
+loadout-name-ClothingOuterCoatGentle = gentle coat
+loadout-name-ClothingOuterCoatDetective = detective coat
+loadout-name-N14ClothingOuterJacketBomber = bomber jacket 
 loadout-name-N14LoadoutOuterCoatLeatherDuster = leather duster
 loadout-name-N14LoadoutOuterCoatBattlecoat = battlecoat
 loadout-name-N14LoadoutOuterCoatBattlecoatTan = battlecoat (tan)
@@ -111,6 +114,10 @@ loadout-name-N14LoadoutShoesRags = rag shoes
 loadout-name-N14ClothingBootsCombat = combat boots
 
 # Head
+loadout-name-ClothingHeadHatFedoraChoc = brown fedora
+loadout-name-ClothingHeadHatFedoraBlack = black fedora  
+loadout-name-ClothingHeadHatFlatBrown = brown flat cap     
+loadout-name-ClothingHeadHatFlatBlack = black flat cap
 loadout-name-N14LoadoutHeadHatTrucker = trucker hat
 loadout-name-N14LoadoutHeadHatArmyCap = army cap
 loadout-name-N14LoadoutHeadHatBeanie = beanie

--- a/Resources/Locale/en-US/_Misfits/loadout-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/loadout-names.ftl
@@ -23,6 +23,13 @@ loadout-name-N14ClothingBackpackSatchelMilitary = military satchel
 loadout-name-N14ClothingBackpackSatchelTrekker = trekker satchel
 
 # Uniforms
+loadout-name-N14LoadoutUniformJumpsuitPreWarLumberjackVault = pre-war lumberjack outfit
+loadout-name-N14LoadoutUniformJumpsuitBlueSuitVault = blue suit
+loadout-name-N14LoadoutUniformJumpsuitPreWarManagerVault = pre-war manager outfit
+loadout-name-N14LoadoutUniformJumpsuitPreWarCasualVault = pre-war casual outfit
+loadout-name-N14LoadoutUniformJumpsuitPreWarRelaxedVault = pre-war relaxed outfit
+loadout-name-N14LoadoutUniformJumpsuitCheckeredVault = checkered suit
+loadout-name-N14LoadoutUniformJumpsuitDetectiveAltVault = detective suit
 loadout-name-N14LoadoutUniformJumpsuitVault14 = Vault 14 jumpsuit
 loadout-name-N14LoadoutUniformJumpskirtVault14 = Vault 14 jumpskirt
 loadout-name-N14LoadoutUniformJumpsuitSettlerRags = settler rags
@@ -67,9 +74,12 @@ loadout-name-N14LoadoutUniformJumpskirtDressLongSleeve = long sleeve dress
 loadout-name-N14LoadoutUniformJumpskirtDressFormalRed = formal red dress
 
 # Outer clothing
-loadout-name-ClothingOuterCoatGentle = gentle coat
-loadout-name-ClothingOuterCoatDetective = detective coat
-loadout-name-N14ClothingOuterJacketBomber = bomber jacket 
+loadout-name-ClothingOuterDenimJacketVault = denim jacket
+loadout-name-N14LoadoutOuterCoatLeatherJacket = leather jacket
+loadout-name-N14LoadoutOuterCoatLeatherJacketVault = leather jacket
+loadout-name-ClothingOuterCoatGentleVault = gentle coat
+loadout-name-ClothingOuterCoatDetectiveVault = detective coat
+loadout-name-N14ClothingOuterJacketBomberVault = bomber jacket 
 loadout-name-N14LoadoutOuterCoatLeatherDuster = leather duster
 loadout-name-N14LoadoutOuterCoatBattlecoat = battlecoat
 loadout-name-N14LoadoutOuterCoatBattlecoatTan = battlecoat (tan)
@@ -149,6 +159,7 @@ loadout-name-N14ClothingEyesSunGlasses = sunglasses
 loadout-name-N14ClothingDrylanderGoggles = drylander goggles
 
 # Hands
+loadout-name-N14LoadoutHandsGlovesDriver = driver gloves
 loadout-name-N14LoadoutHandsGlovesCloth = cloth gloves
 loadout-name-N14LoadoutHandsGlovesLeather = leather gloves
 loadout-name-N14LoadoutHandsGlovesBlackLeather = black leather gloves

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -1,7 +1,6 @@
 - type: vendingMachineInventory
   id: DetDrobeInventory
   startingInventory:
-    ClothingUniformJumpsuitDetective: 2
     ClothingUniformJumpskirtDetective: 2
     ClothingShoesColorBrown: 2
     ClothingOuterCoatDetectiveLoadout: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -1,15 +1,1 @@
-- type: vendingMachineInventory
-  id: DetDrobeInventory
-  startingInventory:
-    ClothingUniformJumpskirtDetective: 2
-    ClothingShoesColorBrown: 2
-    ClothingOuterCoatDetectiveLoadout: 2
-    ClothingHeadHatFedoraBrown: 2
-    ClothingUniformJumpsuitDetectiveGrey: 2
-    ClothingUniformJumpskirtDetectiveGrey: 2
-    ClothingOuterVestDetective: 2
-    ClothingNeckTieDet: 2
-    ClothingHeadHatFedoraGrey: 2
-    ClothingHandsGlovesColorBlack: 2
-    ClothingHandsGlovesLatex: 2
-    ClothingHeadsetSecurity: 2
+# It's been causing some issues with my PR, so I just removed it for now.

--- a/Resources/Prototypes/Corvax/Loadouts/satchel.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/satchel.yml
@@ -6,10 +6,13 @@
   customName: false
   customDescription: false
   requirements:
-    - !type:CharacterDepartmentRequirement
+    - !type:CharacterJobRequirement
       inverted: true
-      departments:
-      - Vault
+      jobs:
+      - VaultDoctor
+      - Overseer
+      - VaultDweller
+      - VaultSecurity
     - !type:CharacterItemGroupRequirement
       group: N14LodaoutBags
   items:
@@ -25,10 +28,13 @@
   customName: false
   customDescription: false
   requirements:
-    - !type:CharacterDepartmentRequirement
+    - !type:CharacterJobRequirement
       inverted: true
-      departments:
-      - Vault
+      jobs:
+      - VaultDoctor
+      - Overseer
+      - VaultDweller
+      - VaultSecurity
     - !type:CharacterItemGroupRequirement
       group: N14LodaoutBags
   items:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -1,8 +1,8 @@
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterBase
   id: ClothingOuterCoatBomber
   name: bomber jacket
-  description: A thick, well-worn WW2 leather bomber jacket.
+  description: A thick, well-worn pre-war leather bomber jacket.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Coats/bomber.rsi
@@ -10,38 +10,18 @@
     sprite: Clothing/OuterClothing/Coats/bomber.rsi
 
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing]
+  parent: N14ClothingOuterBase
   id: ClothingOuterCoatDetective
   name: detective trenchcoat
-  description: A rugged canvas trenchcoat, designed and created by TX Fabrication Corp. Wearing it makes you feel for the plight of the Tibetans.
+  description: A rugged canvas trenchcoat, perfect for solving any Vault related mysteries. 
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Coats/detective.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/detective.rsi
-  - type: StorageFill
-    contents:
-    - id: SmokingPipeFilledTobacco
-    - id: FlippoEngravedLighter
-  - type: Armor #same as regular sec armor
-    modifiers:
-      coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.80
 
 - type: entity
-  parent: ClothingOuterCoatDetective
-  id: ClothingOuterCoatDetectiveLoadout
-  components:
-  - type: StorageFill
-    contents:
-    - id: SmokingPipeFilledTobacco
-    - id: FlippoLighter #Not the steal objective, only difference from normal detective trenchcoat
-
-- type: entity
-  parent: ClothingOuterStorageBase
+  parent: N14ClothingOuterBase
   id: ClothingOuterCoatGentle
   name: gentle coat
   description: A gentle coat for a gentle man, or woman.

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/handsGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/handsGroup.yml
@@ -9,3 +9,5 @@
       id: N14LoadoutHandsGlovesFur
     - type: loadout
       id: N14LoadoutHandsGlovesBlackLeather
+    - type: loadout
+      id: N14ClothingHandsGlovesDriver

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/handsGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/handsGroup.yml
@@ -10,4 +10,4 @@
     - type: loadout
       id: N14LoadoutHandsGlovesBlackLeather
     - type: loadout
-      id: N14ClothingHandsGlovesDriver
+      id: N14LoadoutHandsGlovesDriver

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/headGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/headGroup.yml
@@ -51,3 +51,11 @@
       id: LoadoutClothingHeadHatBoSInquisitorBattleHelmet 
     - type: loadout # Forge-Add
       id: LoadoutClothingHeadHatBoSInquisitorBattleHelmetHood
+    - type: loadout # Forge-Add
+      id: ClothingHeadHatFlatBlack
+    - type: loadout # Forge-Add
+      id: ClothingHeadHatFlatBrown
+    - type: loadout # Forge-Add
+      id: ClothingHeadHatFedoraBlack 
+    - type: loadout # Forge-Add
+      id: ClothingHeadHatFedoraChoc

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/outerwearGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/outerwearGroup.yml
@@ -67,3 +67,10 @@
       id: N14ClothingOutershaman
     - type: loadout
       id: N14ClothingOuterdrylandersimple
+    - type: loadout
+      id: N14ClothingOuterJacketBomber
+    - type: loadout
+      id: ClothingOuterCoatDetective
+    - type: loadout
+      id: ClothingOuterCoatGentle
+      

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/outerwearGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/outerwearGroup.yml
@@ -68,9 +68,15 @@
     - type: loadout
       id: N14ClothingOuterdrylandersimple
     - type: loadout
-      id: N14ClothingOuterJacketBomber
+      id: N14LoadoutOuterCoatLeatherJacketVault
     - type: loadout
-      id: ClothingOuterCoatDetective
+      id: ClothingOuterCoatDetectiveVault
     - type: loadout
-      id: ClothingOuterCoatGentle
+      id: ClothingOuterCoatGentleVault
+    - type: loadout
+      id: N14ClothingOuterJacketBomberVault
+    - type: loadout
+      id: N14LoadoutOuterCoatLeatherJacket
+    - type: loadout
+      id: ClothingOuterDenimJacketVault
       

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/uniformGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/uniformGroup.yml
@@ -79,3 +79,13 @@
       id: N14ClothingUniformJumpsuittribalpantsf
     - type: loadout
       id: N14ClothingUniformJumpsuittribalpantsnecklace
+    - type: loadout
+      id: ClothingOuterDenimJacket
+    - type: loadout
+      id: ClothingOuterCoatDetective
+    - type: loadout
+      id: ClothingOuterCoatGentle
+    - type: loadout
+      id: N14ClothingOuterJacketBomber
+    - type: loadout
+      id: N14LoadoutOuterCoatLeatherJacket

--- a/Resources/Prototypes/_Nuclear14/CharacterItemGroups/uniformGroup.yml
+++ b/Resources/Prototypes/_Nuclear14/CharacterItemGroups/uniformGroup.yml
@@ -80,12 +80,18 @@
     - type: loadout
       id: N14ClothingUniformJumpsuittribalpantsnecklace
     - type: loadout
-      id: ClothingOuterDenimJacket
+      id: N14LoadoutUniformJumpsuitDetectiveAltVault
     - type: loadout
-      id: ClothingOuterCoatDetective
+      id: N14LoadoutUniformJumpsuitCheckeredVault
     - type: loadout
-      id: ClothingOuterCoatGentle
+      id: N14LoadoutUniformJumpsuitPreWarRelaxedVault
     - type: loadout
-      id: N14ClothingOuterJacketBomber
+      id: N14LoadoutUniformJumpsuitPreWarCasualVault
     - type: loadout
-      id: N14LoadoutOuterCoatLeatherJacket
+      id: N14LoadoutUniformJumpsuitPreWarManagerVault
+    - type: loadout
+      id: N14LoadoutUniformJumpsuitBlueSuitVault 
+    - type: loadout
+      id: N14LoadoutUniformJumpsuitPreWarLumberjackVault
+    - type: loadout
+      id: N14LoadoutUniformJumpsuitAsylumDress

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/hands.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/hands.yml
@@ -1,0 +1,15 @@
+- type: loadout
+  id: N14LoadoutHandsGlovesDriver
+  category: Hands
+  cost: 3
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Vault 
+      min: 1500  # 25 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHands
+    - !type:CharacterJobRequirement # Forge-Change
+       jobs:
+        - VaultDweller
+  items:
+    - N14ClothingHandsGlovesDriver

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/head.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/head.yml
@@ -9,7 +9,7 @@
     - !type:CharacterJobRequirement
       jobs:
       - VaultDweller
-      - VaultOverseer
+      - Overseer
   items:
     - ClothingHeadHatFlatBlack
 
@@ -24,7 +24,7 @@
     - !type:CharacterJobRequirement
       jobs:
       - VaultDweller
-      - VaultOverseer
+      - Overseer
   items:
     - ClothingHeadHatFlatBrown
 
@@ -39,7 +39,7 @@
     - !type:CharacterJobRequirement
       jobs:
       - VaultDweller
-      - VaultOverseer
+      - Overseer
   items:
     - ClothingHeadHatFedoraBlack
 
@@ -54,6 +54,6 @@
     - !type:CharacterJobRequirement
       jobs:
       - VaultDweller
-      - VaultOverseer
+      - Overseer
   items:
     - ClothingHeadHatFedoraChoc

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/head.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/head.yml
@@ -1,5 +1,5 @@
 - type: loadout
-  id: LoadoutHeadFlatBlack
+  id: ClothingHeadHatFlatBlack
   category: Head
   cost: 2
   exclusive: true
@@ -14,7 +14,7 @@
     - ClothingHeadHatFlatBlack
 
 - type: loadout
-  id: LoadoutHeadFlatBrown
+  id: ClothingHeadHatFlatBrown
   category: Head
   cost: 2
   exclusive: true
@@ -29,7 +29,7 @@
     - ClothingHeadHatFlatBrown
 
 - type: loadout
-  id: LoadoutHeadHatFedoraBlack
+  id: ClothingHeadHatFedoraBlack
   category: Head
   cost: 2
   exclusive: true
@@ -44,7 +44,7 @@
     - ClothingHeadHatFedoraBlack
 
 - type: loadout
-  id: LoadoutHeadHatFedoraChoc
+  id: ClothingHeadHatFedoraChoc
   category: Head
   cost: 2
   exclusive: true

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/head.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/head.yml
@@ -1,0 +1,59 @@
+- type: loadout
+  id: LoadoutHeadFlatBlack
+  category: Head
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
+    - !type:CharacterJobRequirement
+      jobs:
+      - VaultDweller
+      - VaultOverseer
+  items:
+    - ClothingHeadHatFlatBlack
+
+- type: loadout
+  id: LoadoutHeadFlatBrown
+  category: Head
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
+    - !type:CharacterJobRequirement
+      jobs:
+      - VaultDweller
+      - VaultOverseer
+  items:
+    - ClothingHeadHatFlatBrown
+
+- type: loadout
+  id: LoadoutHeadHatFedoraBlack
+  category: Head
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
+    - !type:CharacterJobRequirement
+      jobs:
+      - VaultDweller
+      - VaultOverseer
+  items:
+    - ClothingHeadHatFedoraBlack
+
+- type: loadout
+  id: LoadoutHeadHatFedoraChoc
+  category: Head
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
+    - !type:CharacterJobRequirement
+      jobs:
+      - VaultDweller
+      - VaultOverseer
+  items:
+    - ClothingHeadHatFedoraChoc

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/items.yml
@@ -1,0 +1,1 @@
+# Planning to add items soon in the future, but for now this just exists here.

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/outerClothing.yml
@@ -1,5 +1,5 @@
 - type: loadout # I'd like to see a biker gang or something in the Vault, so this is for that.
-  id: N14LoadoutOuterCoatLeatherJacket
+  id: N14ClothingOuterCoatLeatherJacket
   category: Outer
   cost: 2
   requirements:

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/outerClothing.yml
@@ -15,7 +15,7 @@
     - N14ClothingOuterCoatLeatherJacket
 
 - type: loadout 
-  id: N14LoadoutOuterJacketBomber
+  id: N14ClothingOuterJacketBomber
   category: Outer
   cost: 2
   requirements:
@@ -31,7 +31,7 @@
     - N14ClothingOuterJacketBomber
 
 - type: loadout 
-  id: LoadoutOuterCoatDetective
+  id: ClothingOuterCoatDetective
   category: Outer
   cost: 2
   requirements:
@@ -47,7 +47,7 @@
     - ClothingOuterCoatDetective
 
 - type: loadout 
-  id: LoadoutOuterCoatGentle
+  id: ClothingOuterCoatGentle
   category: Outer
   cost: 2
   requirements:
@@ -63,7 +63,7 @@
     - ClothingOuterCoatGentle
 
 - type: loadout 
-  id: LoadoutOuterDenimJacket
+  id: ClothingOuterDenimJacket
   category: Outer
   cost: 2
   requirements:

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/outerClothing.yml
@@ -1,0 +1,79 @@
+- type: loadout # I'd like to see a biker gang or something in the Vault, so this is for that.
+  id: N14LoadoutOuterCoatLeatherJacket
+  category: Outer
+  cost: 2
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Vault
+      min: 1200 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterJobRequirement
+       jobs:
+       - VaultDweller
+  items:
+    - N14ClothingOuterCoatLeatherJacket
+
+- type: loadout 
+  id: N14LoadoutOuterJacketBomber
+  category: Outer
+  cost: 2
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Vault
+      min: 900 # 15 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterJobRequirement
+       jobs:
+       - VaultDweller
+  items:
+    - N14ClothingOuterJacketBomber
+
+- type: loadout 
+  id: LoadoutOuterCoatDetective
+  category: Outer
+  cost: 2
+  requirements:
+    - !type:CharacterPlaytimeRequirement
+      tracker: VaultSecurity
+      min: 1200 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterJobRequirement
+       jobs:
+       - VaultSecurity
+  items:
+    - ClothingOuterCoatDetective
+
+- type: loadout 
+  id: LoadoutOuterCoatGentle
+  category: Outer
+  cost: 2
+  requirements:
+    - !type:CharacterPlaytimeRequirement
+      tracker: Overseer
+      min: 1200 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterJobRequirement
+       jobs:
+       - Overseer
+  items:
+    - ClothingOuterCoatGentle
+
+- type: loadout 
+  id: LoadoutOuterDenimJacket
+  category: Outer
+  cost: 2
+  requirements:
+    - !type:CharacterPlaytimeRequirement
+      tracker: VaultDweller
+      min: 1200 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutOuter
+    - !type:CharacterJobRequirement
+       jobs:
+       - VaultDweller
+  items:
+   - ClothingOuterDenimJacket

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/outerClothing.yml
@@ -1,5 +1,5 @@
 - type: loadout # I'd like to see a biker gang or something in the Vault, so this is for that.
-  id: N14ClothingOuterCoatLeatherJacket
+  id: N14LoadoutOuterCoatLeatherJacketVault
   category: Outer
   cost: 2
   requirements:
@@ -15,7 +15,7 @@
     - N14ClothingOuterCoatLeatherJacket
 
 - type: loadout 
-  id: N14ClothingOuterJacketBomber
+  id: N14ClothingOuterJacketBomberVault
   category: Outer
   cost: 2
   requirements:
@@ -31,7 +31,7 @@
     - N14ClothingOuterJacketBomber
 
 - type: loadout 
-  id: ClothingOuterCoatDetective
+  id: ClothingOuterCoatDetectiveVault
   category: Outer
   cost: 2
   requirements:
@@ -47,7 +47,7 @@
     - ClothingOuterCoatDetective
 
 - type: loadout 
-  id: ClothingOuterCoatGentle
+  id: ClothingOuterCoatGentleVault
   category: Outer
   cost: 2
   requirements:
@@ -63,7 +63,7 @@
     - ClothingOuterCoatGentle
 
 - type: loadout 
-  id: ClothingOuterDenimJacket
+  id: ClothingOuterDenimJacketVault
   category: Outer
   cost: 2
   requirements:

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/uniform.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/uniform.yml
@@ -1,0 +1,117 @@
+- type: loadout # This is for Vault Security players that want to act like an detective of sort.
+  id: N14LoadoutUniformJumpsuitDetectiveAlt
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuitDetectiveAlt
+  requirements:
+    - !type:CharacterPlaytimeRequirement
+      tracker: VaultSecurity
+      min: 1200 # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterJobRequirement
+      jobs:
+      - VaultSecurity
+  
+- type: loadout
+  id: N14LoadoutUniformJumpsuitCheckered
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuitCheckered
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Vault
+      min: 1200  # 20 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterJobRequirement
+      jobs:
+        - VaultDweller
+ 
+- type: loadout
+  id: N14LoadoutUniformJumpsuitPreWarRelaxed
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuitPreWarRelaxed
+  requirements:
+   - !type:CharacterPlaytimeRequirement
+      tracker: VaultDweller
+      min: 1500  # 25 hours
+   - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+   - !type:CharacterJobRequirement
+     jobs:
+       - VaultDweller
+    
+- type: loadout
+  id: N14LoadoutUniformJumpsuitPreWarCasual
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuitPreWarCasual
+  requirements:
+    - !type:CharacterPlaytimeRequirement
+      tracker: VaultDweller
+      min: 1500  # 25 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterJobRequirement
+      jobs:
+        - VaultDweller
+
+- type: loadout
+  id: N14LoadoutUniformJumpsuitPreWarManager
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuitPreWarManager
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Vault
+      min: 1800  # 30 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterJobRequirement
+      jobs:
+        - VaultDweller
+        - Overseer
+
+- type: loadout # This is for dedicated Overseer players who want to show off their time in the vault, but don't want to wear the jumpsuit with the vault logo on the back.
+  id: N14LoadoutUniformJumpsuitBlueSuit 
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - N14ClothingUniformJumpsuitBlueSuit
+  requirements:
+    - !type:CharacterPlaytimeRequirement
+      tracker: Overseer
+      min: 3000  # 50 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterJobRequirement
+      jobs:
+        - Overseer
+
+- type: loadout
+  id: N14LoadoutUniformJumpsuitPreWarLumberjack
+  category: Uniform
+  cost: 2
+  exclusive: true
+  items:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Vault 
+      min: 1500  # 25 hours
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
+    - !type:CharacterJobRequirement
+      jobs:
+        - VaultDweller

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/uniform.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/uniform.yml
@@ -106,7 +106,7 @@
   category: Uniform
   cost: 2
   exclusive: true
-  items:
+  requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Vault 
       min: 1500  # 25 hours
@@ -115,3 +115,5 @@
     - !type:CharacterJobRequirement
       jobs:
         - VaultDweller
+  items:
+  - N14ClothingUniformJumpsuitPreWarLumberjack

--- a/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/uniform.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/VaultLoadout/uniform.yml
@@ -1,5 +1,5 @@
 - type: loadout # This is for Vault Security players that want to act like an detective of sort.
-  id: N14LoadoutUniformJumpsuitDetectiveAlt
+  id: N14LoadoutUniformJumpsuitDetectiveAltVault
   category: Uniform
   cost: 2
   exclusive: true
@@ -16,7 +16,7 @@
       - VaultSecurity
   
 - type: loadout
-  id: N14LoadoutUniformJumpsuitCheckered
+  id: N14LoadoutUniformJumpsuitCheckeredVault
   category: Uniform
   cost: 2
   exclusive: true
@@ -33,7 +33,7 @@
         - VaultDweller
  
 - type: loadout
-  id: N14LoadoutUniformJumpsuitPreWarRelaxed
+  id: N14LoadoutUniformJumpsuitPreWarRelaxedVault
   category: Uniform
   cost: 2
   exclusive: true
@@ -50,7 +50,7 @@
        - VaultDweller
     
 - type: loadout
-  id: N14LoadoutUniformJumpsuitPreWarCasual
+  id: N14LoadoutUniformJumpsuitPreWarCasualVault
   category: Uniform
   cost: 2
   exclusive: true
@@ -67,7 +67,7 @@
         - VaultDweller
 
 - type: loadout
-  id: N14LoadoutUniformJumpsuitPreWarManager
+  id: N14LoadoutUniformJumpsuitPreWarManagerVault
   category: Uniform
   cost: 2
   exclusive: true
@@ -85,7 +85,7 @@
         - Overseer
 
 - type: loadout # This is for dedicated Overseer players who want to show off their time in the vault, but don't want to wear the jumpsuit with the vault logo on the back.
-  id: N14LoadoutUniformJumpsuitBlueSuit 
+  id: N14LoadoutUniformJumpsuitBlueSuitVault
   category: Uniform
   cost: 2
   exclusive: true
@@ -102,7 +102,7 @@
         - Overseer
 
 - type: loadout
-  id: N14LoadoutUniformJumpsuitPreWarLumberjack
+  id: N14LoadoutUniformJumpsuitPreWarLumberjackVault
   category: Uniform
   cost: 2
   exclusive: true

--- a/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
@@ -11,6 +11,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingHandsGlovesCloth
 
@@ -43,6 +47,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingHandsGlovesFur
 
@@ -75,6 +83,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+      - VaultDweller
+      - VaultSecurity
+      - VaultEngineer
+      - Overseer
   items:
     - N14ClothingHandsGlovesNitrile
 
@@ -91,5 +103,9 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+      - VaultDweller
+      - VaultSecurity
+      - VaultEngineer
+      - Overseer
   items:
     - N14ClothingHandsGlovesNitrilePurple

--- a/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
@@ -59,6 +59,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingHeadHatHeadscarf
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
@@ -75,6 +75,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingHeadHatBandit
 
@@ -91,6 +95,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingHeadHatTribalOutcastHood
 
@@ -172,6 +180,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingTribalMuffaloskull
 
@@ -189,5 +201,9 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingTribalRadstagSkull

--- a/Resources/Prototypes/_Nuclear14/Loadouts/neck.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/neck.yml
@@ -5,6 +5,10 @@
    exclusive: true
    customColorTint: true
    requirements:
+     - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
      - !type:CharacterItemGroupRequirement
        group: N14LoadoutNeck
      - !type:CharacterJobRequirement # Forge-Change
@@ -13,10 +17,6 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
-     - !type:CharacterDepartmentRequirement
-       inverted: true
-       departments:
-       - Vault
    items:
      - N14ClothingNeckCloakLeather
 
@@ -27,6 +27,10 @@
    exclusive: true
    customColorTint: true
    requirements:
+     - !type:CharacterDepartmentRequirement
+        inverted: true
+        departments:
+        - Vault
      - !type:CharacterItemGroupRequirement
        group: N14LoadoutNeck
      - !type:CharacterJobRequirement # Forge-Change
@@ -35,10 +39,6 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
-      - !type:CharacterDepartmentRequirement
-        inverted: true
-        departments:
-        - Vault
    items:
      - N14ClothingNeckMantleLeather
 
@@ -85,6 +85,10 @@
    exclusive: true
    customColorTint: true
    requirements:
+     - !type:CharacterDepartmentRequirement
+        inverted: true
+        departments:
+        - Vault
      - !type:CharacterItemGroupRequirement
        group: N14LoadoutNeck
      - !type:CharacterJobRequirement # Forge-Change
@@ -93,10 +97,6 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
-      - !type:CharacterDepartmentRequirement
-        inverted: true
-        departments:
-        - Vault
    items:
      - N14ClothingNeckTribalCloak
 
@@ -107,6 +107,10 @@
    exclusive: true
    customColorTint: true
    requirements:
+     - !type:CharacterDepartmentRequirement
+        inverted: true
+        departments:
+        - Vault
      - !type:CharacterItemGroupRequirement
        group: N14LoadoutNeck
      - !type:CharacterJobRequirement # Forge-Change
@@ -115,10 +119,6 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
-      - !type:CharacterDepartmentRequirement
-        inverted: true
-        departments:
-        - Vault
    items:
      - N14ClothingNeckTribalCloakBr
 
@@ -129,6 +129,10 @@
    exclusive: true
    customColorTint: true
    requirements:
+     - !type:CharacterDepartmentRequirement
+        inverted: true
+        departments:
+        - Vault
      - !type:CharacterItemGroupRequirement
        group: N14LoadoutNeck
      - !type:CharacterJobRequirement # Forge-Change
@@ -137,9 +141,5 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
-      - !type:CharacterDepartmentRequirement
-        inverted: true
-        departments:
-        - Vault
    items:
      - N14ClothingNeckShawl

--- a/Resources/Prototypes/_Nuclear14/Loadouts/neck.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/neck.yml
@@ -13,6 +13,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+     - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
    items:
      - N14ClothingNeckCloakLeather
 
@@ -31,6 +35,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+      - !type:CharacterDepartmentRequirement
+        inverted: true
+        departments:
+        - Vault
    items:
      - N14ClothingNeckMantleLeather
 
@@ -85,6 +93,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+      - !type:CharacterDepartmentRequirement
+        inverted: true
+        departments:
+        - Vault
    items:
      - N14ClothingNeckTribalCloak
 
@@ -103,6 +115,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+      - !type:CharacterDepartmentRequirement
+        inverted: true
+        departments:
+        - Vault
    items:
      - N14ClothingNeckTribalCloakBr
 
@@ -121,5 +137,9 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+      - !type:CharacterDepartmentRequirement
+        inverted: true
+        departments:
+        - Vault
    items:
      - N14ClothingNeckShawl

--- a/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
@@ -235,7 +235,7 @@
     - N14ClothingOuterCoatLeatherDuster
 
 - type: loadout
-  id: N14ClothingOuterCoatLeatherJacket
+  id: N14LoadoutOuterCoatLeatherJacket
   category: Outer
   cost: 1
   requirements:
@@ -255,7 +255,7 @@
     - N14ClothingOuterCoatLeatherJacket
 
 - type: loadout
-  id: N14ClothingOuterCoatLeatherCoat
+  id: N14LoadoutOuterCoatLeatherCoat
   category: Outer
   cost: 1
   requirements:

--- a/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
@@ -207,6 +207,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingOuterCoatDuster
 
@@ -243,6 +247,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingOuterCoatLeatherJacket
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/shoes.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/shoes.yml
@@ -43,6 +43,10 @@
       - BoSMidSerf
       - CaesarLegionSlave
       - NCRPisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
   items:
     - N14ClothingShoesRags
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/uniform.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/uniform.yml
@@ -39,7 +39,7 @@
   requirements:
    - !type:CharacterItemGroupRequirement
       group: N14LoadoutUniform
-    - !type:CharacterJobRequirement # Forge-Change
+   - !type:CharacterJobRequirement # Forge-Change
       inverted: true
       jobs:
       - BoSMidSerf

--- a/Resources/Prototypes/_Nuclear14/Loadouts/uniform.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/uniform.yml
@@ -37,6 +37,8 @@
   items:
     - N14ClothingUniformJumpskirtAsylumDress
   requirements:
+   - !type:CharacterItemGroupRequirement
+      group: N14LoadoutUniform
     - !type:CharacterJobRequirement # Forge-Change
       inverted: true
       jobs:


### PR DESCRIPTION

## About the PR
I Expanded oVault clothing options by adding new outfit variants for Vault Dwellers, Vault Overseers, and Vault Security. I've also made clothing that didn't fit into Vault unavaible to them.
## Why / Balance
Vaulties are currently only limited to jumpsuits which restricts them when it comes to distinction. Gameplay-wise this limits visual variety and role identity.To make it consistent, the items are time-locked.
## Technical details
Removed non-lore-fitting clothing from Vault-specific pools
Made a new file 'VaultLoadout'
Each clothing has Vault in end of their IDs.
## Media
<img width="152" height="297" alt="screenshot " src="https://github.com/user-attachments/assets/9b15e901-efb9-47cf-a8d5-f8adce4b39ce" />
<img width="184" height="329" alt="image" src="https://github.com/user-attachments/assets/a4c6f472-efcf-4b10-9893-682cba04e941" />

:cl:
add: Added new Vault clothing variants for Dwellers, Overseers, and Security.
remove: Removed non-lore-fitting Vault clothing
fix: Fixed Asylum dress so it can no longer be worn together with uniforms.