### PR TITLE
Fixes

### DIFF
--- a/Content.Client/_NC/Trade/Controls/NcContractCard.cs
+++ b/Content.Client/_NC/Trade/Controls/NcContractCard.cs
@@ -462,7 +462,11 @@ public sealed class NcContractCard : PanelContainer
         if (!string.IsNullOrWhiteSpace(tooltip))
             targetRow.ToolTip = tooltip;
 
-        if (!string.IsNullOrWhiteSpace(protoId))
+        // #Misfits Fix - Skip EntityPrototypeView for abstract or unknown prototypes; otherwise
+        // EntMan.Spawn() throws EntityCreationException, which propagates out of AddChild() and
+        // tears down the entire contract list rebuild. This was leaving the trade vendor stuck
+        // open for the user (and locked out for everyone else) after silver-tier contract turn-ins.
+        if (!string.IsNullOrWhiteSpace(protoId) && targetProto is { Abstract: false })
         {
             var view = new EntityPrototypeView
             {
@@ -599,7 +603,10 @@ public sealed class NcContractCard : PanelContainer
                 if (!string.IsNullOrWhiteSpace(tooltip))
                     line.ToolTip = tooltip;
 
-                if (!string.IsNullOrWhiteSpace(id))
+                // #Misfits Fix - Same guard as BuildTargetRow: don't spawn abstract/unknown
+                // reward prototypes through EntityPrototypeView, or AddChild will throw and
+                // abort the contract list rebuild mid-way.
+                if (!string.IsNullOrWhiteSpace(id) && proto is { Abstract: false })
                 {
                     var view = new EntityPrototypeView
                     {

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -249,8 +249,9 @@ namespace Content.Server.Kitchen.EntitySystems
                 var parentId = proto.Parents[0];
                 if (parentId == ancestorId)
                     return true;
-                if (!_prototype.TryIndex<EntityPrototype>(parentId, out proto))
+                if (!_prototype.TryIndex<EntityPrototype>(parentId, out var parentProto))
                     break;
+                proto = parentProto;
             }
             return false;
         }

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -225,7 +225,11 @@ namespace Content.Server.Kitchen.EntitySystems
                             continue;
                         }
 
-                        if (metaData.EntityPrototype.ID == recipeSolid.Key)
+                        // #Misfits Fix - also match ancestor prototypes so child entities
+                        // (e.g. N14FoodMeatRadstag satisfying a brahmin recipe via parent chain)
+                        // are actually consumed instead of being returned to the player.
+                        if (metaData.EntityPrototype.ID == recipeSolid.Key ||
+                            IsPrototypeAncestor(metaData.EntityPrototype, recipeSolid.Key))
                         {
                             _container.Remove(item, component.Storage);
                             EntityManager.DeleteEntity(item);
@@ -234,6 +238,21 @@ namespace Content.Server.Kitchen.EntitySystems
                     }
                 }
             }
+        }
+
+        // #Misfits Fix - checks whether ancestorId appears anywhere in the prototype parent chain of proto.
+        // Used to ensure SubtractContents deletes child entities that satisfied a recipe via the ancestor walk.
+        private bool IsPrototypeAncestor(EntityPrototype proto, string ancestorId)
+        {
+            while (proto.Parents is { Length: > 0 })
+            {
+                var parentId = proto.Parents[0];
+                if (parentId == ancestorId)
+                    return true;
+                if (!_prototype.TryIndex<EntityPrototype>(parentId, out proto))
+                    break;
+            }
+            return false;
         }
 
         private void OnInit(Entity<MicrowaveComponent> ent, ref ComponentInit args)
@@ -477,6 +496,8 @@ namespace Content.Server.Kitchen.EntitySystems
                 return;
 
             var solidsDict = new Dictionary<string, int>();
+            // #Misfits Fix - exact-only dict (no ancestor walk) used to prefer specific recipes over generic parent ones
+            var exactSolidsDict = new Dictionary<string, int>();
             var reagentDict = new Dictionary<string, FixedPoint2>();
             var malfunctioning = false;
             // TODO use lists of Reagent quantities instead of reagent prototype ids.
@@ -520,6 +541,12 @@ namespace Content.Server.Kitchen.EntitySystems
                     solidsDict.Add(metaData.EntityPrototype.ID, 1);
                 }
 
+                // #Misfits Fix - track exact entity IDs separately so we can prefer specific recipes
+                if (exactSolidsDict.ContainsKey(metaData.EntityPrototype.ID))
+                    exactSolidsDict[metaData.EntityPrototype.ID]++;
+                else
+                    exactSolidsDict.Add(metaData.EntityPrototype.ID, 1);
+
                 // #Misfits Fix - also count this entity toward each ancestor prototype ID so
                 // child entities (e.g. N14FoodMeatBrahminCutlet) satisfy recipes that require
                 // their parent (e.g. N14FoodMeatRadCutlet).
@@ -558,8 +585,14 @@ namespace Content.Server.Kitchen.EntitySystems
 
             List<FoodRecipePrototype> recipes = getRecipesEv.Recipes;
             recipes.AddRange(_recipeManager.Recipes);
-            var portionedRecipe = recipes.Select(r =>
-                CanSatisfyRecipe(component, r, solidsDict, reagentDict)).FirstOrDefault(r => r.Item2 > 0);
+            // #Misfits Fix - prefer exact-match recipes (e.g. radstag recipe) over ancestor-match ones
+            // (e.g. brahmin recipe matching radstag via parent chain). This prevents wrong output when
+            // a more specific recipe exists for the entity that was actually placed in the microwave.
+            var portionedRecipe = recipes
+                .Select(r => CanSatisfyRecipe(component, r, solidsDict, reagentDict))
+                .Where(r => r.Item2 > 0)
+                .OrderByDescending(r => CanSatisfyRecipe(component, r.Item1, exactSolidsDict, reagentDict).Item2 > 0)
+                .FirstOrDefault();
 
             _audio.PlayPvs(component.StartCookingSound, uid);
             var activeComp = AddComp<ActiveMicrowaveComponent>(uid); //microwave is now cooking

--- a/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
@@ -93,7 +93,11 @@ namespace Content.Server.Storage.EntitySystems
             if (component.Uses <= 0)
             {
                 args.Handled = true;
-                EntityManager.DeleteEntity(uid);
+                // #Misfits Fix - kit boxes (e.g. NCR Cadet/Private loadout kits) were not despawning after use, allowing infinite item spam.
+                // Strip the component first so any reentrant UseInHandEvent during PickupOrDrop becomes a no-op, then queue-delete so the
+                // entity remains valid for the rest of this handler (PickupOrDrop / audio call below) and is reaped at end-of-tick.
+                RemComp<SpawnItemsOnUseComponent>(uid);
+                QueueDel(uid);
             }
 
             if (entityToPlaceInHands != null)

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -136,8 +136,13 @@ public sealed class FloorTileSystem : EntitySystem
                 var baseTurf = (ContentTileDefinition) _tileDefinitionManager[tile.Tile.TypeId];
                 var preserveUnderlay = false;
 
+                // #Misfits Tweak - Also accept the wasteland-chain rule so roads/concrete/hexacrete
+                // (subfloor, baseTurf=FloorWasteland, not indestructible) can be tiled over with
+                // the underlay preserved. Without this, placement silently fails on most outdoor
+                // ground tiles even though the player has a valid stack of tiles in hand.
                 if (!HasBaseTurf(currentTileDefinition, baseTurf.ID) &&
-                    CanPlaceOverPlanetarySubfloor(currentTileDefinition, baseTurf))
+                    (CanPlaceOverPlanetarySubfloor(currentTileDefinition, baseTurf) ||
+                     CanPlaceOverWastelandTerrain(currentTileDefinition, baseTurf)))
                 {
                     preserveUnderlay = true;
                 }
@@ -186,6 +191,38 @@ public sealed class FloorTileSystem : EntitySystem
                currentTile.IsSubFloor &&
                currentTile.Indestructible &&
                currentTile.ID != ContentTileDefinition.SpaceID;
+    }
+
+    // #Misfits Add - Allow placing crafted floor tiles on top of any non-station "outdoor" subfloor
+    // (roads, concrete paths, hexacrete, etc). The original CanPlaceOverPlanetarySubfloor check above
+    // only matched Indestructible subfloors (i.e. FloorWasteland itself), so painted/decorative
+    // ground tiles whose chain still ends at FloorWasteland could not be replaced. The underlay
+    // is preserved so prying the placed tile restores the original road/concrete beneath.
+    // We deliberately walk the BaseTurf chain instead of accepting any subfloor: this excludes
+    // station Plating (chain: Plating -> Lattice -> Space) and bare Lattice (Space) so vanilla
+    // station construction rules are unaffected.
+    private bool CanPlaceOverWastelandTerrain(ContentTileDefinition replacementTile, ContentTileDefinition currentTile)
+    {
+        if (replacementTile.IsSubFloor || !currentTile.IsSubFloor)
+            return false;
+
+        if (currentTile.MapAtmosphere) // skip space-exposed tiles like Lattice
+            return false;
+
+        var def = currentTile;
+        // Bound the walk to a small constant; tile inheritance chains are shallow.
+        for (var i = 0; i < 8 && def != null; i++)
+        {
+            if (def.ID == "FloorWasteland")
+                return true;
+
+            if (string.IsNullOrEmpty(def.BaseTurf) || def.BaseTurf == ContentTileDefinition.SpaceID)
+                return false;
+
+            def = (ContentTileDefinition) _tileDefinitionManager[def.BaseTurf];
+        }
+
+        return false;
     }
 
     private void PlaceAt(EntityUid user, EntityUid gridUid, MapGridComponent mapGrid, EntityCoordinates location,

--- a/Content.Shared/_NC/RandomAccessKey/RandomAccessKeySystem.cs
+++ b/Content.Shared/_NC/RandomAccessKey/RandomAccessKeySystem.cs
@@ -2,7 +2,9 @@ using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Construction;
 using Content.Shared.Doors.Components;
+using Content.Shared.Doors.Systems;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -14,6 +16,7 @@ public sealed class RandomAccessKeySystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly MetaDataSystem _meta = default!;
+    [Dependency] private readonly SharedDoorSystem _door = default!; // #Misfits Fix - allow toggling door when key is used on it
     private const string RandomAccessPrefix = "RandomAccess";
     private const string Key = "N14IDKeyIronEmpty";
     public override void Initialize()
@@ -21,6 +24,10 @@ public sealed class RandomAccessKeySystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<RandomAccessKeyComponent, ConstructionCompletedEvent>(OmConstructionCompleted);
+        // #Misfits Fix - clicking the locked door with the key in hand had no effect because doors only react
+        // to empty-hand ActivateInWorldEvent. Forward InteractUsingEvent into the standard door toggle path so
+        // the existing AccessReader check (which already enumerates the user's hands) accepts the held key.
+        SubscribeLocalEvent<RandomAccessKeyComponent, InteractUsingEvent>(OnKeyInteractUsing);
     }
 
     private void OmConstructionCompleted(Entity<RandomAccessKeyComponent> ent,
@@ -34,14 +41,21 @@ public sealed class RandomAccessKeySystem : EntitySystem
 
         var randomKey = _random.Next(1000, 9999);
         var prototypeId = $"{RandomAccessPrefix}{randomKey}";
-        var prototype = new AccessLevelPrototype
-        {
-            ID = prototypeId,
-            Name = $"Key #{randomKey}"
-        };
+        // #Misfits Removed - dead AccessLevelPrototype object: it was never registered with IPrototypeManager
+        // and only its .ID (a plain string) was consumed below. The string id is sufficient by itself.
+        // var prototype = new AccessLevelPrototype
+        // {
+        //     ID = prototypeId,
+        //     Name = $"Key #{randomKey}"
+        // };
         var accessReader = EnsureComp<AccessReaderComponent>(ent.Owner);
 
-        accessReader.AccessLists.Add(new HashSet<ProtoId<AccessLevelPrototype>> { prototype.ID });
+        accessReader.AccessLists.Add(new HashSet<ProtoId<AccessLevelPrototype>> { prototypeId });
+        // #Misfits Fix - dirty the access reader so the client sees the new access requirement; without this
+        // the client predicted state of the door has an empty AccessLists and prediction diverges from server.
+        Dirty(ent.Owner, accessReader);
+        // #Misfits Fix - notify NavMap/UI consumers (e.g., door electronics UI) that the access list changed.
+        RaiseLocalEvent(ent.Owner, new AccessReaderConfigurationChangedEvent());
 
         var userCord = _transform.GetMapCoordinates(args.UserUid.Value);
         var doorKey = Spawn(Key, userCord);
@@ -49,11 +63,31 @@ public sealed class RandomAccessKeySystem : EntitySystem
 
         _meta.SetEntityName(doorKey, $"Key #{randomKey}");
         accessKey.Tags.Clear();
-        accessKey.Tags.Add(prototype.ID);
+        accessKey.Tags.Add(prototypeId);
         Dirty(doorKey, accessKey);
-        _hands.PickupOrDrop(args.UserUid, doorKey);
+        _hands.PickupOrDrop(args.UserUid.Value, doorKey); // #Misfits Fix - method expects EntityUid not EntityUid?
         door.CanPry = false;
         door.BumpOpen = false;
         Dirty(ent.Owner, door);
+    }
+
+    // #Misfits Add - bridge InteractUsing -> door toggle so the spawned key (or any matching ID) actually
+    // opens/closes the locked door when used on it. The standard door OnActivate path only handles empty-hand
+    // clicks, so without this the player had no way to use the key after picking it up.
+    private void OnKeyInteractUsing(Entity<RandomAccessKeyComponent> ent, ref InteractUsingEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        // Only react when the held item actually carries access tags, otherwise let other handlers run
+        // (e.g., construction tools deconstructing the door, prying, welding, etc.).
+        if (!HasComp<AccessComponent>(args.Used))
+            return;
+
+        if (!TryComp(ent.Owner, out DoorComponent? door))
+            return;
+
+        if (_door.TryToggleDoor(ent.Owner, door, args.User, predicted: true))
+            args.Handled = true;
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -12,6 +12,13 @@
       sprite: Objects/Weapons/Melee/shields.rsi
       size: Ginormous
       heldPrefix: riot
+    # #Misfits Fix - Add Clothing so shields can be equipped to Back / armor suitStorage (matches Legion shield behavior)
+    - type: Clothing
+      sprite: Objects/Weapons/Melee/shields.rsi
+      quickEquip: false
+      slots:
+      - Back
+      - suitStorage
     - type: Blocking
       passiveBlockModifier:
         coefficients:
@@ -243,6 +250,9 @@
     - type: Item
       sprite: Objects/Weapons/Melee/web-shield.rsi
       heldPrefix: icon
+    # #Misfits Fix - Override Clothing sprite to match web shield RSI
+    - type: Clothing
+      sprite: Objects/Weapons/Melee/web-shield.rsi
     - type: Blocking
       passiveBlockModifier:
         coefficients:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Shields/shields.yml
@@ -11,6 +11,13 @@
     - type: Item
       sprite: _Nuclear14/Objects/Weapons/Melee/shield_light.rsi
       size: Ginormous
+    # #Misfits Fix - Add Clothing so metal shields can be equipped to Back / armor suitStorage (matches Legion shield behavior)
+    - type: Clothing
+      sprite: _Nuclear14/Objects/Weapons/Melee/shield_light.rsi
+      quickEquip: false
+      slots:
+      - Back
+      - suitStorage
     - type: Damageable
       damageContainer: Shield
     - type: Destructible
@@ -78,6 +85,9 @@
     - type: Sprite
       sprite: _Nuclear14/Objects/Weapons/Melee/shield_heavy.rsi
     - type: Item
+      sprite: _Nuclear14/Objects/Weapons/Melee/shield_heavy.rsi
+    # #Misfits Fix - Override Clothing sprite to match heavy shield RSI
+    - type: Clothing
       sprite: _Nuclear14/Objects/Weapons/Melee/shield_heavy.rsi
     - type: Destructible
       thresholds:


### PR DESCRIPTION

:cl: cythisiax

fix: Trade vendor no longer gets stuck open and locked for other players after a silver-tier contract is turned in.
fix: Faction loadout kit boxes (NCR, etc.) now disappear after use instead of letting players grab from them infinitely.
fix: Microwave cooking now correctly consumes child food variants when they satisfy a parent recipe, and picks the most specific matching recipe to avoid cooking the wrong thing.
fix: Random access key doors can now actually be opened by clicking on them with the key in hand; the door also immediately recognizes its assigned key without needing a relog.
tweak: Floor tiles can now be placed over roads, concrete paths, and other outdoor terrain, not just bare wasteland ground. Removing the placed tile still restores whatever was underneath.
add: Shields can now be stored on your back slot or tucked into armor suit storage.
