### PR TITLE
Standardize LMG Spread Based on Fire Rate Tiers

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -351,7 +351,7 @@
   - type: GunRequiresWield
   - type: GunWieldBonus
     minAngle: -21 # Corvax-Change
-    maxAngle: -50 # Corvax-Change
+    maxAngle: -40 # Corvax-Change
   - type: Gun
     minAngle: 24
     maxAngle: 60

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -350,8 +350,8 @@
     wieldedSpeedModifier: 0.8
   - type: GunRequiresWield
   - type: GunWieldBonus
-    minAngle: -21 # Corvax-Change
-    maxAngle: -40 # Corvax-Change
+    minAngle: -21 
+    maxAngle: -40 
   - type: Gun
     minAngle: 24
     maxAngle: 60


### PR DESCRIPTION
## About the PR
Standardized .308 MG accuracy to create a linear trade off between fire rate and precision. The current m60's spread is too large for a weapon with a 3 ROF.

## Why / Balance
Standardizing ensures that for every 0.5 decrease in fire rate, weapons have 5 degree less max spread. This prevents the M60 (ROF 3.0) from being a "junk" weapon, giving it a niche as a high precision persistent MG compared to the Auto Rifle (ROF 4.0).


## Technical details
YML changes


# Changelog
🆑 n44
- tweak: reduced M60's spread

