### PR TITLE
Not Quite My Tempo

### DIFF
--- a/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
@@ -396,22 +396,22 @@ undecided-loadout-category-corvax-auxilia-medic-description =
 
 undecided-loadout-category-corvax-veteran-decanus-command-name = Veteran Decanus Command
 undecided-loadout-category-corvax-veteran-decanus-command-description =
-    Includes a Legion shield, a M240B HMG with spare HMG belt,
+    Includes a Legion shield, a neostead with two boxes of 12g,
     a rope belt, a .45 Colt pistol, 2 .45 magazines,
     a box of .45 ammo, a handcuff box, a bola,
     2 healing poultice, 2 K rations, and a ceramic flask.
 
 undecided-loadout-category-corvax-veteran-decanus-hunter-name = Veteran Decanus Hunter
 undecided-loadout-category-corvax-veteran-decanus-hunter-description =
-    Includes a Legion buckler, a M240B HMG with spare HMG belt,
-    a .45 Colt pistol, 2 .45 magazines, a rope belt,
+    Includes a Legion buckler, a .50 pipe rifle with 2 spare boxes,
+    a .45 M3A1, 2 .45 SMG magazines, a rope belt,
     a short shotgun, a box of 12 gauge shells,
     2 healing poultices, a healing powder,
     2 K rations, and a ceramic flask.
 
 undecided-loadout-category-corvax-veteran-decanus-crusher-name = Veteran Decanus Crusher
 undecided-loadout-category-corvax-veteran-decanus-crusher-description =
-    Includes a big tribal club, a Legion SKS with 4 clips,
+    Includes a decorated tribal club, a Legion SKS with 4 clips,
     a .45 Colt pistol, 2 .45 magazines, a smoke grenade,
     2 healing poultice, 2 K rations, and a ceramic flask.
 
@@ -425,7 +425,7 @@ undecided-loadout-category-corvax-decanus-gladiator-description =
 
 undecided-loadout-category-corvax-decanus-sagitaria-name = Decanus Sagitaria
 undecided-loadout-category-corvax-decanus-sagitaria-description =
-    Includes a Legion SKS with 4 clips,
+    Includes a salvaged M60 with a single extra box,
     a .45 revolver with 2 spare magazines, a rope belt,
     a smoke grenade, 2 healing poultice, 2 K rations,
     a ceramic flask, and mustard.

--- a/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
@@ -109,7 +109,7 @@ undecided-loadout-category-med-combat-description =
 
 # NCRA Weapon Specialist Kits
 
-undecided-loadout-category-ws-gunner-name = Specialist Gunner Kit
+undecided-loadout-category-ws-gunner-name = Specialist heavy sniper Kit
 undecided-loadout-category-ws-gunner-description =
     Includes 1 NCR belt, 1 metal helmet, 1 NCR cloak, 1 NCR .50 rifle,
     1 box of .50, 1 9mm pistol, 2 9mm pistol magazines,

--- a/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
@@ -111,8 +111,8 @@ undecided-loadout-category-med-combat-description =
 
 undecided-loadout-category-ws-gunner-name = Specialist Gunner Kit
 undecided-loadout-category-ws-gunner-description =
-    Includes 1 NCR belt, 1 metal helmet, 1 NCR cloak, 1 Automatic rifle,
-    2 .308 magazines, 1 9mm pistol, 2 9mm pistol magazines,
+    Includes 1 NCR belt, 1 metal helmet, 1 NCR cloak, 1 NCR .50 rifle,
+    1 box of .50, 1 9mm pistol, 2 9mm pistol magazines,
     1 C ration MRE, 1 stimpak, 1 RadAway blood bag, 1 gauze pack, and 1 flare.
 
 undecided-loadout-category-ws-grenadier-name = Specialist Grenadier Kit

--- a/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
@@ -547,9 +547,9 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14LegionnaireShield
-      - id: N14WeaponUSHMG # #Misfits Change by BILL CLINTON!: Parity with NCR specialist kits. they get lmgs why doesn't legion?
-      - id: Magazine762AmmoBelt # #Misfits Change by bill - one belt of LMG is more than enough
-        amount: 1
+      - id: N14WeaponShotgunNeostead # #Misfits Change by BILL CLINTON!: Specializing the vet decanus instead of making him a vital 1 slot char for legion
+      - id: MagazineBox12gauge # #Misfits Change by bill - two boxes should suffice.
+        amount: 2
       - id: ClothingBeltRope
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
       - id: N14MagazinePistol45
@@ -581,12 +581,12 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14LegionnaireBuckler
-      - id: N14WeaponUSHMG # #Misfits Change by BILL CLINTON!: Parity with NCR specialist kits. they get lmgs why doesn't legion?
-      - id: Magazine762AmmoBelt # #Misfits Change by bill - one belt of LMG is more than enough.
-        amount: 1
+      - id: N14WeaponSniper50Pipe # #Misfits Change by BILL CLINTON!: Armor hunter. hunt and kill their tankies while the other decani hold the line down.
+      - id: MagazineBox50 # #Misfits Change by bill - one box? ...two box.
+        amount: 2
       - id: ClothingBeltRope
-      - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
-      - id: N14MagazinePistol45
+      - id: N14WeaponSMGGreaseGun # #Misfits Change: legion smg for hunting armor. 
+      - id: Magazine45SubMachineGun
         amount: 2
       - id: N14WeaponShotgunShort
       - id: MagazineBox12gauge
@@ -612,7 +612,7 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14TribalBigClub
+      - id: N14TribalBigClubDecorated
       - id: N14WeaponRifleSKS # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
       - id: SKSEnbloc308 # #Misfits Change - replaced GarandEnbloc308
         amount: 4
@@ -676,9 +676,9 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponRifleSKS # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
-      - id: SKSEnbloc308 # #Misfits Change - replaced GarandEnbloc308
-        amount: 4
+      - id: N14WeaponM60GPMG # #Misfits Change by BILL CLINTON!: HMG gunner swap from vet decanus down to the lesser decani.
+      - id: Magazine308M60Box # #Misfits Change - replaced GarandEnbloc308
+        amount: 1
       - id: ClothingBeltRope
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
       - id: N14MagazinePistol45

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -453,9 +453,8 @@
       - id: ClothingBeltNCR
       - id: N14ClothingHeadHatNCRHelmetMetalDesert # Forge-Change
       - id: N14ClothingNeckCloakNCR # Forge-Change
-      - id: N14WeaponLMGAutoRifle
-      - id: Magazine308Rifle
-        amount: 2
+      - id: N14WeaponSniper50NCRRifle # Bill- the autorifle was too much. Kill tankies with skillful shots
+      - id: MagazineBox50
       - id: N14WeaponPistol9mm
       - id: N14MagazinePistol9mm
         amount: 2

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -439,7 +439,7 @@
 # NCRA Weapon Specialist Kits
 
 - type: entity
-  name: specialist's gunner kit
+  name: specialist's heavy sniper kit
   parent: KitBase
   id: KitNCR_WSGunner
   description: A crate containing all an NCR weapon specialist needs to perform their job.

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/308.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/308.yml
@@ -89,7 +89,7 @@
     - 0,1,0,1
   - type: BallisticAmmoProvider
     proto: N14Cartridge308Rifle
-    capacity: 100
+    capacity: 50
   - type: Sprite
     netsync: false
     sprite: _Nuclear14/Objects/Weapons/Guns/Ammunition/Magazines/308/mag4.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -330,9 +330,9 @@
 
 - type: entity
   name: M60 GPMG
-  parent: N14WeaponHMGcanadian
+  parent: BaseWeaponRifle
   id: N14WeaponM60GPMG
-  description: The M60 General Purpose Machine Gun (GPMG) is a pre-war machine gun that fires around 600 rounds. Large, powerful, and fearsome - this old-world relic is a monster in combat. The words 'Cheese 'Em' are scratched into the stock.
+  description: The M60 General Purpose Machine Gun is a pre-war machine gun that has a slow, chugging fire rate. Large, powerful, and loud - this old design was looted by legionnaires from old national guard warehouses.
   components:
   - type: Clothing
     sprite: _Nuclear14/Objects/Weapons/Guns/LMGs/m60.rsi
@@ -346,6 +346,23 @@
   - type: Item
     size: Huge
     sprite: _Nuclear14/Objects/Weapons/Guns/LMGs/m60.rsi
+  - type: Wieldable
+    wieldedSpeedModifier: 0.8
+  - type: GunRequiresWield
+  - type: GunWieldBonus
+    minAngle: -21 # Corvax-Change
+    maxAngle: -50 # Corvax-Change
+  - type: Gun
+    minAngle: 24
+    maxAngle: 60
+    angleIncrease: 4
+    angleDecay: 16
+    fireRate: 3
+    soundGunshot:
+      collection: N14AutoRifleGunshot
+    selectedMode: FullAuto
+    availableModes:
+    - FullAuto
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/hammer.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/hammer.yml
@@ -52,7 +52,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 55
+        Blunt: 75
         Structural: 35
   - type: MeleeThrowOnHit
     speed: 10


### PR DESCRIPTION
## About the PR
NCR specialists have lost their BAR. they got the single shot .50 instead. Work together and bring down the armored beasts.
Legion vet decanus has lost his prototype legion M240B. legate wasn't satisfied and decided to take it back.
Legion prime decanus and decanus have now been given the M60 GPMG. Modified by yours truly to follow a balancing for it.
M60 GPMG given 3 RPS fire rate, nerfed the box from 100 rounds of .308 down to 50. Made it a little more accurate than the canadian HMG.
Legion vet decanus kits given the choice of pipe .50 cal with M3A1 SMG, neostead, or tribal decorated with legion SKS.
FTL changed to reflect this
EDIT: buffed super sledge
EDIT EDIT: NCR "gunner" specialist renamed to "heavy sniper" instead. Reflects their role with a .50 better.

## Why / Balance
Legion relying on a single slot 1 man role for literally any form of combat against HTs (without serious prep and using a lot of resources) is not very good from a balance perspective nor is it nice on the player to carry such a weight. This spreads the responsibility so that losing the vet decanus wasn't literally game end for legion.
Took away the specialist bars because they can just make them with blueprints if they'd rather. and .50 rifle is better at killing heavy armor anyways.

I feel as if this can add a lovely tempo to combat, heavies pushing the line while lessers form the front. more specialized soldiers picking off higher value targets.

## Technical details
YML and FTL changes

## Media

https://github.com/user-attachments/assets/9de9b752-1b6e-46a3-8af3-12b8a88f9a71

# Changelog

:cl: Bill Clinton
- add: Gave NCRA specialist gunner the NCR .50 single shot sniper. Bring down the pain on the heavy armor of legion and brotherhood.
- remove: removed NCRA specialist BAR, NCR suffers legion celebrates
- remove: Removed vet decanus M240B, legion suffers NCR celebrates
- tweak: Fixed the M60 to be an M60. Slower fire, heavy bullets, low mag capacity relative to other MGs.
- add: decanus and prime decanus are now the M60 gunners. This spreads responsibility across the roles while also making it more versatile. Be the anchor in the horde.
- tweak: vet decanus given more specialized equipment for armor hunting and crowd control. Beat them back on the frontline and crack open their powered suits.
- tweak: buffed super sledge since it wasn't performing as well as some others
- tweak: Changed NCRA specialist gunner kit from "gunner" to "heavy sniper" to reflect their job and priorities 