### PR TITLE
Maple Syrup

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/reagents.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/reagents.ftl
@@ -226,8 +226,11 @@ reagent-desc-bitterdrink = A mixture of crushed plants mixed with water neutrali
 reagent-name-smelling-salts = smelling salts
 reagent-desc-smelling-salts = A grainy mixture of rocks with an insanely potent smell.
 
-reagent-name-mourning-poultice = mournin poultice
+reagent-name-mourning-poultice = mourning poultice
 reagent-desc-mourning-poultice = A mixture of poisonous crushed plants used in tribalistic ceremonies said to make you see gods.
+
+reagent-name-maple-syrup = maple syrup
+reagent-desc-maple-syrup = "Grade A Golden" pure Maple Syrup. A sugary syrup derived from maple trees, eh?
 
 # Medicine
 reagent-name-healing-mixture = stimpak

--- a/Resources/Prototypes/_Nuclear14/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/Consumable/Drink/drinks.yml
@@ -4,13 +4,13 @@
   parent: Milk
   name: reagent-name-milk-brahmin
   desc: reagent-desc-milk-brahmin
-  
+
 - type: reagent
   id: N14MilkBighorner
   parent: Milk
   name: reagent-name-milk-bighorner
   desc: reagent-desc-milk-bighorner
-  
+
 - type: reagent
   id: N14MilkRadstag
   parent: Milk
@@ -148,3 +148,22 @@
         damage:
           groups:
             Burn: -1.5
+
+## Maple Syrup
+- type: reagent
+  id: MapleSyrup
+  name: reagent-name-maple-syrup
+  parent: BaseJuice
+  desc: reagent-desc-maple-syrup
+  physicalDesc: reagent-physical-desc-sticky
+  flavor: sweet
+  color: "#fec108"
+  recognizable: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Sugar
+        amount: 0.4
+      - !type:SatiateThirst
+        factor: 0.5


### PR DESCRIPTION
adds maple syrup as a chemical, sweet, half thirst sating, sugary drink.



## About the PR
added maple syrup to the drinks file in nuclear-14
also fixes spelling error: mournin -> mourning poultice

## Why / Balance
in-game interest in maple syrup existing. opens up options for canadian involvement. no crafting recipe yet. 

## Technical details
added MapleSyrup to drinks.yml in n14 prototypes

## Media
no relevant media

# Changelog
:cl: NajaTheNaja

- add: added maple syrup and an uncraftable, sweet liquid that adds sugar to your bloodstream and sates thirst at .5x rate

- fix: fixed name of mourning poultice to be spelled correctly

