### PR TITLE
More C-27 Rolling Fixes & Adjustments

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -189,6 +189,10 @@
                             <Button Visible="False" Name="Rejuv" Access="Public"
                                     Text="{Loc 'admin-player-actions-rejuv'}"
                                     StyleClasses="ButtonSmall" MinWidth="55" MinHeight="26" />
+                            <!-- #Misfits Add - Logs button: opens admin logs panel filtered for the selected player. -->
+                            <Button Visible="False" Name="Logs" Access="Public"
+                                    Text="{Loc 'admin-player-actions-logs'}"
+                                    StyleClasses="ButtonSmall" MinWidth="55" MinHeight="26" />
                         </BoxContainer>
                     </PanelContainer>
 

--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml.cs
@@ -302,6 +302,14 @@ namespace Content.Client.Administration.UI.Bwoink
                     _console.ExecuteCommand($"player:imm \"{_currentPlayer.Username}\" | player:entity | rejuvenate");
             };
 
+            // #Misfits Add - Logs button: opens admin logs panel pre-filtered to the selected player's username.
+            // Uses the extended "adminlogs" command which accepts an optional username argument.
+            Logs.OnPressed += _ =>
+            {
+                if (_currentPlayer is not null)
+                    _console.ExecuteCommand($"adminlogs \"{_currentPlayer.Username}\"");
+            };
+
             PopOut.OnPressed += _ =>
             {
                 uiController.PopOut();
@@ -492,6 +500,8 @@ namespace Content.Client.Administration.UI.Bwoink
             Bans.StyleBoxOverride = actionBox;
             Respawn.StyleBoxOverride = actionBox;
             Rejuv.StyleBoxOverride = actionBox;
+            // #Misfits Add - neutral flat style for Logs button, matches Notes/Bans.
+            Logs.StyleBoxOverride = actionBox;
 
             // Dark amber for Follow (caution intent)
             Follow.StyleBoxOverride = new StyleBoxFlat
@@ -898,6 +908,10 @@ namespace Content.Client.Administration.UI.Bwoink
             // #Misfits Add - Rejuv button visibility, requires Admin flag
             Rejuv.Visible = _adminManager.HasFlag(AdminFlags.Admin);
             Rejuv.Disabled = !Rejuv.Visible || disabled;
+
+            // #Misfits Add - Logs button visibility, requires Logs flag (same as adminlogs command).
+            Logs.Visible = _adminManager.HasFlag(AdminFlags.Logs);
+            Logs.Disabled = !Logs.Visible || disabled;
         }
 
         private string FormatTabTitle(ItemList.Item li, PlayerInfo? pl = default)

--- a/Content.Client/_Misfits/Administration/UI/Tabs/LoreMasterTab.xaml.cs
+++ b/Content.Client/_Misfits/Administration/UI/Tabs/LoreMasterTab.xaml.cs
@@ -33,6 +33,7 @@ public sealed partial class LoreMasterTab : Control
         ("Robots",               "PlayerRobot"),       // #Misfits Add - Synthetic robot player jobs
         ("FEV Mutants",          "PlayerSuperMutant"), // #Misfits Add - Super mutant player jobs
         ("Raiders",              "PlayerRaider"),      // #Misfits Add - Raider-gang player jobs
+        ("Enclave",              "Enclave"),           // #Misfits Add - Enclave remnant player jobs
     };
 
     // #Misfits Tweak - FactionObjectives preset list removed: kill/steal presets were disabled (low-RP).

--- a/Content.Server/Administration/Commands/OpenAdminLogsCommand.cs
+++ b/Content.Server/Administration/Commands/OpenAdminLogsCommand.cs
@@ -10,7 +10,9 @@ public sealed class OpenAdminLogsCommand : IConsoleCommand
 {
     public string Command => "adminlogs";
     public string Description => "Opens the admin logs panel.";
-    public string Help => $"Usage: {Command}";
+    // #Misfits Tweak - Optional username argument pre-filters the logs search field,
+    // used by the bwoink panel "Logs" quick-action button.
+    public string Help => $"Usage: {Command} [username]";
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -23,5 +25,10 @@ public sealed class OpenAdminLogsCommand : IConsoleCommand
         var eui = IoCManager.Resolve<EuiManager>();
         var ui = new AdminLogsEui();
         eui.OpenEui(ui, player);
+
+        // #Misfits Add - If a username was supplied, pre-fill the search filter so the
+        // panel opens focused on that player's activity.
+        if (args.Length > 0 && !string.IsNullOrWhiteSpace(args[0]))
+            ui.SetLogFilter(search: args[0]);
     }
 }

--- a/Content.Server/Clothing/Systems/LoadoutSystem.cs
+++ b/Content.Server/Clothing/Systems/LoadoutSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.CCVar;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.Loadouts.Prototypes;
 using Content.Shared.Clothing.Loadouts.Systems;
+using Content.Shared.Hands.EntitySystems; // #Misfits Fix - hand fallback for failed loadout equips
 using Content.Shared.Inventory;
 using Content.Shared.Item;
 using Content.Shared.Mind.Components;
@@ -41,8 +42,19 @@ public sealed class LoadoutSystem : EntitySystem
     [Dependency] private readonly ILogManager _log = default!;
     [Dependency] private readonly SharedJobSystem _job = default!;
     [Dependency] private readonly SharedTransformSystem _xform = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!; // #Misfits Fix - hand fallback for failed loadout equips
 
     private ISawmill _sawmill = default!;
+
+    // #Misfits Fix - Slot priority for placing failed loadout items into worn storage.
+    // Tried in order; first slot whose equipped item has a StorageComponent that accepts the
+    // loadout entity wins. Order favors larger/more-appropriate containers first.
+    private static readonly string[] FallbackStorageSlots =
+    {
+        "back",         // backpacks, satchels, duffels
+        "suitstorage",  // hardsuit storage
+        "belt",         // tool belts, holsters
+    };
 
 
     public override void Initialize()
@@ -85,16 +97,40 @@ public sealed class LoadoutSystem : EntitySystem
         var (failedLoadouts, allLoadouts) =
             _loadout.ApplyCharacterLoadout(uid, job, profile, playTimes, whitelisted, out var heirlooms);
 
-        // Try to find back-mounted storage apparatus
-        if (_inventory.TryGetSlotEntity(uid, "back", out var item) &&
-            EntityManager.TryGetComponent<StorageComponent>(item, out var inventory))
-            // Try inserting the entity into the storage, if it can't, it leaves the loadout item on the ground
-            foreach (var loadout in failedLoadouts)
-                if ((!EntityManager.TryGetComponent<ItemComponent>(loadout, out var itemComp)
-                        || !_storage.CanInsert(item.Value, loadout, out _, inventory, itemComp)
-                        || !_storage.Insert(item.Value, loadout, out _, playSound: false))
-                    && deleteFailed)
-                    EntityManager.QueueDeleteEntity(loadout);
+        // #Misfits Fix - Cascading fallback for loadout items that couldn't equip to their natural
+        // slot (slot collision with job startingGear, or non-clothing items like weapons that have
+        // no slot at all). Previously we only tried the "back" slot's storage; if that slot was
+        // occupied by the job's default backpack the loadout backpack would be stuffed inside the
+        // wrong container and follow-up items (e.g. a Double-Barreled Shotgun) would silently fall
+        // on the spawn floor and get walked off. New order: worn storage slots in priority order →
+        // any empty hand → leave on the ground (existing behavior, items already spawned at
+        // player coords by SharedLoadoutSystem). deleteFailed is honored only after every fallback
+        // is exhausted.
+        // # #Misfits Removed - replaced with cascading fallback below.
+        // if (_inventory.TryGetSlotEntity(uid, "back", out var item) &&
+        //     EntityManager.TryGetComponent<StorageComponent>(item, out var inventory))
+        //     foreach (var loadout in failedLoadouts)
+        //         if ((!EntityManager.TryGetComponent<ItemComponent>(loadout, out var itemComp)
+        //                 || !_storage.CanInsert(item.Value, loadout, out _, inventory, itemComp)
+        //                 || !_storage.Insert(item.Value, loadout, out _, playSound: false))
+        //             && deleteFailed)
+        //             EntityManager.QueueDeleteEntity(loadout);
+        foreach (var loadout in failedLoadouts)
+        {
+            if (!Exists(loadout) || Deleted(loadout))
+                continue;
+
+            if (TryStashInWornStorage(uid, loadout))
+                continue;
+
+            if (_hands.TryPickupAnyHand(uid, loadout, checkActionBlocker: false, animate: false))
+                continue;
+
+            // All fallbacks exhausted - the entity remains on the ground at the player's spawn
+            // coordinates (where SharedLoadoutSystem spawned it). Only delete if explicitly asked.
+            if (deleteFailed)
+                EntityManager.QueueDeleteEntity(loadout);
+        }
 
         foreach (var loadout in allLoadouts)
         {
@@ -146,6 +182,32 @@ public sealed class LoadoutSystem : EntitySystem
             _protoMan.TryIndex(job, out jobProto))
             foreach (var special in jobProto.AfterLoadoutSpecial)
                 special.AfterEquip(uid);
+    }
+
+    // #Misfits Fix - Walk the player's worn slots in priority order and try to insert the failed
+    // loadout entity into the first slot whose equipped item has a StorageComponent that accepts
+    // it. Returns true if successfully stored anywhere.
+    private bool TryStashInWornStorage(EntityUid wearer, EntityUid loadout)
+    {
+        if (!EntityManager.TryGetComponent<ItemComponent>(loadout, out var itemComp))
+            return false;
+
+        foreach (var slotName in FallbackStorageSlots)
+        {
+            if (!_inventory.TryGetSlotEntity(wearer, slotName, out var slotEnt))
+                continue;
+
+            if (!EntityManager.TryGetComponent<StorageComponent>(slotEnt, out var storage))
+                continue;
+
+            if (!_storage.CanInsert(slotEnt.Value, loadout, out _, storage, itemComp))
+                continue;
+
+            if (_storage.Insert(slotEnt.Value, loadout, out _, storageComp: storage, playSound: false))
+                return true;
+        }
+
+        return false;
     }
 
     // Corvax-Change-Start

--- a/Content.Server/Ghost/ReturnToBodyEui.cs
+++ b/Content.Server/Ghost/ReturnToBodyEui.cs
@@ -11,10 +11,22 @@ public sealed class ReturnToBodyEui : BaseEui
 
     private readonly MindComponent _mind;
 
+    // #Misfits Add - Optional callback invoked when the player accepts. Used by the
+    // resuscitation flow so the body is only revived after the ghost consents — denying
+    // the prompt now leaves the corpse dead instead of silently reviving it.
+    private readonly Action? _onAccept;
+
     public ReturnToBodyEui(MindComponent mind, SharedMindSystem mindSystem)
+        : this(mind, mindSystem, null)
+    {
+    }
+
+    // #Misfits Add - Overload that runs an action on Accept (e.g. perform the actual revive).
+    public ReturnToBodyEui(MindComponent mind, SharedMindSystem mindSystem, Action? onAccept)
     {
         _mind = mind;
         _mindSystem = mindSystem;
+        _onAccept = onAccept;
     }
 
     public override void HandleMessage(EuiMessageBase msg)
@@ -27,6 +39,10 @@ public sealed class ReturnToBodyEui : BaseEui
             Close();
             return;
         }
+
+        // #Misfits Change - Run the consent-gated revive (if any) before transferring
+        // the mind back, so the body is alive the moment the player re-enters it.
+        _onAccept?.Invoke();
 
         _mindSystem.UnVisit(_mind.Session);
 

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -57,6 +57,14 @@ namespace Content.Server.Ghost.Roles
         private uint _nextRoleIdentifier;
         private bool _needsUpdateGhostRoleCount = true;
 
+        // #Misfits Add - Debounce GhostUpdateGhostRoleCountEvent broadcasts. Without this, every
+        // single ghost-role register/unregister (which can fire dozens per second during map init,
+        // migrations, or mass-spawn events) sends a network event to every connected player. At
+        // 150 pop this was a measurable chunk of per-tick network work. Coalesce bursts into at
+        // most one broadcast per second.
+        private float _ghostRoleCountDebounceAccumulator;
+        private const float GhostRoleCountDebounceInterval = 1.0f;
+
         private readonly Dictionary<uint, Entity<GhostRoleComponent>> _ghostRoles = new();
         private readonly Dictionary<uint, Entity<GhostRoleRaffleComponent>> _ghostRoleRaffles = new();
 
@@ -198,6 +206,14 @@ namespace Content.Server.Ghost.Roles
             if (!_needsUpdateGhostRoleCount)
                 return;
 
+            // #Misfits Tweak - Coalesce burst updates (mass-spawn, round start, map init) into
+            // at most one broadcast per GhostRoleCountDebounceInterval seconds. The flag stays
+            // set so the next tick past the debounce window actually fires the broadcast.
+            _ghostRoleCountDebounceAccumulator += (float)_timing.TickPeriod.TotalSeconds;
+            if (_ghostRoleCountDebounceAccumulator < GhostRoleCountDebounceInterval)
+                return;
+
+            _ghostRoleCountDebounceAccumulator = 0f;
             _needsUpdateGhostRoleCount = false;
             var response = new GhostUpdateGhostRoleCountEvent(GetGhostRoleCount());
             foreach (var player in _playerManager.Sessions)

--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -217,6 +217,11 @@ public sealed class DefibrillatorSystem : EntitySystem
         var sound = !result.Revived || !result.HasMindSession
             ? component.FailureSound
             : component.SuccessSound;
+        // #Misfits Tweak - When the consent prompt was sent the body is not yet revived
+        // (we're awaiting the player's choice), but the defib functioned correctly — play
+        // the success sound so the medic doesn't think the zap failed.
+        if (result.PromptSent)
+            sound = component.SuccessSound;
         _audio.PlayPvs(sound, uid);
 
         // if we don't have enough power left for another shot, turn it off

--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -6,11 +6,13 @@ using Robust.Shared.CPUJob.JobQueues;
 using Robust.Shared.CPUJob.JobQueues.Queues;
 using Content.Server.NPC.HTN.PrimitiveTasks;
 using Content.Server.NPC.Systems;
+using Content.Shared._Misfits.CCVar; // #Misfits Add - CVar gate for ReplanRate
 using Content.Shared.Administration;
 using Content.Shared.Mobs;
 using Content.Shared.NPC;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects; // Corvax
+using Robust.Shared.Configuration; // #Misfits Add - CVar gate for ReplanRate
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -25,6 +27,7 @@ namespace Content.Server.NPC.HTN;
 public sealed class HTNSystem : EntitySystem
 {
     [Dependency] private readonly IAdminManager _admin = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!; // #Misfits Add - CVar gate for ReplanRate
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly NPCSystem _npc = default!;
@@ -40,10 +43,11 @@ public sealed class HTNSystem : EntitySystem
 
     private readonly HashSet<ICommonSession> _subscribers = new();
 
-    // #Misfits Change — Increased from 4/sec to 7/sec to reduce delay between aggro event and combat response.
-    // HTN tasks are evaluated up to 7 times/second instead of 4, cutting combat response window from ~250ms to ~140ms.
-    // Impact: ~2-3% CPU increase in normal scenarios, negligible during average gameplay.
-    private const float ReplanRate = 7f; // per second, TODO: CVar?
+    // #Misfits Change — ReplanRate was forced to a const 7f Hz to cut combat response latency.
+    // Reverted to upstream 5f default and surfaced as CVar `misfits.htn_replan_rate` so ops
+    // can tune without a rebuild. At 150+ pop on constrained VPS hardware the extra 2 Hz of
+    // HTN work across every active NPC was measurable; 5 Hz is the safer baseline.
+    private float _replanRate = 5f; // per second, CVar-driven
     private float Accumulator; // limit replanning rate
 
     // Hierarchical Task Network
@@ -52,6 +56,8 @@ public sealed class HTNSystem : EntitySystem
         base.Initialize();
         _mapQuery = GetEntityQuery<WorldControllerComponent>(); // Corvax
         _loadedQuery = GetEntityQuery<LoadedChunkComponent>(); // Corvax
+        // #Misfits Add - Live-track the replan rate CVar (initial fire + updates).
+        Subs.CVar(_cfg, PerformanceCVars.HTNReplanRate, v => _replanRate = v > 0f ? v : 1f, true);
         SubscribeLocalEvent<HTNComponent, MobStateChangedEvent>(_npc.OnMobStateChange);
         SubscribeLocalEvent<HTNComponent, MapInitEvent>(_npc.OnNPCMapInit);
         SubscribeLocalEvent<HTNComponent, PlayerAttachedEvent>(_npc.OnPlayerNPCAttach);
@@ -168,7 +174,9 @@ public sealed class HTNSystem : EntitySystem
         _planQueue.Process();
 
         // Limit update rate
-        const float updatePeriod = 1/ReplanRate;
+        // #Misfits Tweak - Was `const float updatePeriod = 1/ReplanRate;` when ReplanRate
+        // was a const. Now computed per-call from the CVar-driven field.
+        var updatePeriod = 1f / _replanRate;
         Accumulator += frameTime;
         if (Accumulator < updatePeriod)
             return;

--- a/Content.Server/Salvage/SalvageSystem.Runner.cs
+++ b/Content.Server/Salvage/SalvageSystem.Runner.cs
@@ -131,9 +131,44 @@ public sealed partial class SalvageSystem
         QueueDel(ev.FromMapUid.Value);
     }
 
+    // #Misfits Add - Reused scratch buffers for the auto-FTL shuttle index.
+    // Built lazily at most once per UpdateRunner call when any expedition hits its
+    // FTL window; scales with (expeditions × shuttles) before, (shuttles) after.
+    private readonly Dictionary<EntityUid, List<(EntityUid Uid, ShuttleComponent Shuttle, TransformComponent Xform)>> _shuttlesByMap = new();
+    private bool _shuttleIndexBuilt;
+
+    // #Misfits Add - Snapshot every ShuttleComponent keyed by its map uid.
+    // Called at most once per UpdateRunner tick, and only when a shuttle FTL is actually needed.
+    private void BuildShuttleIndex()
+    {
+        foreach (var list in _shuttlesByMap.Values)
+            list.Clear();
+
+        var shuttleQuery = AllEntityQuery<ShuttleComponent, TransformComponent>();
+        while (shuttleQuery.MoveNext(out var shuttleUid, out var shuttle, out var shuttleXform))
+        {
+            if (shuttleXform.MapUid is not { } mapUid)
+                continue;
+
+            if (!_shuttlesByMap.TryGetValue(mapUid, out var list))
+            {
+                list = new List<(EntityUid, ShuttleComponent, TransformComponent)>();
+                _shuttlesByMap[mapUid] = list;
+            }
+
+            list.Add((shuttleUid, shuttle, shuttleXform));
+        }
+
+        _shuttleIndexBuilt = true;
+    }
+
     // Runs the expedition
     private void UpdateRunner()
     {
+        // #Misfits Tweak - Reset lazy shuttle-index flag each tick; we only pay to build it
+        // if at least one expedition is actually in its FTL window.
+        _shuttleIndexBuilt = false;
+
         // Generic missions
         var query = EntityQueryEnumerator<SalvageExpeditionComponent>();
 
@@ -179,15 +214,22 @@ public sealed partial class SalvageSystem
                 }
 
                 ftlTime = MathF.Min(ftlTime, _shuttle.DefaultStartupTime);
-                var shuttleQuery = AllEntityQuery<ShuttleComponent, TransformComponent>();
 
-                if (TryComp<StationDataComponent>(comp.Station, out var data))
+                // #Misfits Tweak - Build the map→shuttles index at most once per tick
+                // (lazy), then index into it instead of re-enumerating all shuttles per
+                // expedition. Preserves original behaviour: FTL every shuttle on this
+                // expedition's map (that isn't already FTLing) to the station's first grid.
+                if (!_shuttleIndexBuilt)
+                    BuildShuttleIndex();
+
+                if (TryComp<StationDataComponent>(comp.Station, out var data)
+                    && _shuttlesByMap.TryGetValue(uid, out var shuttlesOnMap))
                 {
                     foreach (var member in data.Grids)
                     {
-                        while (shuttleQuery.MoveNext(out var shuttleUid, out var shuttle, out var shuttleXform))
+                        foreach (var (shuttleUid, shuttle, _) in shuttlesOnMap)
                         {
-                            if (shuttleXform.MapUid != uid || HasComp<FTLComponent>(shuttleUid))
+                            if (HasComp<FTLComponent>(shuttleUid))
                                 continue;
 
                             _shuttle.FTLToDock(shuttleUid, shuttle, member, ftlTime);

--- a/Content.Server/_Misfits/Disease/DiseaseSystem.cs
+++ b/Content.Server/_Misfits/Disease/DiseaseSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Body.Components;
 using Content.Server.Chat.Systems;
 using Content.Server.Medical;
 using Content.Server.Temperature.Components;
+using Content.Shared._Misfits.CCVar;
 using Content.Shared._Misfits.Disease;
 using Content.Shared._Misfits.Disease.Components;
 using Content.Shared._Misfits.Disease.Cures;
@@ -18,6 +19,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -31,6 +33,7 @@ namespace Content.Server._Misfits.Disease;
 /// </summary>
 public sealed class DiseaseSystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!; // #Misfits Add - CVar gate
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -44,9 +47,25 @@ public sealed class DiseaseSystem : EntitySystem
     /// <summary>Range in tiles for airborne disease spread.</summary>
     private const float AirborneRange = 3f;
 
+    // #Misfits Add - Performance: throttle the outer tick. Disease TickTime is seconds-scale
+    // per prototype, so running the carrier sweep at 1 Hz is indistinguishable from 30 Hz.
+    private const float UpdateInterval = 1f;
+    private float _updateAccumulator;
+    private bool _enabled;
+
+    // #Misfits Add - Reusable scratch buffers so the per-tick sweep doesn't allocate.
+    // _tickBuffer replaces the per-carrier `new Dictionary(carrier.Diseases)` copy.
+    // _curesBuffer replaces `new List<DiseaseCure>()` in CheckCures.
+    private readonly List<(ProtoId<DiseasePrototype> Id, float AccumulatedTime)> _tickBuffer = new();
+    private readonly List<DiseaseCure> _curesBuffer = new();
+
     public override void Initialize()
     {
         base.Initialize();
+
+        // #Misfits Add - Gate the entire system behind a CVar. Defaults false because no
+        // in-game assets currently produce diseases.
+        Subs.CVar(_cfg, PerformanceCVars.DiseaseEnabled, v => _enabled = v, true);
 
         // When a mask/gas-mask with DiseaseProtection is equipped, mark it active
         SubscribeLocalEvent<DiseaseProtectionComponent, GotEquippedEvent>(OnProtectionEquipped);
@@ -57,13 +76,23 @@ public sealed class DiseaseSystem : EntitySystem
     {
         base.Update(frameTime);
 
+        // #Misfits Add - CVar kill switch. Skips the entire per-carrier sweep when disabled.
+        if (!_enabled)
+            return;
+
+        // #Misfits Add - Throttle: run the carrier sweep once per UpdateInterval seconds.
+        _updateAccumulator += frameTime;
+        if (_updateAccumulator < UpdateInterval)
+            return;
+        var elapsed = _updateAccumulator;
+        _updateAccumulator = 0f;
+
         var query = EntityQueryEnumerator<DiseaseCarrierComponent>();
         while (query.MoveNext(out var uid, out var carrier))
         {
-            // Skip dead entities
-            if (TryComp<MobStateComponent>(uid, out var mobState) && _mobState.IsDead(uid, mobState))
-                continue;
-
+            // #Misfits Tweak - Hoisted the empty-carrier short-circuit above the MobState
+            // check and BEFORE any allocation. Uninfected carriers now cost a single
+            // dictionary count lookup + a deferred component remove.
             if (carrier.Diseases.Count == 0)
             {
                 // No active diseases — remove the marker if present
@@ -71,26 +100,37 @@ public sealed class DiseaseSystem : EntitySystem
                 continue;
             }
 
+            // Skip dead entities
+            if (TryComp<MobStateComponent>(uid, out var mobState) && _mobState.IsDead(uid, mobState))
+                continue;
+
             // Ensure marker component is present while sick
             EnsureComp<DiseasedComponent>(uid);
 
-            // Iterate over a snapshot to allow removal during loop
-            foreach (var (diseaseId, accumulatedTime) in new Dictionary<ProtoId<DiseasePrototype>, float>(carrier.Diseases))
+            // #Misfits Tweak - Snapshot into a reused buffer instead of allocating a new
+            // Dictionary every iteration. Mutations to carrier.Diseases during the loop
+            // are still safe because we iterate the buffer, not the live dictionary.
+            _tickBuffer.Clear();
+            foreach (var kv in carrier.Diseases)
+                _tickBuffer.Add((kv.Key, kv.Value));
+
+            foreach (var (diseaseId, accumulatedTime) in _tickBuffer)
             {
                 if (!_proto.TryIndex(diseaseId, out var disease))
                     continue;
 
-                // Advance the per-disease tick accumulator
+                // #Misfits Tweak - Use elapsed (time since last sweep) rather than
+                // frameTime, since the sweep is now throttled.
                 if (!carrier.Accumulators.TryGetValue(diseaseId, out var tickAcc))
                     tickAcc = 0f;
 
-                tickAcc += frameTime;
+                tickAcc += elapsed;
 
                 if (tickAcc < disease.TickTime)
                 {
                     carrier.Accumulators[diseaseId] = tickAcc;
                     // Still advance total accumulated time for JustWaitCure
-                    carrier.Diseases[diseaseId] = accumulatedTime + frameTime;
+                    carrier.Diseases[diseaseId] = accumulatedTime + elapsed;
                     Dirty(uid, carrier);
                     continue;
                 }
@@ -171,19 +211,20 @@ public sealed class DiseaseSystem : EntitySystem
     /// </summary>
     private bool CheckCures(EntityUid uid, DiseasePrototype disease, int stage)
     {
-        var relevantCures = new List<DiseaseCure>();
+        // #Misfits Tweak - Reuse a cached buffer so the cure check doesn't allocate per tick.
+        _curesBuffer.Clear();
         foreach (var cure in disease.Cures)
         {
             if (cure.Stages.Count > 0 && !cure.Stages.Contains(stage))
                 continue;
-            relevantCures.Add(cure);
+            _curesBuffer.Add(cure);
         }
 
-        if (relevantCures.Count == 0)
+        if (_curesBuffer.Count == 0)
             return false;
 
         var args = new DiseaseEffectArgs(uid, disease, EntityManager);
-        foreach (var cure in relevantCures)
+        foreach (var cure in _curesBuffer)
         {
             // #Misfits Fix - Server-only cures handled inline because their
             // dependencies (TemperatureComponent, BloodstreamComponent) are server-only.

--- a/Content.Server/_Misfits/FactionWar/FactionWarSystem.cs
+++ b/Content.Server/_Misfits/FactionWar/FactionWarSystem.cs
@@ -93,6 +93,12 @@ public sealed class FactionWarSystem : EntitySystem
     private float _warUpdateAccumulator;
     private const float WarUpdateInterval = 1.0f;
 
+    // #Misfits Add - Scratch buffers reused by Update() for pending-activation and auto-expiry
+    // scans. These were per-tick allocations; keeping them resident eliminates steady-state
+    // GC pressure on the 1 Hz war sweep.
+    private readonly List<FactionWarEntry> _activatedScratch = new();
+    private readonly List<FactionWarEntry> _expiredScratch = new();
+
     /// <summary>
     /// Sessions that currently have the /war panel open.
     /// Panel data is only sent to these sessions on state change, avoiding O(N) broadcasts.
@@ -176,7 +182,9 @@ public sealed class FactionWarSystem : EntitySystem
         // ── Pending → Active transitions ──────────────────────────────
         if (_warActivationTimes.Count > 0)
         {
-            var activated = new List<FactionWarEntry>();
+            // #Misfits Tweak - Reused scratch buffer; cleared here each sweep.
+            var activated = _activatedScratch;
+            activated.Clear();
 
             foreach (var war in _activeWars)
             {
@@ -222,7 +230,9 @@ public sealed class FactionWarSystem : EntitySystem
         // #Misfits Add - End wars that have exceeded WarMaxDuration.
         if (_warAutoEndTimes.Count > 0)
         {
-            var expired = new List<FactionWarEntry>();
+            // #Misfits Tweak - Reused scratch buffer; cleared here each sweep.
+            var expired = _expiredScratch;
+            expired.Clear();
 
             foreach (var war in _activeWars)
             {

--- a/Content.Server/_Misfits/Medical/ResuscitationSystem.cs
+++ b/Content.Server/_Misfits/Medical/ResuscitationSystem.cs
@@ -61,41 +61,93 @@ public sealed class ResuscitationSystem : EntitySystem
             return default;
 
         if (_rotting.IsRotten(target))
-            return new ResuscitationResult(false, true, false);
+            return new ResuscitationResult(false, true, false, false);
 
-        var revived = false;
-        if (_mobState.IsDead(target, mobState))
-            _damageable.TryChangeDamage(target, reviveHeal, true, origin: source);
+        // Only dead targets are subject to the consent flow. If they aren't dead there's
+        // nothing to revive here (callers gate on CanResuscitate, but stay defensive).
+        if (!_mobState.IsDead(target, mobState))
+            return new ResuscitationResult(false, false, false, false);
 
-        if (_mobThreshold.TryGetThresholdForState(target, MobState.Dead, out var threshold) &&
-            TryComp<DamageableComponent>(target, out var damageableComponent) &&
-            damageableComponent.TotalDamage < threshold)
-        {
-            _mobState.ChangeMobState(target, MobState.Critical, mobState, user);
-            revived = true;
-
-            if (!string.IsNullOrWhiteSpace(reviveDoKey))
-            {
-                _chat.TrySendInGameDoMessage(target,
-                    Loc.GetString(reviveDoKey, ("target", target)),
-                    ChatTransmitRange.Normal,
-                    hideLog: true,
-                    ignoreActionBlocker: true);
-            }
-        }
-
+        // Look up the ghost's session.
         ICommonSession? session = null;
-        if (_mind.TryGetMind(target, out _, out var mind) &&
-            mind.Session is { } playerSession)
+        MindComponent? mindComp = null;
+        if (_mind.TryGetMind(target, out _, out var mind) && mind.Session is { } playerSession)
         {
             session = playerSession;
-
-            if (mind.CurrentEntity != target)
-                _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind), session);
+            mindComp = mind;
         }
 
-        return new ResuscitationResult(revived, false, session != null);
+        // No active session (SSD / disconnected) → cannot consent, do not revive.
+        // The caller's "no mind" feedback message still plays via HasMindSession=false.
+        if (session == null || mindComp == null)
+            return new ResuscitationResult(false, false, false, false);
+
+        // Mind is still attached to the body (player hasn't ghosted yet) → revive directly,
+        // no prompt needed since they're already "there".
+        if (mindComp.CurrentEntity == target)
+        {
+            var revivedNow = PerformRevive(source, target, user, reviveHeal, reviveDoKey, mobState, thresholds);
+            return new ResuscitationResult(revivedNow, false, true, false);
+        }
+
+        // Mind is ghosted → ask first. Heal + state change only run if the player accepts.
+        // Capture locals so the closure has stable references.
+        var sourceCopy = source;
+        var targetCopy = target;
+        var userCopy = user;
+        var healCopy = reviveHeal;
+        var keyCopy = reviveDoKey;
+        _euiManager.OpenEui(new ReturnToBodyEui(mindComp, _mind, () =>
+        {
+            // Re-validate at acceptance time — target may have been deleted, rotted,
+            // or already revived by another medic between prompt and acceptance.
+            if (Deleted(targetCopy) || _rotting.IsRotten(targetCopy))
+                return;
+            if (!TryComp<MobStateComponent>(targetCopy, out var ms) ||
+                !TryComp<MobThresholdsComponent>(targetCopy, out var th))
+                return;
+            if (!_mobState.IsDead(targetCopy, ms))
+                return;
+
+            PerformRevive(sourceCopy, targetCopy, userCopy, healCopy, keyCopy, ms, th);
+        }), session);
+
+        return new ResuscitationResult(false, false, true, true);
+    }
+
+    // #Misfits Add - Centralised heal + state transition. Called either immediately
+    // (mind in body) or from the ReturnToBodyEui accept callback (mind ghosted).
+    private bool PerformRevive(
+        EntityUid source,
+        EntityUid target,
+        EntityUid user,
+        DamageSpecifier reviveHeal,
+        string? reviveDoKey,
+        MobStateComponent mobState,
+        MobThresholdsComponent thresholds)
+    {
+        _damageable.TryChangeDamage(target, reviveHeal, true, origin: source);
+
+        if (!_mobThreshold.TryGetThresholdForState(target, MobState.Dead, out var threshold) ||
+            !TryComp<DamageableComponent>(target, out var damageableComponent) ||
+            damageableComponent.TotalDamage >= threshold)
+            return false;
+
+        _mobState.ChangeMobState(target, MobState.Critical, mobState, user);
+
+        if (!string.IsNullOrWhiteSpace(reviveDoKey))
+        {
+            _chat.TrySendInGameDoMessage(target,
+                Loc.GetString(reviveDoKey, ("target", target)),
+                ChatTransmitRange.Normal,
+                hideLog: true,
+                ignoreActionBlocker: true);
+        }
+
+        return true;
     }
 }
 
-public readonly record struct ResuscitationResult(bool Revived, bool Rotten, bool HasMindSession);
+// #Misfits Tweak - Added PromptSent so callers can distinguish "asked the player,
+// awaiting decision" from a hard failure and play an appropriate sound/message.
+public readonly record struct ResuscitationResult(bool Revived, bool Rotten, bool HasMindSession, bool PromptSent);

--- a/Content.Server/_Misfits/PipBoy/PipBoyHubCartridgeSystem.cs
+++ b/Content.Server/_Misfits/PipBoy/PipBoyHubCartridgeSystem.cs
@@ -39,6 +39,20 @@ public sealed class PipBoyHubCartridgeSystem : EntitySystem
     private const int MaxWaypointLabelLength = 32;
     private const int NotificationMaxLength = 64; // #Misfits Add - max length for notification body text
 
+    // #Misfits Add - Shared empty sentinels for UpdateUI's locked/no-card placeholder paths.
+    // These replace ten per-call `new List/Dictionary` allocations that were executed on every
+    // PipBoy UI refresh (roughly once per second per active user). They are never mutated —
+    // the unlocked path reassigns the local variables to live collections returned from the
+    // network system. With ~150 concurrent users this eliminates ~1500 allocations/sec.
+    private static readonly Dictionary<uint, PipBoyContact> EmptyContacts = new();
+    private static readonly List<PipBoyTrackedLocation> EmptyTrackedLocations = new();
+    private static readonly List<PipBoyGroupInfo> EmptyGroups = new();
+    private static readonly List<PipBoyGroupMessage> EmptyGroupMessages = new();
+    private static readonly List<PipBoyWaypoint> EmptyWaypoints = new();
+    private static readonly List<PipBoyDirectoryEntry> EmptyDirectory = new();
+    private static readonly List<PipBoySosAlert> EmptySosAlerts = new();
+    private static readonly List<PipBoyDeadDrop> EmptyDeadDrops = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -606,17 +620,20 @@ public sealed class PipBoyHubCartridgeSystem : EntitySystem
         var hasPassword = false;
         var isLocked = false;
         var isVisible = true;
-        var contacts = new Dictionary<uint, PipBoyContact>();
-        var contactLocs = new List<PipBoyTrackedLocation>();
-        var groups = new List<PipBoyGroupInfo>();
-        var groupMessages = new List<PipBoyGroupMessage>();
-        var groupLocs = new List<PipBoyTrackedLocation>();
-        var groupWaypoints = new List<PipBoyWaypoint>();
-        var directory = new List<PipBoyDirectoryEntry>();
-        var sosAlerts = new List<PipBoySosAlert>();
+        // #Misfits Tweak - Start with shared empty sentinels; each field is reassigned to a
+        // live collection in the unlocked-card path. This avoids ten `new` allocations per
+        // UI refresh (see Empty* sentinel block above).
+        Dictionary<uint, PipBoyContact> contacts = EmptyContacts;
+        List<PipBoyTrackedLocation> contactLocs = EmptyTrackedLocations;
+        List<PipBoyGroupInfo> groups = EmptyGroups;
+        List<PipBoyGroupMessage> groupMessages = EmptyGroupMessages;
+        List<PipBoyTrackedLocation> groupLocs = EmptyTrackedLocations;
+        List<PipBoyWaypoint> groupWaypoints = EmptyWaypoints;
+        List<PipBoyDirectoryEntry> directory = EmptyDirectory;
+        List<PipBoySosAlert> sosAlerts = EmptySosAlerts;
         var presenceStatus = PipBoyPresenceStatus.Available;
         string? statusMessage = null;
-        var nearbyDeadDrops = new List<PipBoyDeadDrop>();
+        List<PipBoyDeadDrop> nearbyDeadDrops = EmptyDeadDrops;
         var hasRadioConnection = false;
 
         if (ent.Comp.Card != null &&

--- a/Content.Server/_Misfits/WastelandMap/WastelandMapSystem.cs
+++ b/Content.Server/_Misfits/WastelandMap/WastelandMapSystem.cs
@@ -35,6 +35,16 @@ public sealed class WastelandMapSystem : EntitySystem
     private float _updateAccumulator;
     private readonly Dictionary<(MapId MapId, WastelandMapTacticalFeedKind Feed), List<WastelandMapAnnotation>> _sharedFeedAnnotations = new();
 
+    // #Misfits Add - Scratch buffers + tick-local cache for BuildState.
+    // At 150 pop with many open wasteland maps, the 2.5s sweep was the single hottest user-
+    // facing UI allocator. These buffers are reused per Update sweep; the _nonActorCache
+    // holds faction/tribal blips keyed by (mapId, feed) so multiple map entities with the
+    // same feed only pay for one world-scan per sweep.
+    private readonly List<WastelandMapTrackedBlip> _blipScratch = new();
+    private readonly List<WastelandMapTrackedBlip> _groupScratch = new();
+    private readonly Dictionary<(MapId MapId, WastelandMapTacticalFeedKind Feed), WastelandMapTrackedBlip[]> _nonActorCache = new();
+    private bool _inUpdateSweep;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -54,23 +64,35 @@ public sealed class WastelandMapSystem : EntitySystem
 
         _updateAccumulator = 0f;
 
-        var query = EntityQueryEnumerator<WastelandMapComponent, UserInterfaceComponent, TransformComponent>();
-        while (query.MoveNext(out var uid, out var map, out var ui, out var xform))
+        // #Misfits Add - Open a sweep window so BuildState can cache the non-actor blip
+        // portion per (mapId, feed) across multiple map entities on this tick.
+        _nonActorCache.Clear();
+        _inUpdateSweep = true;
+        try
         {
-            // #Misfits Fix: Skip the expensive BUI rebuild when nobody has this map open.
-            // GetActors() is O(1) with the early-out; the rebuild + GetIdCardBlips world-scan is O(all id cards).
-            var viewerMap = xform.MapID;
-            EntityUid? firstActor = null;
-            foreach (var actor in _uiSystem.GetActors((uid, ui), WastelandMapUiKey.Key))
+            var query = EntityQueryEnumerator<WastelandMapComponent, UserInterfaceComponent, TransformComponent>();
+            while (query.MoveNext(out var uid, out var map, out var ui, out var xform))
             {
-                viewerMap = Transform(actor).MapID;
-                firstActor = actor; // #Misfits Add - pass actor so group blips are relative to who holds the map
-                break;
-            }
-            if (firstActor == null)
-                continue;
+                // #Misfits Fix: Skip the expensive BUI rebuild when nobody has this map open.
+                // GetActors() is O(1) with the early-out; the rebuild + GetIdCardBlips world-scan is O(all id cards).
+                var viewerMap = xform.MapID;
+                EntityUid? firstActor = null;
+                foreach (var actor in _uiSystem.GetActors((uid, ui), WastelandMapUiKey.Key))
+                {
+                    viewerMap = Transform(actor).MapID;
+                    firstActor = actor; // #Misfits Add - pass actor so group blips are relative to who holds the map
+                    break;
+                }
+                if (firstActor == null)
+                    continue;
 
-            _uiSystem.SetUiState((uid, ui), WastelandMapUiKey.Key, BuildState(map, viewerMap, actor: firstActor));
+                _uiSystem.SetUiState((uid, ui), WastelandMapUiKey.Key, BuildState(map, viewerMap, actor: firstActor));
+            }
+        }
+        finally
+        {
+            _inUpdateSweep = false;
+            _nonActorCache.Clear();
         }
     }
 
@@ -231,36 +253,74 @@ public sealed class WastelandMapSystem : EntitySystem
     // #Misfits Add - actor param enables group-member blip injection
     private WastelandMapTrackedBlip[] GetTrackedBlips(WastelandMapTacticalFeedKind feed, MapId mapId, Box2 bounds, EntityUid? actor = null)
     {
-        var blips = new List<WastelandMapTrackedBlip>();
-
-        var factionBlips = feed switch
+        // #Misfits Tweak - Cache the non-actor (faction + tribal) portion per (mapId, feed)
+        // for the lifetime of a single Update sweep, so multiple open maps sharing a feed
+        // pay for one world-scan instead of N. Outside the sweep this falls back to a
+        // direct rebuild (e.g. OnAfterOpen, annotation messages).
+        WastelandMapTrackedBlip[] nonActorBlips;
+        var cacheKey = (mapId, feed);
+        if (_inUpdateSweep && _nonActorCache.TryGetValue(cacheKey, out var cached))
         {
-            WastelandMapTacticalFeedKind.Brotherhood => GetIdCardBlips(mapId, bounds, "IdCardBrotherhood"),
-            WastelandMapTacticalFeedKind.Vault => GetIdCardBlips(mapId, bounds, "IdCardVault"),
-            WastelandMapTacticalFeedKind.NCR => GetIdCardBlips(mapId, bounds, "IdCardNCR"),
-            WastelandMapTacticalFeedKind.Enclave => GetIdCardBlips(mapId, bounds, "IdCardEnclave"), // #Misfits Change
-            WastelandMapTacticalFeedKind.Legion => GetIdCardBlips(mapId, bounds, "IdCardLegion"), // #Misfits Add - Legion tactical feed
-            _ => [],
-        };
+            nonActorBlips = cached;
+        }
+        else
+        {
+            _blipScratch.Clear();
+            AppendFactionBlips(_blipScratch, feed, mapId, bounds);
+            AppendTribalHuntTargetBlips(_blipScratch, mapId, bounds);
+            nonActorBlips = _blipScratch.ToArray();
+            if (_inUpdateSweep)
+                _nonActorCache[cacheKey] = nonActorBlips;
+        }
 
-        blips.AddRange(factionBlips);
-        blips.AddRange(GetTribalHuntTargetBlips(mapId, bounds));
-
-        // #Misfits Add - inject group member blips if the map carrier is in a group
+        // Group blips are per-actor and therefore never cached across viewers.
         if (actor.HasValue)
-            blips.AddRange(GetGroupMemberBlips(actor.Value, mapId, bounds));
+        {
+            _groupScratch.Clear();
+            AppendGroupMemberBlips(_groupScratch, actor.Value, mapId, bounds);
+            if (_groupScratch.Count == 0)
+                return nonActorBlips;
 
-        return blips.ToArray();
+            var combined = new WastelandMapTrackedBlip[nonActorBlips.Length + _groupScratch.Count];
+            nonActorBlips.CopyTo(combined, 0);
+            for (var i = 0; i < _groupScratch.Count; i++)
+                combined[nonActorBlips.Length + i] = _groupScratch[i];
+            return combined;
+        }
+
+        return nonActorBlips;
     }
 
-    /// <summary>Returns a blip for each group member on the same map as the actor, excluding the actor themselves.</summary>
-    private WastelandMapTrackedBlip[] GetGroupMemberBlips(EntityUid actor, MapId mapId, Box2 bounds)
+    // #Misfits Add - Append the faction blip set for this feed into the supplied buffer.
+    private void AppendFactionBlips(List<WastelandMapTrackedBlip> buffer, WastelandMapTacticalFeedKind feed, MapId mapId, Box2 bounds)
+    {
+        switch (feed)
+        {
+            case WastelandMapTacticalFeedKind.Brotherhood:
+                AppendIdCardBlips(buffer, mapId, bounds, "IdCardBrotherhood");
+                break;
+            case WastelandMapTacticalFeedKind.Vault:
+                AppendIdCardBlips(buffer, mapId, bounds, "IdCardVault");
+                break;
+            case WastelandMapTacticalFeedKind.NCR:
+                AppendIdCardBlips(buffer, mapId, bounds, "IdCardNCR");
+                break;
+            case WastelandMapTacticalFeedKind.Enclave:
+                AppendIdCardBlips(buffer, mapId, bounds, "IdCardEnclave");
+                break;
+            case WastelandMapTacticalFeedKind.Legion:
+                AppendIdCardBlips(buffer, mapId, bounds, "IdCardLegion");
+                break;
+        }
+    }
+
+    /// <summary>Appends a blip for each group member on the same map as the actor, excluding the actor themselves.</summary>
+    private void AppendGroupMemberBlips(List<WastelandMapTrackedBlip> buffer, EntityUid actor, MapId mapId, Box2 bounds)
     {
         var members = _groupSystem.GetGroupMemberEntities(actor);
         if (members == null || members.Count == 0)
-            return [];
+            return;
 
-        var blips = new List<WastelandMapTrackedBlip>(members.Count);
         foreach (var member in members)
         {
             if (member == actor)
@@ -275,15 +335,12 @@ public sealed class WastelandMapSystem : EntitySystem
                 continue;
 
             var label = Name(member);
-            blips.Add(new WastelandMapTrackedBlip(pos.X, pos.Y, label, WastelandMapTrackedBlipKind.PipBoyGroupMember));
+            buffer.Add(new WastelandMapTrackedBlip(pos.X, pos.Y, label, WastelandMapTrackedBlipKind.PipBoyGroupMember));
         }
-
-        return blips.ToArray();
     }
 
-    private WastelandMapTrackedBlip[] GetTribalHuntTargetBlips(MapId mapId, Box2 bounds)
+    private void AppendTribalHuntTargetBlips(List<WastelandMapTrackedBlip> buffer, MapId mapId, Box2 bounds)
     {
-        var blips = new List<WastelandMapTrackedBlip>();
         var query = EntityQueryEnumerator<LegendaryCreatureComponent, TransformComponent>();
 
         while (query.MoveNext(out var uid, out var legendary, out var xform))
@@ -303,19 +360,16 @@ public sealed class WastelandMapSystem : EntitySystem
                 ? "Legendary Target"
                 : $"Legendary {legendary.CreatureName}";
 
-            blips.Add(new WastelandMapTrackedBlip(
+            buffer.Add(new WastelandMapTrackedBlip(
                 pos.X,
                 pos.Y,
                 label,
                 WastelandMapTrackedBlipKind.TribalHuntTarget));
         }
-
-        return blips.ToArray();
     }
 
-    private WastelandMapTrackedBlip[] GetIdCardBlips(MapId mapId, Box2 bounds, string requiredTag)
+    private void AppendIdCardBlips(List<WastelandMapTrackedBlip> buffer, MapId mapId, Box2 bounds, string requiredTag)
     {
-        var blips = new List<WastelandMapTrackedBlip>();
         var query = EntityQueryEnumerator<PresetIdCardComponent, IdCardComponent, TransformComponent>();
 
         while (query.MoveNext(out var uid, out var presetId, out var idCard, out var xform))
@@ -335,10 +389,8 @@ public sealed class WastelandMapSystem : EntitySystem
 
             var label = GetHolotagLabel(idCard, presetId);
             var kind = GetHolotagKind(idCard, presetId, meta);
-            blips.Add(new WastelandMapTrackedBlip(pos.X, pos.Y, label, kind));
+            buffer.Add(new WastelandMapTrackedBlip(pos.X, pos.Y, label, kind));
         }
-
-        return blips.ToArray();
     }
 
     private static string GetHolotagLabel(IdCardComponent idCard, PresetIdCardComponent presetId)

--- a/Content.Shared/_Misfits/C27/MisfitsC27ArmorSystem.cs
+++ b/Content.Shared/_Misfits/C27/MisfitsC27ArmorSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Humanoid;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory.Events;
 
 namespace Content.Shared._Misfits.C27;
@@ -14,6 +15,25 @@ public sealed class MisfitsC27ArmorSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<MisfitsC27ArmorComponent, BeingEquippedAttemptEvent>(OnEquipAttempt);
+        // #Misfits Add - Present C-27 chassis as synthetic for identity purposes. Mirrors
+        // SharedBorgSystem.OnTryGetIdentityShortInfo: when a C-27 is seen without ID, use the
+        // entity name (e.g. "c-27 humanoid robot") instead of the default "old person" fallback.
+        SubscribeLocalEvent<TryGetIdentityShortInfoEvent>(OnTryGetIdentityShortInfo);
+    }
+
+    private void OnTryGetIdentityShortInfo(TryGetIdentityShortInfoEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!TryComp<HumanoidAppearanceComponent>(args.ForActor, out var humanoid))
+            return;
+
+        if (humanoid.Species != "C27" && humanoid.Species != "C27NCR" && humanoid.Species != "C27BoS")
+            return;
+
+        args.Title = Name(args.ForActor).Trim();
+        args.Handled = true;
     }
 
     private void OnEquipAttempt(Entity<MisfitsC27ArmorComponent> item, ref BeingEquippedAttemptEvent args)

--- a/Content.Shared/_Misfits/CCVar/CCVars.Performance.cs
+++ b/Content.Shared/_Misfits/CCVar/CCVars.Performance.cs
@@ -61,4 +61,24 @@ public sealed class PerformanceCVars : CVars
     // #Misfits Add - CVar to disable all respiratory suffocation
     public static readonly CVarDef<bool> Suffocation =
         CVarDef.Create("misfits.suffocation", false, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Whether the Misfits disease system processes ticks. When false,
+    /// <c>DiseaseSystem.Update()</c> returns immediately — no per-carrier iteration,
+    /// no stage progression, no airborne spread. Defaults to false because no
+    /// in-game assets currently produce diseases; re-enable if disease content is added.
+    /// </summary>
+    // #Misfits Add - CVar to disable the disease tick system entirely
+    public static readonly CVarDef<bool> DiseaseEnabled =
+        CVarDef.Create("misfits.disease.enabled", false, CVar.SERVERONLY);
+
+    /// <summary>
+    /// How many times per second the HTN planner evaluates NPC plans.
+    /// Upstream default is 5 Hz; higher values reduce combat response delay at
+    /// the cost of CPU. At 150+ pop on constrained VPS hardware, 5 Hz is the
+    /// safer baseline — raise only if NPC reaction time becomes a complaint.
+    /// </summary>
+    // #Misfits Add - CVar gate for HTN replan rate (was const 7f, reverted to 5f default)
+    public static readonly CVarDef<float> HTNReplanRate =
+        CVarDef.Create("misfits.htn_replan_rate", 5f, CVar.SERVERONLY);
 }

--- a/Content.Shared/_Misfits/FactionWar/FactionWarMessages.cs
+++ b/Content.Shared/_Misfits/FactionWar/FactionWarMessages.cs
@@ -18,6 +18,7 @@ public static class FactionWarConfig
     {
         "NCR", "BrotherhoodOfSteel", "CaesarLegion",
         "Townsfolk", "PlayerRaider",
+        "Enclave", // #Misfits Add - Enclave remnant faction is war-capable.
     };
 
     // #Misfits Add - Major factions that cannot enlist (individually or faction-wide) into
@@ -26,6 +27,7 @@ public static class FactionWarConfig
     public static readonly HashSet<string> MajorFactions = new()
     {
         "NCR", "BrotherhoodOfSteel", "CaesarLegion",
+        "Enclave", // #Misfits Add - Enclave is treated as a major power for cross-faction enlistment rules.
     };
 
     /// <summary>Returns true if the given canonical faction ID is a major faction.</summary>
@@ -57,6 +59,7 @@ public static class FactionWarConfig
         ["CaesarLegion"]       = "Caesar's Legion",
         ["Townsfolk"]          = "Townsfolk",
         ["PlayerRaider"]       = "Raiders",
+        ["Enclave"]            = "Enclave", // #Misfits Add - Enclave display label for war/raid UIs.
     };
 
     /// <summary>

--- a/Content.Shared/_Misfits/RaidRequest/RaidRequestMessages.cs
+++ b/Content.Shared/_Misfits/RaidRequest/RaidRequestMessages.cs
@@ -26,6 +26,7 @@ public static class RaidRequestConfig
         "NCR", "BrotherhoodOfSteel", "CaesarLegion",
         "Townsfolk", "PlayerRaider",
         "Tribal", "Vault", "Followers",
+        "Enclave", // #Misfits Add - Enclave remnant faction may submit faction-tier raid requests.
     };
 
     /// <summary>

--- a/Resources/Locale/en-US/administration/ui/actions.ftl
+++ b/Resources/Locale/en-US/administration/ui/actions.ftl
@@ -5,6 +5,7 @@ admin-player-actions-ban = Ban
 admin-player-actions-ahelp = AHelp
 admin-player-actions-respawn = Respawn
 admin-player-actions-rejuv = Rejuv
+admin-player-actions-logs = Logs
 admin-player-actions-spawn = Spawn here
 admin-player-spawn-failed = Failed to find valid coordinates
 admin-player-actions-player-panel = Open Player Panel

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_armor.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_armor.yml
@@ -12,7 +12,10 @@
 
 - type: entity
   abstract: true
-  parent: ClothingOuterBase
+  # #Misfits Fix - add AllowSuitStorageClothing so the c27 inventory template's suitstorage
+  # slot (gated by dependsOnComponents: AllowSuitStorage) becomes usable while wearing C-27
+  # armor. Mirrors how standard combat armor enables suit storage in upstream armor.yml.
+  parent: [ClothingOuterBase, AllowSuitStorageClothing]
   id: BaseC27Armor
   components:
   - type: MisfitsC27Armor

--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
@@ -13,6 +13,12 @@
   components:
   - type: HumanoidAppearance
     species: C27
+  # #Misfits Fix - Override BaseMobSpecies' default NanoTrasen faction with Wastelander
+  # (same as MobHuman / SuperMutant). Raiders, ghouls (Feral), wastelandanimal, etc. only
+  # target Wastelander — without this C-27 players are invisible to all hostile wasteland NPCs.
+  - type: NpcFactionMember
+    factions:
+    - Wastelander
   - type: Inventory
     templateId: c27
     speciesId: c27

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
@@ -410,6 +410,7 @@
     - N14BPLegionAmmoBox50
     - N14BPLegionAmmo40mmGrenadeIncendiary
     - N14BPLegionAmmoMagazine308RifleLong  # #Misfits Add - .308 Long mag for Bren LMG
+    - N14BPLegionAmmoMagazine308M60Box     # #Misfits Add - .308 50-round box mag for M60 LMG
 
 # =====================================================================
 # BROTHERHOOD OF STEEL BLUEPRINTS

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -2492,5 +2492,21 @@
 
     N14Gunpowder: 15
 
+# #Misfits Add - T4 ammo for M60 LMG (.308 box magazine, 50-round box). Same material cost as Bren mag per design intent.
+- type: latheRecipe
+  id: N14BPLegionAmmoMagazine308M60Box
+  result: Magazine308M60Box
+  category: N14BlueprintLegionAmmoT4
+  completetime: 8
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 2500
+
+    Lead: 25
+
+    N14Gunpowder: 15
+
 
 

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_priestess_of_mars.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/CaesarLegion/legion_priestess_of_mars.yml
@@ -44,6 +44,7 @@
             - CaesarLegion
         - type: ReplacementAccent
           accent: latin
+        - type: CPRTraining # Priestess is a former Auxilia and serves as Legion support officer; retains medical training.
         - type: Warcry
           action: ActionMarsWarcry
           targetDepartment: CaesarLegion

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Decoration/bonfire.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Decoration/bonfire.yml
@@ -107,10 +107,10 @@
     cooldown: 300
     maxMessageLength: 128
     targetDepartment: Tribe
-  - type: ActivatableUI
-    inHandsOnly: false
-    singleUser: true
-    key: enum.SmokeSignalUiKey.Key
+  # #Misfits Fix - No ActivatableUI: left-click must stay as ExtinguishOnInteract.
+  # The "Send Smoke Signal" verb opens the BUI via _ui.OpenUi directly, so ActivatableUI
+  # would collide with ExtinguishOnInteract on ActivateInWorldEvent (UseDelay fires, popup
+  # shows "you start patting the flames", and the BUI closes the same frame it opens).
   - type: UserInterface
     interfaces:
       enum.SmokeSignalUiKey.Key:


### PR DESCRIPTION
:cl: cythisiax

fix: Defib & Salts no longer force chara revive even after hitting [NO]. Consent is needed for revive.
fix: C-27 suitslots function. 
fix: C-27 robots being ignored by all hostile NPCs (raiders, ghouls, feral creatures).
fix: C-27 robots displaying as "old person" when examined without an ID card.
fix: Fixed the smoke signal bonfire closing its window immediately when you clicked it.
fix: Reverted NPC reaction speed to a safer default to reduce server load at high population. 
tweak: POM now has CPR trait
tweak: Loadout items from chara. cust screen now fall back to backpack > loadoutbox if equipment full.
tweak: Added a "Logs" button to the admin AHelp panel that opens the admin log filtered to that player.
tweak: Added a server config option to fully disable the disease system. Disabled now since no diseases exist in-game yet.
tweak: Ghost role slot count updates are now batched to at most once per second instead of spamming on every change.
tweak: Reduced background server memory overhead across several high-traffic systems including PipBoy, wasteland map, faction war.
add: M60 magazine to T4 Legion BP