### PR TITLE
This Is the Tenth Circle of Hell.

### DIFF
--- a/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
@@ -289,8 +289,8 @@ undecided-loadout-category-misfits-centurion-armor-ranger-hunter-description =
 
 undecided-loadout-category-corvax-venator-marksman-name = Venator Marksman
 undecided-loadout-category-corvax-venator-marksman-description =
-    Includes an anti-materiel rifle, a rope belt,
-    3 boxes of .50 ammo, night vision goggles,
+    Includes a .308 sniper rifle, a rope belt,
+    2 mags of .308, night vision goggles,
     2 healing powder, 2 K rations,
     a ceramic flask, and mustard.
 

--- a/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
@@ -124,8 +124,8 @@ undecided-loadout-category-ws-grenadier-description =
 
 undecided-loadout-category-ws-sniper-name = Specialist Sniper Kit
 undecided-loadout-category-ws-sniper-description =
-    Includes 1 NCR belt, 1 recon beret, 1 NCR cloak, 1 NCR .50 rifle,
-    1 box of .50 ammo, 1 .45 pistol, 2 .45 pistol magazines,
+    Includes 1 NCR belt, 1 recon beret, 1 NCR cloak, 1 .308 sniper rifle,
+    1 mag of .308, 1 .45 pistol, 2 .45 pistol magazines,
     1 C ration MRE, 1 stimpak, 1 RadAway blood bag, 1 gauze pack, and 1 flare.
 
 undecided-loadout-category-ws-stealth-name = Specialist Infiltrator Kit

--- a/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
@@ -181,11 +181,11 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponSniper50NCRRifle  # #Misfits Change - bolt-action .50 replaces semi-auto AMR; Frumentarii use a slower, precise weapon for covert ops
+      - id: N14WeaponRifle308SniperRifle  # #Misfits Change - bolt-action .50 replaces semi-auto AMR; Frumentarii use a slower, precise weapon for covert ops
       - id: ClothingBeltRope
       # #Misfits Change - AMR magazines removed; bolt-action uses single cartridges from ammo boxes
-      - id: MagazineBox50
-        amount: 3
+      - id: Magazine308RifleSniper
+        amount: 
       - id: ClothingEyesNightVisionGoggles
       - id: N14HealingPoultice #Misfits Change /Tweak/: replaces dirty stimpak, Legion uses tribal medicine
         amount: 2

--- a/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
@@ -185,7 +185,7 @@
       - id: ClothingBeltRope
       # #Misfits Change - AMR magazines removed; bolt-action uses single cartridges from ammo boxes
       - id: Magazine308RifleSniper
-        amount: 
+        amount: 2
       - id: ClothingEyesNightVisionGoggles
       - id: N14HealingPoultice #Misfits Change /Tweak/: replaces dirty stimpak, Legion uses tribal medicine
         amount: 2

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_bos_town.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_bos_town.yml
@@ -17,9 +17,9 @@
   materials:
     Steel: 1000
 
-    Glass: 5
+    Glass: 500
 
-    Circuitry: 5
+    Circuitry: 500
 
 
 # Recharger variants are intentionally excluded from blueprint crafting.
@@ -36,9 +36,9 @@
   materials:
     Steel: 1000
 
-    Glass: 5
+    Glass: 250
 
-    Scrap: 5
+    Scrap: 500
 
 
 - type: latheRecipe
@@ -52,7 +52,7 @@
   materials:
     Steel: 1500
 
-    Scrap: 5
+    Scrap: 50
 
 
 # --- BoS Tier 2 Weapons (Knight energy weapons) ---
@@ -67,11 +67,11 @@
   materials:
     Steel: 3500
 
-    Glass: 15
+    Glass: 350
 
-    Circuitry: 5
+    Circuitry: 250
 
-    Scrap: 15
+    Scrap: 250
 
 
 - type: latheRecipe
@@ -85,11 +85,11 @@
   materials:
     Steel: 3500
 
-    Glass: 15
+    Glass: 450
 
-    Circuitry: 15
+    Circuitry: 350
 
-    Scrap: 5
+    Scrap: 500
 
 
 - type: latheRecipe
@@ -101,13 +101,13 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Steel: 3500
+    Steel: 4500
 
-    Glass: 20
+    Glass: 600
 
-    Circuitry: 15
+    Circuitry: 600
 
-    Plastic: 5
+    Plastic: 500
 
 
 
@@ -123,11 +123,11 @@
   materials:
     Steel: 3000
 
-    Glass: 20
+    Glass: 200
 
-    Circuitry: 15
+    Circuitry: 150
 
-    ScrapElectronic: 5
+    ScrapElectronic: 500
 
 
 - type: latheRecipe
@@ -141,11 +141,11 @@
   materials:
     Steel: 3500
 
-    Glass: 20
+    Glass: 800
 
-    Circuitry: 15
+    Circuitry: 900
 
-    ScrapElectronic: 5
+    ScrapElectronic: 500
 
 
 # --- BoS Tier 3 Weapons (Paladin arsenal) ---
@@ -160,13 +160,13 @@
   materials:
     Steel: 6000
 
-    Glass: 30
+    Glass: 1500
 
-    Circuitry: 30
+    Circuitry: 500
 
-    ScrapElectronic: 15
+    ScrapElectronic: 800
 
-    Plastic: 10
+    Plastic: 1000
 
 
 - type: latheRecipe
@@ -180,11 +180,11 @@
   materials:
     Steel: 6000
 
-    Glass: 30
+    Glass: 3500
 
-    Circuitry: 30
+    Circuitry: 600
 
-    ScrapElectronic: 20
+    ScrapElectronic: 200
 
 
 - type: latheRecipe
@@ -198,13 +198,13 @@
   materials:
     Steel: 6000
 
-    Glass: 35
+    Glass: 4000
 
-    Circuitry: 30
+    Circuitry: 1000
 
-    ScrapElectronic: 20
+    ScrapElectronic: 400
 
-    Plastic: 10
+    Plastic: 1200
 
 
 - type: latheRecipe
@@ -216,13 +216,13 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Steel: 6000
+    Steel: 6500
 
-    Glass: 30
+    Glass: 2300
 
-    Circuitry: 30
+    Circuitry: 1200
 
-    Plastic: 15
+    Plastic: 1500
 
 
 - type: latheRecipe
@@ -236,11 +236,11 @@
   materials:
     Steel: 6000
 
-    Glass: 40
+    Glass: 400
 
-    Circuitry: 30
+    Circuitry: 750
 
-    ScrapElectronic: 15
+    ScrapElectronic: 450
 
 
 - type: latheRecipe
@@ -254,11 +254,11 @@
   materials:
     Steel: 6000
 
-    Glass: 50
+    Glass: 1200
 
-    Circuitry: 30
+    Circuitry: 1000
 
-    ScrapElectronic: 15
+    ScrapElectronic: 550
 
 
 - type: latheRecipe
@@ -270,15 +270,15 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Steel: 6000
+    Steel: 5000
 
-    Glass: 35
+    Glass: 900
 
-    Circuitry: 30
+    Circuitry: 600
 
-    ScrapElectronic: 15
+    ScrapElectronic: 450
 
-    Plastic: 10
+    Plastic: 800
 
 
 # --- BoS Tier 4 Weapons (Elder's vault - pre-war prototypes) ---
@@ -293,13 +293,13 @@
   materials:
     Steel: 10500
 
-    Glass: 70
+    Glass: 700
 
-    Circuitry: 50
+    Circuitry: 1200
 
-    ScrapElectronic: 35
+    ScrapElectronic: 1000
 
-    N14Gold: 5
+    N14Gold: 500
 
 # #Misfits Add - AER-12 recipe at T4; advanced amber-beam laser rifle
 - type: latheRecipe
@@ -313,11 +313,11 @@
   materials:
     Steel: 8000
 
-    Glass: 60
+    Glass: 1600
 
-    Circuitry: 40
+    Circuitry: 1000
 
-    ScrapElectronic: 25
+    ScrapElectronic: 1300
 
 
 # #Misfits Add - Bozar as T4 craftable BoS weapon blueprint; removed from Knight loadout kit
@@ -350,13 +350,13 @@
   materials:
     Steel: 9500
 
-    Glass: 70
+    Glass: 3400
 
-    Circuitry: 55
+    Circuitry: 2500
 
-    ScrapElectronic: 35
+    ScrapElectronic: 1000
 
-    N14Silver: 10
+    N14Silver: 600
 
 # #Misfits Add - AER-15 recipe at T5; highest-damage blue-beam laser rifle
 - type: latheRecipe
@@ -370,13 +370,13 @@
   materials:
     Steel: 12000
 
-    Glass: 80
+    Glass: 2300
 
-    Circuitry: 60
+    Circuitry: 600
 
-    ScrapElectronic: 45
+    ScrapElectronic: 450
 
-    N14Gold: 10
+    N14Gold: 1000
 
 
 - type: latheRecipe
@@ -433,13 +433,13 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Cloth: 5
+    Cloth: 500
 
-    Thread: 5
+    Thread: 500
 
     Steel: 1000
 
-    Leather: 2
+    Leather: 200
 
 
 - type: latheRecipe
@@ -451,13 +451,13 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Cloth: 5
+    Cloth: 500
 
-    Thread: 5
+    Thread: 500
 
     Steel: 1000
 
-    Leather: 2
+    Leather: 200
 
 
 - type: latheRecipe
@@ -469,11 +469,11 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Cloth: 5
+    Cloth: 500
 
-    Thread: 5
+    Thread: 500
 
-    Leather: 2
+    Leather: 200
 
 
 - type: latheRecipe
@@ -487,11 +487,11 @@
   materials:
     Steel: 3500
 
-    Cloth: 15
+    Cloth: 1500
 
-    Thread: 10
+    Thread: 1000
 
-    Leather: 7
+    Leather: 700
 
 
 - type: latheRecipe
@@ -505,11 +505,11 @@
   materials:
     Steel: 3500
 
-    Cloth: 15
+    Cloth: 1500
 
-    Thread: 10
+    Thread: 1000
 
-    Leather: 7
+    Leather: 700
 
 
 - type: latheRecipe
@@ -523,11 +523,11 @@
   materials:
     Steel: 3500
 
-    Cloth: 12
+    Cloth: 1200
 
-    Thread: 10
+    Thread: 1000
 
-    Leather: 7
+    Leather: 700
 
 
 # --- BoS Tier 3 Armor ---
@@ -542,13 +542,13 @@
   materials:
     Steel: 6000
 
-    Cloth: 17
+    Cloth: 1700
 
-    Thread: 15
+    Thread: 1500
 
-    Leather: 12
+    Leather: 1200
 
-    Circuitry: 10
+    Circuitry: 500
 
 
 - type: latheRecipe
@@ -562,13 +562,13 @@
   materials:
     Steel: 6000
 
-    Cloth: 17
+    Cloth: 1700
 
-    Thread: 15
+    Thread: 1500
 
-    Leather: 12
+    Leather: 1200
 
-    Circuitry: 10
+    Circuitry: 500
 
 
 - type: latheRecipe
@@ -582,13 +582,13 @@
   materials:
     Steel: 7000
 
-    Cloth: 20
+    Cloth: 2000
 
-    Thread: 15
+    Thread: 1500
 
-    Leather: 12
+    Leather: 1200
 
-    Circuitry: 10
+    Circuitry: 500
 
 
 - type: latheRecipe
@@ -602,13 +602,13 @@
   materials:
     Steel: 7000
 
-    Cloth: 20
+    Cloth: 2000
 
-    Thread: 15
+    Thread: 1500
 
-    Leather: 12
+    Leather: 1200
 
-    Circuitry: 10
+    Circuitry: 500
 
 
 - type: latheRecipe
@@ -622,13 +622,13 @@
   materials:
     Steel: 6500
 
-    Cloth: 17
+    Cloth: 1700
 
-    Thread: 12
+    Thread: 1200
 
-    Leather: 12
+    Leather: 1200
 
-    Circuitry: 10
+    Circuitry: 1000
 
 
 # --- BoS Tier 4 Armor (Power Armor) ---
@@ -949,7 +949,7 @@
   materials:
     Steel: 2000
 
-    Wood: 10
+    Wood: 1000
 
 
 - type: latheRecipe
@@ -963,7 +963,7 @@
   materials:
     Steel: 2000
 
-    Wood: 10
+    Wood: 1000
 
 
 # --- Town Tier 2 Weapons ---
@@ -978,9 +978,9 @@
   materials:
     Steel: 3500
 
-    N14Iron: 7
+    N14Iron: 700
 
-    Wood: 5
+    Wood: 500
 
 
 - type: latheRecipe
@@ -994,7 +994,7 @@
   materials:
     Steel: 3000
 
-    N14Iron: 7
+    N14Iron: 700
 
 
 - type: latheRecipe
@@ -1008,9 +1008,9 @@
   materials:
     Steel: 4000
 
-    Wood: 25
+    Wood: 2500
 
-    N14Iron: 5
+    N14Iron: 500
 
 
 - type: latheRecipe
@@ -1024,9 +1024,9 @@
   materials:
     Steel: 4000
 
-    Wood: 15
+    Wood: 1500
 
-    N14Iron: 7
+    N14Iron: 700
 
 
 - type: latheRecipe
@@ -1040,9 +1040,9 @@
   materials:
     Steel: 3000
 
-    N14Iron: 7
+    N14Iron: 700
 
-    Leather: 5
+    Leather: 50
 
 
 - type: latheRecipe
@@ -1056,7 +1056,7 @@
   materials:
     Steel: 2500
 
-    Wood: 25
+    Wood: 250
 
 
 - type: latheRecipe
@@ -1070,9 +1070,9 @@
   materials:
     Steel: 3000
 
-    Wood: 20
+    Wood: 200
 
-    N14Iron: 5
+    N14Iron: 500
 
 
 - type: latheRecipe
@@ -1086,9 +1086,9 @@
   materials:
     Steel: 3500
 
-    N14Iron: 7
+    N14Iron: 700
 
-    N14Brass: 5
+    N14Brass: 250
 
 
 - type: latheRecipe
@@ -1102,9 +1102,9 @@
   materials:
     Steel: 3500
 
-    Wood: 25
+    Wood: 550
 
-    N14Iron: 7
+    N14Iron: 700
 
 
 # --- Town Tier 3 Weapons ---
@@ -1119,9 +1119,9 @@
   materials:
     Steel: 6000
 
-    N14Iron: 12
+    N14Iron: 120
 
-    Wood: 15
+    Wood: 150
 
 
 - type: latheRecipe
@@ -1135,9 +1135,9 @@
   materials:
     Steel: 6000
 
-    N14Iron: 12
+    N14Iron: 120
 
-    N14Brass: 10
+    N14Brass: 300
 
 
 - type: latheRecipe
@@ -1151,11 +1151,11 @@
   materials:
     Steel: 5000
 
-    Wood: 15
+    Wood: 1500
 
-    Glass: 15
+    Glass: 150
 
-    N14Iron: 7
+    N14Iron: 700
 
 
 - type: latheRecipe
@@ -1169,9 +1169,9 @@
   materials:
     Steel: 6500
 
-    Wood: 15
+    Wood: 1500
 
-    N14Iron: 12
+    N14Iron: 1200
 
 
 - type: latheRecipe
@@ -1185,9 +1185,9 @@
   materials:
     Steel: 6500
 
-    Wood: 15
+    Wood: 1500
 
-    N14Iron: 12
+    N14Iron: 1200
 
 
 - type: latheRecipe
@@ -1201,9 +1201,9 @@
   materials:
     Steel: 6000
 
-    N14Iron: 12
+    N14Iron: 1200
 
-    N14Brass: 15
+    N14Brass: 150
 
 
 - type: latheRecipe
@@ -1217,9 +1217,9 @@
   materials:
     Steel: 5500
 
-    Wood: 15
+    Wood: 1500
 
-    N14Iron: 7
+    N14Iron: 700
 
 
 - type: latheRecipe
@@ -1233,9 +1233,9 @@
   materials:
     Steel: 5000
 
-    N14Iron: 10
+    N14Iron: 1000
 
-    Scrap: 15
+    Scrap: 1500
 
 
 - type: latheRecipe
@@ -1247,11 +1247,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Steel: 6000
+    Steel: 3000
 
-    Wood: 25
+    Wood: 4500
 
-    N14Iron: 7
+    N14Iron: 1500
 
 
 # --- Town Tier 4 Weapons (best civilian can get - NOT top-tier from any faction) ---
@@ -1266,11 +1266,11 @@
   materials:
     Steel: 9500
 
-    N14Iron: 20
+    N14Iron: 200
 
-    Plastic: 20
+    Plastic: 2000
 
-    N14Brass: 15
+    N14Brass: 150
 
 
 - type: latheRecipe
@@ -1284,9 +1284,9 @@
   materials:
     Steel: 9500
 
-    N14Iron: 20
+    N14Iron: 200
 
-    N14Brass: 20
+    N14Brass: 200
 
 
 - type: latheRecipe
@@ -1300,7 +1300,7 @@
   materials:
     Steel: 9000
 
-    Wood: 45
+    Wood: 450
 
     N14Iron: 12
 
@@ -1316,9 +1316,9 @@
   materials:
     Steel: 9000
 
-    N14Iron: 20
+    N14Iron: 200
 
-    Wood: 25
+    Wood: 250
 
 
 - type: latheRecipe
@@ -1332,9 +1332,9 @@
   materials:
     Steel: 9000
 
-    Wood: 40
+    Wood: 400
 
-    N14Iron: 17
+    N14Iron: 170
 
 
 # =====================================================================
@@ -1351,11 +1351,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Leather: 5
+    Leather: 500
 
-    Cloth: 5
+    Cloth: 500
 
-    Thread: 2
+    Thread: 200
 
 
 - type: latheRecipe
@@ -1367,11 +1367,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Leather: 5
+    Leather: 500
 
-    Cloth: 5
+    Cloth: 500
 
-    Thread: 2
+    Thread: 200
 
 
 - type: latheRecipe
@@ -1383,11 +1383,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Leather: 7
+    Leather: 700
 
-    Cloth: 5
+    Cloth: 500
 
-    Thread: 5
+    Thread: 500
 
 
 # --- Town Tier 2 Armor ---
@@ -1400,11 +1400,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Cloth: 17
+    Cloth: 1700
 
-    Thread: 17
+    Thread: 1700
 
-    Leather: 15
+    Leather: 150
 
     Steel: 2500
 
@@ -1418,11 +1418,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Leather: 17
+    Leather: 170
 
-    Cloth: 17
+    Cloth: 1700
 
-    Thread: 15
+    Thread: 1500
 
     Steel: 2500
 
@@ -1436,11 +1436,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Leather: 17
+    Leather: 1700
 
-    Cloth: 17
+    Cloth: 170
 
-    Thread: 17
+    Thread: 170
 
     Steel: 2000
 
@@ -1454,11 +1454,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Leather: 15
+    Leather: 1500
 
-    Cloth: 10
+    Cloth: 100
 
-    Thread: 10
+    Thread: 100
 
 
 # --- Town Tier 3 Armor ---
@@ -1473,11 +1473,11 @@
   materials:
     Steel: 5000
 
-    Leather: 17
+    Leather: 170
 
-    Cloth: 17
+    Cloth: 1700
 
-    Thread: 15
+    Thread: 1500
 
 
 - type: latheRecipe
@@ -1491,11 +1491,11 @@
   materials:
     Steel: 5000
 
-    Cloth: 17
+    Cloth: 170
 
-    Thread: 15
+    Thread: 150
 
-    Leather: 15
+    Leather: 1500
 
 
 - type: latheRecipe
@@ -1507,13 +1507,13 @@
   availableFaction:
   - Townsfolk
   materials:
-    Leather: 25
+    Leather: 2500
 
     Steel: 4000
 
-    Cloth: 20
+    Cloth: 200
 
-    Thread: 12
+    Thread: 120
 
 
 - type: latheRecipe
@@ -1527,11 +1527,11 @@
   materials:
     Steel: 6000
 
-    N14Iron: 12
+    N14Iron: 1200
 
-    Leather: 7
+    Leather: 70
 
-    Cloth: 7
+    Cloth: 70
 
 
 # --- Town Tier 4 Armor ---
@@ -1544,15 +1544,15 @@
   availableFaction:
   - Townsfolk
   materials:
-    Steel: 10500
+    Steel: 7000
 
-    Cloth: 25
+    Cloth: 2500
 
-    Thread: 17
+    Thread: 1700
 
-    Leather: 17
+    Leather: 1700
 
-    Circuitry: 10
+    Circuitry: 100
 
 
 - type: latheRecipe
@@ -1566,11 +1566,11 @@
   materials:
     Steel: 9500
 
-    Leather: 22
+    Leather: 1200
 
-    Scrap: 40
+    Scrap: 400
 
-    N14Iron: 15
+    N14Iron: 150
 
 
 - type: latheRecipe
@@ -1582,11 +1582,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Leather: 51
+    Leather: 510
 
-    Cloth: 45
+    Cloth: 450
 
-    Thread: 35
+    Thread: 350
 
     Steel: 7000
 
@@ -1912,11 +1912,11 @@
   availableFaction:
   - Townsfolk
   materials:
-    Steel: 7500
+    Steel: 2500
 
     Lead: 65
 
-    N14Gunpowder: 40
+    N14Gunpowder: 400
 
 # =====================================================================
 # #Misfits Add - HELMET RECIPES
@@ -1936,8 +1936,8 @@
   - BrotherhoodOfSteel
   materials:
     Steel: 800
-    Cloth: 5
-    Leather: 3
+    Cloth: 50
+    Leather: 30
 
 # --- BoS Tier 2 Helmets (squire / midwest) ---
 - type: latheRecipe
@@ -1950,9 +1950,9 @@
   - BrotherhoodOfSteel
   materials:
     Steel: 1500
-    Cloth: 6
-    Leather: 4
-    ScrapElectronic: 3
+    Cloth: 60
+    Leather: 40
+    ScrapElectronic: 30
 
 - type: latheRecipe
   id: N14BPBoSArmorHelmetBrotherhoodMidwest
@@ -1964,9 +1964,9 @@
   - BrotherhoodOfSteel
   materials:
     Steel: 1500
-    Cloth: 6
-    Leather: 4
-    ScrapElectronic: 3
+    Cloth: 60
+    Leather: 40
+    ScrapElectronic: 30
 
 # --- BoS Tier 3 Helmets (knight / paladin / midwest veteran) ---
 - type: latheRecipe
@@ -1979,9 +1979,9 @@
   - BrotherhoodOfSteel
   materials:
     Steel: 2500
-    Cloth: 8
-    Leather: 5
-    Circuitry: 4
+    Cloth: 80
+    Leather: 50
+    Circuitry: 40
 
 - type: latheRecipe
   id: N14BPBoSArmorHelmetBrotherhoodPaladin
@@ -1993,9 +1993,9 @@
   - BrotherhoodOfSteel
   materials:
     Steel: 2500
-    Cloth: 8
-    Leather: 5
-    Circuitry: 4
+    Cloth: 80
+    Leather: 50
+    Circuitry: 40
 
 - type: latheRecipe
   id: N14BPBoSArmorHelmetBrotherhoodMK2
@@ -2007,9 +2007,9 @@
   - BrotherhoodOfSteel
   materials:
     Steel: 2800
-    Cloth: 8
-    Leather: 5
-    Circuitry: 5
+    Cloth: 80
+    Leather: 50
+    Circuitry: 50
 
 - type: latheRecipe
   id: N14BPBoSArmorHelmetBrotherhoodMidwestVeteran
@@ -2021,9 +2021,9 @@
   - BrotherhoodOfSteel
   materials:
     Steel: 2800
-    Cloth: 8
-    Leather: 5
-    Circuitry: 5
+    Cloth: 80
+    Leather: 50
+    Circuitry: 50
 
 # #Misfits Removed - user requested no power armor helmet recipes
 # --- BoS Tier 4 Helmets (T-45 power armor) ---
@@ -2052,9 +2052,9 @@
   availableFaction:
   - Townsfolk
   materials:
-    Cloth: 8
-    Leather: 4
-    Thread: 4
+    Cloth: 80
+    Leather: 40
+    Thread: 40
 
 # --- Town Tier 2 Helmets (Brodie / metal) ---
 - type: latheRecipe
@@ -2067,8 +2067,8 @@
   - Townsfolk
   materials:
     Steel: 1000
-    Cloth: 5
-    Leather: 3
+    Cloth: 50
+    Leather: 30
 
 - type: latheRecipe
   id: N14BPTownArmorHelmetMetal
@@ -2080,8 +2080,8 @@
   - Townsfolk
   materials:
     Steel: 1200
-    Cloth: 5
-    Leather: 3
+    Cloth: 50
+    Leather: 30
 
 # --- Town Tier 3 Helmets (riot / sheriff) ---
 - type: latheRecipe
@@ -2094,8 +2094,8 @@
   - Townsfolk
   materials:
     Steel: 1500
-    Cloth: 8
-    Leather: 4
+    Cloth: 80
+    Leather: 40
 
 - type: latheRecipe
   id: N14BPTownArmorHelmetBrodieVisor
@@ -2107,8 +2107,8 @@
   - Townsfolk
   materials:
     Steel: 1800
-    Cloth: 8
-    Leather: 4
+    Cloth: 80
+    Leather: 40
     Glass: 200
 
 - type: latheRecipe
@@ -2121,8 +2121,8 @@
   - Townsfolk
   materials:
     Steel: 2000
-    Cloth: 8
-    Leather: 4
+    Cloth: 80
+    Leather: 40
     Glass: 150
 
 # --- Town Tier 4 Helmets (combat / pre-war military) ---
@@ -2136,8 +2136,8 @@
   - Townsfolk
   materials:
     Steel: 3000
-    Cloth: 10
-    Leather: 5
+    Cloth: 100
+    Leather: 50
     Plastic: 100
 
 - type: latheRecipe
@@ -2150,8 +2150,8 @@
   - Townsfolk
   materials:
     Steel: 3200
-    Cloth: 10
-    Leather: 5
+    Cloth: 100
+    Leather: 50
     Plastic: 100
 
 - type: latheRecipe
@@ -2164,7 +2164,7 @@
   - Townsfolk
   materials:
     Steel: 3000
-    Cloth: 10
-    Leather: 5
+    Cloth: 100
+    Leather: 50
 
 

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -18,7 +18,7 @@
   materials:
     Steel: 1000
 
-    Scrap: 5
+    Scrap: 50
 
 
 - type: latheRecipe
@@ -32,7 +32,7 @@
   materials:
     Steel: 1500
 
-    Scrap: 5
+    Scrap: 50
 
 
 - type: latheRecipe
@@ -46,7 +46,7 @@
   materials:
     Steel: 1000
 
-    Scrap: 5
+    Scrap: 50
 
 
 - type: latheRecipe
@@ -60,7 +60,7 @@
   materials:
     Steel: 1000
 
-    N14Iron: 2
+    N14Iron: 20
 
 
 - type: latheRecipe
@@ -74,7 +74,7 @@
   materials:
     Steel: 1500
 
-    N14Iron: 2
+    N14Iron: 20
 
 
 - type: latheRecipe
@@ -88,7 +88,7 @@
   materials:
     Steel: 2000
 
-    Wood: 10
+    Wood: 1000
 
 
 - type: latheRecipe
@@ -102,7 +102,7 @@
   materials:
     Steel: 2000
 
-    Wood: 10
+    Wood: 1000
 
 
 - type: latheRecipe
@@ -116,7 +116,7 @@
   materials:
     Steel: 2000
 
-    Wood: 10
+    Wood: 1000
 
 
 - type: latheRecipe
@@ -130,7 +130,7 @@
   materials:
     Steel: 1500
 
-    Wood: 10
+    Wood: 1000
 
 
 - type: latheRecipe
@@ -144,7 +144,7 @@
   materials:
     Steel: 1500
 
-    Wood: 10
+    Wood: 1000
 
 
 # --- NCR Tier 2 Weapons (Standard military issue) ---
@@ -159,9 +159,9 @@
   materials:
     Steel: 3000
 
-    N14Iron: 7
+    N14Iron: 700
 
-    Wood: 5
+    Wood: 500
 
 
 - type: latheRecipe
@@ -175,9 +175,9 @@
   materials:
     Steel: 3500
 
-    Wood: 25
+    Wood: 2500
 
-    N14Iron: 5
+    N14Iron: 500
 
 
 - type: latheRecipe
@@ -191,11 +191,11 @@
   materials:
     Steel: 4000
 
-    Wood: 20
+    Wood: 2000
 
-    Glass: 10
+    Glass: 500
 
-    N14Iron: 5
+    N14Iron: 500
 
 
 - type: latheRecipe
@@ -209,9 +209,9 @@
   materials:
     Steel: 4000
 
-    Wood: 15
+    Wood: 1500
 
-    N14Iron: 7
+    N14Iron: 700
 
 
 - type: latheRecipe
@@ -225,9 +225,9 @@
   materials:
     Steel: 3500
 
-    N14Iron: 7
+    N14Iron: 700
 
-    N14Brass: 5
+    N14Brass: 500
 
 
 - type: latheRecipe
@@ -241,9 +241,9 @@
   materials:
     Steel: 3500
 
-    Wood: 15
+    Wood: 1500
 
-    N14Iron: 5
+    N14Iron: 500
 
 
 - type: latheRecipe
@@ -257,9 +257,9 @@
   materials:
     Steel: 3500
 
-    N14Iron: 7
+    N14Iron: 700
 
-    Scrap: 10
+    Scrap: 1000
 
 
 - type: latheRecipe
@@ -271,11 +271,11 @@
   availableFaction:
   - NCR
   materials:
-    Steel: 3500
+    Steel: 4500
 
-    N14Iron: 7
+    N14Iron: 700
 
-    Plastic: 5
+    Plastic: 2500
 
 
 - type: latheRecipe
@@ -289,9 +289,9 @@
   materials:
     Steel: 4000
 
-    Wood: 20
+    Wood: 2000
 
-    N14Iron: 5
+    N14Iron: 500
 
 
 - type: latheRecipe
@@ -305,11 +305,11 @@
   materials:
     Steel: 4000
 
-    Wood: 15
+    Wood: 1500
 
-    Glass: 10
+    Glass: 1000
 
-    N14Iron: 5
+    N14Iron: 500
 
 
 # --- NCR Tier 3 Weapons (Ranger/Veteran grade) ---
@@ -325,11 +325,11 @@
   materials:
     Steel: 6000
 
-    Wood: 25
+    Wood: 1500
 
-    N14Iron: 12
+    N14Iron: 120
 
-    N14Brass: 10
+    N14Brass: 100
 
 
 - type: latheRecipe
@@ -343,11 +343,11 @@
   materials:
     Steel: 6000
 
-    N14Iron: 12
+    N14Iron: 1200
 
-    Plastic: 10
+    Plastic: 1000
 
-    N14Brass: 10
+    N14Brass: 100
 
 
 - type: latheRecipe
@@ -361,9 +361,9 @@
   materials:
     Steel: 6500
 
-    Wood: 15
+    Wood: 1500
 
-    N14Iron: 12
+    N14Iron: 1200
 
 
 - type: latheRecipe
@@ -377,9 +377,9 @@
   materials:
     Steel: 7000
 
-    Wood: 15
+    Wood: 1500
 
-    N14Iron: 12
+    N14Iron: 120
 
 
 - type: latheRecipe
@@ -393,9 +393,9 @@
   materials:
     Steel: 7000
 
-    Wood: 15
+    Wood: 1500
 
-    N14Iron: 12
+    N14Iron: 120
 
 
 - type: latheRecipe
@@ -409,9 +409,9 @@
   materials:
     Steel: 6000
 
-    N14Iron: 12
+    N14Iron: 120
 
-    N14Brass: 15
+    N14Brass: 150
 
 
 - type: latheRecipe
@@ -425,9 +425,9 @@
   materials:
     Steel: 6000
 
-    N14Iron: 15
+    N14Iron: 150
 
-    N14Brass: 15
+    N14Brass: 150
 
 
 - type: latheRecipe
@@ -441,9 +441,9 @@
   materials:
     Steel: 6000
 
-    N14Iron: 12
+    N14Iron: 120
 
-    Wood: 15
+    Wood: 150
 
 
 - type: latheRecipe
@@ -457,9 +457,9 @@
   materials:
     Steel: 6000
 
-    N14Iron: 12
+    N14Iron: 120
 
-    N14Brass: 10
+    N14Brass: 100
 
 
 - type: latheRecipe
@@ -474,11 +474,11 @@
   materials:
     Steel: 6000
 
-    N14Iron: 15
+    N14Iron: 1500
 
-    Wood: 15
+    Wood: 1500
 
-    N14Silver: 10
+    N14Silver: 500
 
 
 - type: latheRecipe
@@ -492,9 +492,9 @@
   materials:
     Steel: 6000
 
-    N14Iron: 12
+    N14Iron: 1200
 
-    N14Brass: 15
+    N14Brass: 1000
 
 
 # --- NCR Tier 4 Weapons (Elite/Heavy) ---
@@ -510,11 +510,11 @@
   materials:
     Steel: 12000
 
-    N14Iron: 30
+    N14Iron: 300
 
-    N14Brass: 30
+    N14Brass: 300
 
-    Glass: 15
+    Glass: 150
 
 
 - type: latheRecipe
@@ -528,11 +528,11 @@
   materials:
     Steel: 11500
 
-    N14Iron: 27
+    N14Iron: 270
 
-    Wood: 25
+    Wood: 2500
 
-    N14Brass: 25
+    N14Brass: 250
 
 
 - type: latheRecipe
@@ -546,11 +546,11 @@
   materials:
     Steel: 11500
 
-    N14Iron: 25
+    N14Iron: 2500
 
-    N14Brass: 25
+    N14Brass: 250
 
-    Plastic: 15
+    Plastic: 1500
 
 
 - type: latheRecipe
@@ -564,11 +564,11 @@
   materials:
     Steel: 10500
 
-    N14Iron: 20
+    N14Iron: 200
 
-    N14Brass: 30
+    N14Brass: 300
 
-    Circuitry: 10
+    Circuitry: 100
 
 
 - type: latheRecipe
@@ -582,9 +582,9 @@
   materials:
     Steel: 10500
 
-    N14Iron: 22
+    N14Iron: 220
 
-    Wood: 30
+    Wood: 300
 
 
 - type: latheRecipe
@@ -598,11 +598,11 @@
   materials:
     Steel: 12000
 
-    N14Iron: 37
+    N14Iron: 370
 
     N14Brass: 45
 
-    Circuitry: 15
+    Circuitry: 150
 
 
 # --- NCR Tier 5 Weapons (Anti-Materiel) ---
@@ -642,11 +642,11 @@
   availableFaction:
   - NCR
   materials:
-    Cloth: 8
+    Cloth: 800
 
-    Thread: 5
+    Thread: 500
 
-    Leather: 5
+    Leather: 500
 
 
 - type: latheRecipe
@@ -658,11 +658,11 @@
   availableFaction:
   - NCR
   materials:
-    Cloth: 8
+    Cloth: 800
 
-    Thread: 5
+    Thread: 500
 
-    Leather: 5
+    Leather: 500
 
 
 - type: latheRecipe
@@ -674,11 +674,11 @@
   availableFaction:
   - NCR
   materials:
-    Cloth: 8
+    Cloth: 800
 
-    Thread: 5
+    Thread: 500
 
-    Leather: 5
+    Leather: 500
 
 
 # --- NCR Tier 2 Armor ---
@@ -693,11 +693,11 @@
   materials:
     Steel: 3000
 
-    Cloth: 15
+    Cloth: 150
 
-    Thread: 12
+    Thread: 120
 
-    Leather: 7
+    Leather: 70
 
 
 - type: latheRecipe
@@ -711,11 +711,11 @@
   materials:
     Steel: 3000
 
-    Cloth: 15
+    Cloth: 150
 
-    Thread: 12
+    Thread: 120
 
-    Leather: 7
+    Leather: 70
 
 
 - type: latheRecipe
@@ -727,11 +727,11 @@
   availableFaction:
   - NCR
   materials:
-    Cloth: 17
+    Cloth: 170
 
-    Thread: 12
+    Thread: 120
 
-    Leather: 7
+    Leather: 70
 
 
 - type: latheRecipe
@@ -743,11 +743,11 @@
   availableFaction:
   - NCR
   materials:
-    Cloth: 17
+    Cloth: 170
 
-    Thread: 12
+    Thread: 120
 
-    Leather: 7
+    Leather: 70
 
 
 - type: latheRecipe
@@ -759,11 +759,11 @@
   availableFaction:
   - NCR
   materials:
-    Cloth: 17
+    Cloth: 170
 
-    Thread: 12
+    Thread: 120
 
-    Leather: 7
+    Leather: 70
 
 
 - type: latheRecipe
@@ -775,11 +775,11 @@
   availableFaction:
   - NCR
   materials:
-    Cloth: 17
+    Cloth: 170
 
-    Thread: 17
+    Thread: 170
 
-    Leather: 12
+    Leather: 120
 
     Steel: 2000
 
@@ -796,11 +796,11 @@
   materials:
     Steel: 6000
 
-    Cloth: 22
+    Cloth: 2200
 
-    Thread: 15
+    Thread: 150
 
-    Leather: 12
+    Leather: 120
 
 
 - type: latheRecipe
@@ -813,11 +813,11 @@
   - NCR
   - Rangers
   materials:
-    Leather: 30
+    Leather: 300
 
-    Cloth: 30
+    Cloth: 300
 
-    Thread: 22
+    Thread: 220
 
     Steel: 4000
 
@@ -832,11 +832,11 @@
   - NCR
   - Rangers
   materials:
-    Leather: 30
+    Leather: 300
 
-    Cloth: 30
+    Cloth: 300
 
-    Thread: 22
+    Thread: 220
 
     Steel: 4500
 
@@ -851,11 +851,11 @@
   - NCR
   - Rangers
   materials:
-    Leather: 25
+    Leather: 250
 
-    Cloth: 25
+    Cloth: 250
 
-    Thread: 17
+    Thread: 170
 
 
 # --- NCR Tier 4 Armor ---
@@ -870,13 +870,13 @@
   materials:
     Steel: 11500
 
-    Cloth: 32
+    Cloth: 320
 
-    Thread: 20
+    Thread: 200
 
-    Leather: 15
+    Leather: 150
 
-    Circuitry: 10
+    Circuitry: 100
 
 
 - type: latheRecipe
@@ -890,13 +890,13 @@
   materials:
     Steel: 12000
 
-    N14Iron: 45
+    N14Iron: 450
 
-    Circuitry: 30
+    Circuitry: 300
 
-    ScrapElectronic: 25
+    ScrapElectronic: 250
 
-    N14Brass: 15
+    N14Brass: 150
 
 
 - type: latheRecipe
@@ -911,13 +911,13 @@
   materials:
     Steel: 12000
 
-    Leather: 30
+    Leather: 300
 
-    Cloth: 22
+    Cloth: 220
 
-    Thread: 17
+    Thread: 170
 
-    Circuitry: 10
+    Circuitry: 100
 
 
 - type: latheRecipe
@@ -932,15 +932,15 @@
   materials:
     Steel: 12000
 
-    Leather: 37
+    Leather: 370
 
-    Cloth: 27
+    Cloth: 270
 
-    Thread: 20
+    Thread: 200
 
-    Circuitry: 15
+    Circuitry: 150
 
-    ScrapElectronic: 10
+    ScrapElectronic: 100
 
 
 - type: latheRecipe
@@ -1334,11 +1334,11 @@
   availableFaction:
   - NCR
   materials:
-    Steel: 8000
+    Steel: 1200
 
-    Lead: 65
+    Lead: 550
 
-    N14Gunpowder: 40
+    N14Gunpowder: 400
 
 
 - type: latheRecipe
@@ -1350,11 +1350,11 @@
   availableFaction:
   - NCR
   materials:
-    Steel: 8500
+    Steel: 1200
 
-    Lead: 65
+    Lead: 650
 
-    N14Gunpowder: 45
+    N14Gunpowder: 450
 
 
 - type: latheRecipe
@@ -1366,11 +1366,11 @@
   availableFaction:
   - NCR
   materials:
-    Steel: 8000
+    Steel: 800
 
-    Lead: 65
+    Lead: 650
 
-    N14Gunpowder: 35
+    N14Gunpowder: 350
 
 
 # =====================================================================
@@ -1387,9 +1387,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    N14Iron: 5
+    N14Iron: 500
 
-    Leather: 2
+    Leather: 200
 
 
 - type: latheRecipe
@@ -1401,9 +1401,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Wood: 10
+    Wood: 1000
 
-    Leather: 2
+    Leather: 200
 
 
 - type: latheRecipe
@@ -1415,9 +1415,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Scrap: 10
+    Scrap: 2000
 
-    ScrapSteel: 5
+    ScrapSteel: 500
 
 
 - type: latheRecipe
@@ -1429,9 +1429,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Wood: 10
+    Wood: 1000
 
-    N14Iron: 2
+    N14Iron: 200
 
 
 - type: latheRecipe
@@ -1443,11 +1443,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Wood: 10
+    Wood: 2500
 
-    N14Iron: 2
+    N14Iron: 1200
 
-    Leather: 2
+    Leather: 200
 
 
 - type: latheRecipe
@@ -1459,11 +1459,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    N14Iron: 5
+    N14Iron: 500
 
-    Scrap: 10
+    Scrap: 100
 
-    Wood: 5
+    Wood: 500
 
 
 # --- Legion Tier 2 Weapons (Legionnaire grade) ---
@@ -1476,11 +1476,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    N14Iron: 15
+    N14Iron: 1500
 
-    Leather: 7
+    Leather: 70
 
-    Wood: 5
+    Wood: 500
 
 
 - type: latheRecipe
@@ -1494,9 +1494,9 @@
   materials:
     Steel: 2500
 
-    N14Iron: 7
+    N14Iron: 700
 
-    Leather: 2
+    Leather: 20
 
 
 - type: latheRecipe
@@ -1508,11 +1508,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    N14Iron: 12
+    N14Iron: 1200
 
-    Wood: 15
+    Wood: 1500
 
-    Leather: 2
+    Leather: 20
 
 
 - type: latheRecipe
@@ -1524,11 +1524,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    N14Iron: 15
+    N14Iron: 2500
 
-    Leather: 7
+    Leather: 700
 
-    Cloth: 2
+    Cloth: 200
 
 
 - type: latheRecipe
@@ -1540,11 +1540,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    N14Iron: 17
+    N14Iron: 170
 
     Steel: 2000
 
-    Scrap: 15
+    Scrap: 150
 
 
 - type: latheRecipe
@@ -1558,9 +1558,9 @@
   materials:
     Steel: 3000
 
-    Wood: 20
+    Wood: 2000
 
-    N14Iron: 2
+    N14Iron: 20
 
 
 - type: latheRecipe
@@ -1572,11 +1572,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Scrap: 25
+    Scrap: 250
 
-    ScrapSteel: 15
+    ScrapSteel: 150
 
-    Wood: 5
+    Wood: 500
 
 
 - type: latheRecipe
@@ -1588,11 +1588,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Wood: 25
+    Wood: 2500
 
-    N14Iron: 10
+    N14Iron: 1000
 
-    Leather: 2
+    Leather: 20
 
 
 # --- Legion Tier 3 Weapons (Veteran grade) ---
@@ -1607,11 +1607,11 @@
   materials:
     Steel: 6000
 
-    N14Iron: 15
+    N14Iron: 1500
 
-    Leather: 7
+    Leather: 70
 
-    N14Gold: 5
+    N14Gold: 50
 
 
 - type: latheRecipe
@@ -1623,11 +1623,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 5000
+    Steel: 3000
 
-    N14Iron: 17
+    N14Iron: 170
 
-    Leather: 7
+    Leather: 70
 
 
 - type: latheRecipe
@@ -1641,9 +1641,9 @@
   materials:
     Steel: 6000
 
-    Wood: 25
+    Wood: 250
 
-    N14Iron: 12
+    N14Iron: 120
 
 
 - type: latheRecipe
@@ -1655,11 +1655,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Wood: 50
+    Wood: 3000
 
-    N14Iron: 15
+    N14Iron: 1500
 
-    Leather: 7
+    Leather: 400
 
 
 - type: latheRecipe
@@ -1673,11 +1673,11 @@
   materials:
     Steel: 4500
 
-    N14Iron: 20
+    N14Iron: 200
 
-    Scrap: 20
+    Scrap: 200
 
-    N14Brass: 10
+    N14Brass: 100
 
 
 - type: latheRecipe
@@ -1691,9 +1691,9 @@
   materials:
     Steel: 5000
 
-    N14Iron: 17
+    N14Iron: 170
 
-    Scrap: 15
+    Scrap: 150
 
 
 - type: latheRecipe
@@ -1707,9 +1707,9 @@
   materials:
     Steel: 6000
 
-    Wood: 20
+    Wood: 2000
 
-    N14Iron: 15
+    N14Iron: 150
 
 
 - type: latheRecipe
@@ -1723,9 +1723,9 @@
   materials:
     Steel: 6000
 
-    N14Iron: 17
+    N14Iron: 1700
 
-    N14Brass: 15
+    N14Brass: 150
 
 
 - type: latheRecipe
@@ -1737,9 +1737,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Wood: 45
+    Wood: 450
 
-    Leather: 5
+    Leather: 50
 
 
 # #Misfits Add - T3 firearm parity: semi-auto shotgun, SMG, and carbine rifle to close gap with NCR
@@ -1754,9 +1754,9 @@
   materials:
     Steel: 5500
 
-    N14Iron: 15
+    N14Iron: 150
 
-    Leather: 10
+    Leather: 100
 
 
 - type: latheRecipe
@@ -1770,9 +1770,9 @@
   materials:
     Steel: 4500
 
-    N14Iron: 10
+    N14Iron: 100
 
-    N14Brass: 15
+    N14Brass: 150
 
 
 - type: latheRecipe
@@ -1786,9 +1786,9 @@
   materials:
     Steel: 5000
 
-    Wood: 20
+    Wood: 200
 
-    N14Iron: 12
+    N14Iron: 120
 
 
 # #Misfits Add - M240B GPMG for Tier 3 Legion crafting
@@ -1803,11 +1803,11 @@
   materials:
     Steel: 7000
 
-    N14Iron: 20
+    N14Iron: 200
 
-    N14Brass: 10
+    N14Brass: 100
 
-    Leather: 5
+    Leather: 50
 
 
 # --- Legion Tier 4 Weapons (Legate's elite) ---
@@ -1822,11 +1822,11 @@
   materials:
     Steel: 12000
 
-    N14Iron: 30
+    N14Iron: 3000
 
-    Circuitry: 10
+    Circuitry: 100
 
-    ScrapElectronic: 10
+    ScrapElectronic: 100
 
 
 - type: latheRecipe
@@ -1838,13 +1838,13 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Wood: 90
+    Wood: 3000
 
-    N14Iron: 35
+    N14Iron: 1250
 
-    Leather: 17
+    Leather: 170
 
-    N14Gold: 10
+    N14Gold: 100
 
 
 - type: latheRecipe
@@ -1858,11 +1858,11 @@
   materials:
     Steel: 10000
 
-    N14Iron: 30
+    N14Iron: 300
 
-    N14Brass: 30
+    N14Brass: 300
 
-    N14Gold: 5
+    N14Gold: 50
 
 
 - type: latheRecipe
@@ -1874,13 +1874,13 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 10500
+    Steel: 5500
 
-    N14Iron: 27
+    N14Iron: 270
 
-    Circuitry: 20
+    Circuitry: 200
 
-    ScrapElectronic: 15
+    ScrapElectronic: 150
 
 
 - type: latheRecipe
@@ -1892,13 +1892,13 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 9000
+    Steel: 7000
 
-    N14Iron: 35
+    N14Iron: 350
 
-    Wood: 45
+    Wood: 2000
 
-    Leather: 12
+    Leather: 120
 
 
 - type: latheRecipe
@@ -1912,11 +1912,11 @@
   materials:
     Steel: 12000
 
-    N14Iron: 37
+    N14Iron: 370
 
-    Circuitry: 25
+    Circuitry: 250
 
-    ScrapElectronic: 15
+    ScrapElectronic: 150
 
 
 # #Misfits Add - T4 firearm additions: Bren LMG (.308 FullAuto) and Auto Shotgun for DPS parity with NCR T4
@@ -1931,11 +1931,11 @@
   materials:
     Steel: 11000
 
-    N14Iron: 25
+    N14Iron: 250
 
-    N14Brass: 30
+    N14Brass: 300
 
-    Wood: 20
+    Wood: 2000
 
 
 - type: latheRecipe
@@ -1949,9 +1949,9 @@
   materials:
     Steel: 7000
 
-    N14Iron: 15
+    N14Iron: 150
 
-    N14Brass: 10
+    N14Brass: 100
 
 
 # #Misfits Add - T5 Legion Weapons: Scorcher flamethrower (apex incendiary weapon)
@@ -1967,11 +1967,11 @@
   materials:
     Steel: 14000
 
-    N14Iron: 30
+    N14Iron: 300
 
-    Circuitry: 20
+    Circuitry: 200
 
-    ScrapElectronic: 15
+    ScrapElectronic: 150
 
 
 # =====================================================================
@@ -1988,11 +1988,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Leather: 5
+    Leather: 500
 
-    Cloth: 5
+    Cloth: 500
 
-    Thread: 2
+    Thread: 200
 
 
 - type: latheRecipe
@@ -2004,11 +2004,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Leather: 7
+    Leather: 700
 
-    Cloth: 5
+    Cloth: 500
 
-    Thread: 2
+    Thread: 200
 
 
 # --- Legion Tier 2 Armor ---
@@ -2021,13 +2021,13 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Leather: 15
+    Leather: 1500
 
-    Cloth: 12
+    Cloth: 1200
 
-    Thread: 7
+    Thread: 700
 
-    N14Iron: 5
+    N14Iron: 500
 
 
 - type: latheRecipe
@@ -2039,13 +2039,13 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Leather: 17
+    Leather: 1700
 
-    Cloth: 12
+    Cloth: 1200
 
-    Thread: 10
+    Thread: 1000
 
-    N14Iron: 5
+    N14Iron: 500
 
 
 - type: latheRecipe
@@ -2057,11 +2057,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Leather: 15
+    Leather: 1500
 
-    Cloth: 10
+    Cloth: 1000
 
-    Thread: 7
+    Thread: 700
 
 
 # --- Legion Tier 3 Armor ---
@@ -2074,15 +2074,15 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Leather: 30
+    Leather: 300
 
-    Steel: 4500
+    Steel: 3500
 
-    Cloth: 22
+    Cloth: 220
 
-    Thread: 17
+    Thread: 170
 
-    N14Iron: 10
+    N14Iron: 100
 
 
 - type: latheRecipe
@@ -2094,15 +2094,15 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Leather: 25
+    Leather: 250
 
-    Cloth: 22
+    Cloth: 220
 
-    Thread: 17
+    Thread: 170
 
-    N14Iron: 10
+    N14Iron: 1000
 
-    N14Gold: 5
+    N14Gold: 150
 
 
 - type: latheRecipe
@@ -2116,11 +2116,11 @@
   materials:
     Steel: 5000
 
-    Leather: 20
+    Leather: 200
 
-    Cloth: 17
+    Cloth: 170
 
-    Thread: 15
+    Thread: 150
 
 
 - type: latheRecipe
@@ -2132,13 +2132,13 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Leather: 25
+    Leather: 250
 
-    Cloth: 17
+    Cloth: 170
 
-    Thread: 15
+    Thread: 150
 
-    N14Iron: 7
+    N14Iron: 70
 
 
 # --- Legion Tier 4 Armor ---
@@ -2153,13 +2153,13 @@
   materials:
     Steel: 10000
 
-    Leather: 35
+    Leather: 350
 
-    Cloth: 30
+    Cloth: 300
 
-    Thread: 20
+    Thread: 200
 
-    N14Iron: 20
+    N14Iron: 200
 
 
 - type: latheRecipe
@@ -2171,17 +2171,15 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 10500
+    Steel: 6500
 
-    Leather: 35
+    Leather: 350
 
-    Cloth: 27
+    Cloth: 270
 
-    Thread: 20
+    Thread: 200
 
-    N14Iron: 20
-
-    N14Gold: 5
+    N14Iron: 200
 
 
 - type: latheRecipe
@@ -2195,13 +2193,13 @@
   materials:
     Steel: 10500
 
-    Leather: 45
+    Leather: 450
 
-    N14Iron: 27
+    N14Iron: 270
 
-    Cloth: 17
+    Cloth: 170
 
-    Thread: 15
+    Thread: 150
 
 
 # =====================================================================
@@ -2364,7 +2362,7 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 4500
+    Steel: 2500
 
     N14Gunpowder: 50
 
@@ -2431,13 +2429,13 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 10000
+    Steel: 1000
 
-    N14Gunpowder: 80
+    N14Gunpowder: 4000
 
-    N14Iron: 20
+    N14Iron: 200
 
-    Circuitry: 10
+    Circuitry: 100
 
 
 - type: latheRecipe
@@ -2467,13 +2465,13 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 8000
+    Steel: 1000
 
-    N14Gunpowder: 1
+    N14Gunpowder: 1000
 
-    N14Iron: 27
+    N14Iron: 270
 
-    Plastic: 15
+    Plastic: 150
 
 
 # #Misfits Add - T4 ammo for Bren LMG (.308 Long magazine, 20-round box)
@@ -2527,8 +2525,8 @@
   - NCR
   materials:
     Steel: 500
-    Cloth: 4
-    Leather: 2
+    Cloth: 40
+    Leather: 20
 
 - type: latheRecipe
   id: N14BPNCRArmorHelmetMetalWoods
@@ -2540,8 +2538,8 @@
   - NCR
   materials:
     Steel: 500
-    Cloth: 4
-    Leather: 2
+    Cloth: 40
+    Leather: 20
 
 - type: latheRecipe
   id: N14BPNCRArmorHelmetMetalDesert
@@ -2553,8 +2551,8 @@
   - NCR
   materials:
     Steel: 500
-    Cloth: 4
-    Leather: 2
+    Cloth: 40
+    Leather: 20
 
 # --- NCR Tier 2 Helmets (paired with plate / pouched / CF vests) ---
 - type: latheRecipe
@@ -2567,9 +2565,9 @@
   - NCR
   materials:
     Steel: 1000
-    Cloth: 6
-    Leather: 3
-    ScrapElectronic: 3
+    Cloth: 60
+    Leather: 30
+    ScrapElectronic: 30
 
 - type: latheRecipe
   id: N14BPNCRArmorHelmetMetalRadioSnow
@@ -2581,9 +2579,9 @@
   - NCR
   materials:
     Steel: 1000
-    Cloth: 6
-    Leather: 3
-    ScrapElectronic: 3
+    Cloth: 60
+    Leather: 30
+    ScrapElectronic: 30
 
 - type: latheRecipe
   id: N14BPNCRArmorHelmetMetalMilitaryPolice
@@ -2595,8 +2593,8 @@
   - NCR
   materials:
     Steel: 900
-    Cloth: 5
-    Leather: 3
+    Cloth: 50
+    Leather: 30
 
 - type: latheRecipe
   id: N14BPNCRArmorHelmetMetalMedic
@@ -2608,8 +2606,8 @@
   - NCR
   materials:
     Steel: 900
-    Cloth: 5
-    Leather: 3
+    Cloth: 50
+    Leather: 30
 
 - type: latheRecipe
   id: N14BPNCRArmorHelmetMetalGhillie
@@ -2622,7 +2620,7 @@
   materials:
     Steel: 800
     Cloth: 10
-    Leather: 4
+    Leather: 40
 
 # --- NCR Tier 3 Helmets (combat / ranger) ---
 - type: latheRecipe
@@ -2635,8 +2633,8 @@
   - NCR
   materials:
     Steel: 2000
-    Cloth: 8
-    Leather: 4
+    Cloth: 80
+    Leather: 40
     Plastic: 100
 
 - type: latheRecipe
@@ -2650,8 +2648,8 @@
   - Rangers
   materials:
     Steel: 1800
-    Leather: 10
-    Cloth: 8
+    Leather: 100
+    Cloth: 80
     Glass: 200
 
 - type: latheRecipe
@@ -2665,8 +2663,8 @@
   - Rangers
   materials:
     Steel: 1800
-    Leather: 10
-    Cloth: 8
+    Leather: 100
+    Cloth: 80
     Glass: 200
 
 - type: latheRecipe
@@ -2680,8 +2678,8 @@
   - Rangers
   materials:
     Steel: 1800
-    Leather: 10
-    Cloth: 8
+    Leather: 100
+    Cloth: 80
     Glass: 200
 
 # --- NCR Tier 4 Helmets (elite / power armor) ---
@@ -2695,9 +2693,9 @@
   - NCR
   materials:
     Steel: 4000
-    Cloth: 10
-    Leather: 5
-    Circuitry: 5
+    Cloth: 100
+    Leather: 50
+    Circuitry: 50
 
 - type: latheRecipe
   id: N14BPNCRArmorRangerHelmetElite
@@ -2710,10 +2708,10 @@
   - Rangers
   materials:
     Steel: 4000
-    Leather: 12
-    Cloth: 10
+    Leather: 120
+    Cloth: 100
     Glass: 250
-    Circuitry: 5
+    Circuitry: 50
 
 # #Misfits Removed - user requested no power armor helmet recipes
 # - type: latheRecipe
@@ -2741,8 +2739,8 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Cloth: 8
-    Thread: 5
+    Cloth: 80
+    Thread: 50
 
 - type: latheRecipe
   id: N14BPLegionArmorHelmetTribalHeadWraps
@@ -2753,8 +2751,8 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Cloth: 8
-    Thread: 5
+    Cloth: 80
+    Thread: 50
 
 # --- Legion Tier 2 Helmets (legionnaire hoods) ---
 - type: latheRecipe
@@ -2766,9 +2764,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Cloth: 12
-    Thread: 8
-    Leather: 5
+    Cloth: 120
+    Thread: 80
+    Leather: 50
 
 - type: latheRecipe
   id: N14BPLegionArmorHelmetTribalOutcastHood
@@ -2779,9 +2777,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Cloth: 12
-    Thread: 8
-    Leather: 5
+    Cloth: 120
+    Thread: 80
+    Leather: 50
 
 # --- Legion Tier 3 Helmets (veteran skulls and hunter hoods) ---
 - type: latheRecipe
@@ -2793,9 +2791,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Cloth: 15
-    Thread: 10
-    Leather: 8
+    Cloth: 150
+    Thread: 100
+    Leather: 80
 
 - type: latheRecipe
   id: N14BPLegionArmorHelmetHeadtakerwraps
@@ -2806,9 +2804,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Cloth: 15
-    Thread: 10
-    Leather: 8
+    Cloth: 150
+    Thread: 100
+    Leather: 80
 
 - type: latheRecipe
   id: N14BPLegionArmorHelmetMuffaloskull
@@ -2819,8 +2817,8 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Leather: 20
-    Thread: 8
+    Leather: 200
+    Thread: 80
 
 # --- Legion Tier 4 Helmets (looted pre-war military) ---
 - type: latheRecipe
@@ -2833,8 +2831,8 @@
   - CaesarLegion
   materials:
     Steel: 3000
-    Cloth: 10
-    Leather: 5
+    Cloth: 100
+    Leather: 50
 
 - type: latheRecipe
   id: N14BPLegionArmorHelmetMetalHelmet
@@ -2846,7 +2844,7 @@
   - CaesarLegion
   materials:
     Steel: 3000
-    Cloth: 10
-    Leather: 5
+    Cloth: 100
+    Leather: 50
 
 

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
@@ -15,8 +15,8 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 12500
-    Plastic: 25
+    Steel: 2500
+    Plastic: 250
 
 - type: latheRecipe
   id: N14BPVaultWeaponPoliceBaton
@@ -27,8 +27,8 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 7500
-    Plastic: 50
+    Steel: 2500
+    Plastic: 500
 
 - type: latheRecipe
   id: N14BPVaultWeaponLaserPistol
@@ -39,9 +39,9 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 100
-    Glass: 50
-    Circuitry: 25
+    Steel: 1000
+    Glass: 550
+    Circuitry: 500
 
 # --- Vault Tier 2 Weapons (Advanced security) ---
 - type: latheRecipe
@@ -53,9 +53,9 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 25000
-    Plastic: 75
-    N14Iron: 50
+    Steel: 5000
+    Plastic: 750
+    N14Iron: 500
 
 # Recharger variants are intentionally excluded from blueprint crafting.
 
@@ -68,7 +68,7 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 100
+    Steel: 200
     Plastic: 25
 
 # --- Vault Tier 3 Weapons (R&D energy weapons) ---
@@ -81,10 +81,10 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 300
-    Glass: 175
-    Circuitry: 150
-    ScrapElectronic: 75
+    Steel: 600
+    Glass: 375
+    Circuitry: 250
+    ScrapElectronic: 200
 
 - type: latheRecipe
   id: N14BPVaultWeaponLaserRifle
@@ -95,10 +95,10 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 300
-    Glass: 175
-    Circuitry: 125
-    Plastic: 75
+    Steel: 5500
+    Glass: 575
+    Circuitry: 925
+    Plastic: 750
 
 - type: latheRecipe
   id: N14BPVaultWeaponPlasmaDefender
@@ -109,10 +109,10 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 27500
-    Glass: 175
-    Circuitry: 150
-    ScrapElectronic: 75
+    Steel: 7500
+    Glass: 1000
+    Circuitry: 1500
+    ScrapElectronic: 750
 
 # --- Vault Tier 4 Weapons (Experimental prototypes) ---
 - type: latheRecipe
@@ -124,11 +124,11 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 500
-    Glass: 3
-    Circuitry: 250
+    Steel: 7000
+    Glass: 700
+    Circuitry: 1000
     ScrapElectronic: 150
-    Plastic: 50
+    Plastic: 500
 
 - type: latheRecipe
   id: N14BPVaultWeaponLaserRifleWattz2000
@@ -139,10 +139,10 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 500
-    Glass: 350
-    Circuitry: 275
-    ScrapElectronic: 150
+    Steel: 10000
+    Glass: 3500
+    Circuitry: 1000
+    ScrapElectronic: 550
 
 - type: latheRecipe
   id: N14BPVaultWeaponLaserRifleAuto
@@ -153,11 +153,11 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 55000
-    Glass: 3
-    Circuitry: 250
-    ScrapElectronic: 175
-    Plastic: 75
+    Steel: 8000
+    Glass: 1500
+    Circuitry: 950
+    ScrapElectronic: 675
+    Plastic: 750
 
 - type: latheRecipe
   id: N14BPVaultWeaponLaserRCW
@@ -168,11 +168,11 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 55000
-    Glass: 350
-    Circuitry: 250
-    ScrapElectronic: 175
-    Plastic: 75
+    Steel: 70000
+    Glass: 3500
+    Circuitry: 1200
+    ScrapElectronic: 975
+    Plastic: 750
 
 # =====================================================================
 # VAULT ARMOR RECIPES
@@ -188,9 +188,9 @@
   availableFaction:
   - Vault
   materials:
-    Cloth: 125
-    Thread: 1
-    Plastic: 50
+    Cloth: 1250
+    Thread: 500
+    Plastic: 500
 
 # --- Vault Tier 2 Armor ---
 - type: latheRecipe
@@ -202,10 +202,10 @@
   availableFaction:
   - Vault
   materials:
-    Leather: 150
-    Cloth: 125
-    Thread: 1
-    Plastic: 25
+    Leather: 1500
+    Cloth: 550
+    Thread: 800
+    Plastic: 250
 
 - type: latheRecipe
   id: N14BPVaultArmorReinforcedLeatherArmor
@@ -216,10 +216,10 @@
   availableFaction:
   - Vault
   materials:
-    Leather: 2
-    Steel: 100
+    Leather: 2000
+    Steel: 1000
     Cloth: 150
-    Thread: 1
+    Thread: 700
 
 # --- Vault Tier 3 Armor ---
 - type: latheRecipe
@@ -231,11 +231,11 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 400
-    Cloth: 250
-    Thread: 175
-    Plastic: 75
-    Circuitry: 25
+    Steel: 4000
+    Cloth: 2500
+    Thread: 1750
+    Plastic: 750
+    Circuitry: 250
 
 - type: latheRecipe
   id: N14BPVaultArmorPoliceCombat
@@ -246,10 +246,10 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 35000
-    Cloth: 225
-    Thread: 150
-    Plastic: 50
+    Steel: 4300
+    Cloth: 2250
+    Thread: 1500
+    Plastic: 500
 
 # --- Vault Tier 4 Armor ---
 - type: latheRecipe
@@ -261,12 +261,12 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 700
-    Cloth: 350
-    Thread: 250
-    Circuitry: 1
-    ScrapElectronic: 75
-    Plastic: 50
+    Steel: 7000
+    Cloth: 3500
+    Thread: 2000
+    Circuitry: 500
+    ScrapElectronic: 750
+    Plastic: 5000
 
 - type: latheRecipe
   id: N14BPVaultArmorMarineArmor
@@ -277,12 +277,12 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 900
-    Cloth: 4
-    Thread: 275
-    Circuitry: 150
-    ScrapElectronic: 1
-    N14Iron: 1
+    Steel: 9000
+    Cloth: 4000
+    Thread: 2750
+    Circuitry: 1500
+    ScrapElectronic: 1200
+    N14Iron: 1500
 
 # =====================================================================
 # VAULT AMMO RECIPES
@@ -311,7 +311,7 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 7500
+    Steel: 750
     Lead: 50
     N14Gunpowder: 25
 
@@ -339,9 +339,9 @@
   availableFaction:
   - Vault
   materials:
-    Steel: 12500
-    Lead: 1
-    N14Gunpowder: 50
+    Steel: 1250
+    Lead: 200
+    N14Gunpowder: 300
 
 # --- Vault Tier 3 Ammo ---
 # #Misfits Removed - MFC recipe commented out; consolidated to single generic cell at T2
@@ -399,8 +399,8 @@
   availableFaction:
   - Tribe
   materials:
-    N14Iron: 75
-    Leather: 25
+    N14Iron: 750
+    Leather: 250
 
 - type: latheRecipe
   id: N14BPTribeWeaponTribalClub
@@ -411,8 +411,8 @@
   availableFaction:
   - Tribe
   materials:
-    Wood: 1
-    Leather: 50
+    Wood: 1500
+    Leather: 500
 
 - type: latheRecipe
   id: N14BPTribeWeaponWastelandSpear
@@ -423,9 +423,9 @@
   availableFaction:
   - Tribe
   materials:
-    Wood: 1
-    N14Iron: 50
-    Leather: 25
+    Wood: 1200
+    N14Iron: 700
+    Leather: 250
 
 - type: latheRecipe
   id: N14BPTribeWeaponRevolver44Tribal
@@ -436,9 +436,9 @@
   availableFaction:
   - Tribe
   materials:
-    N14Iron: 1
-    Scrap: 75
-    Wood: 25
+    N14Iron: 500
+    Scrap: 750
+    Wood: 250
 
 - type: latheRecipe
   id: N14BPTribeWeaponBrokenPipe
@@ -449,8 +449,8 @@
   availableFaction:
   - Tribe
   materials:
-    Scrap: 75
-    ScrapSteel: 50
+    Scrap: 3000
+    ScrapSteel: 500
 
 # --- Tribe Tier 2 Weapons (Warrior weapons) ---
 - type: latheRecipe
@@ -462,9 +462,9 @@
   availableFaction:
   - Tribe
   materials:
-    N14Iron: 175
-    Leather: 75
-    Wood: 50
+    N14Iron: 1750
+    Leather: 750
+    Wood: 500
 
 - type: latheRecipe
   id: N14BPTribeWeaponTribalHatchet
@@ -475,9 +475,9 @@
   availableFaction:
   - Tribe
   materials:
-    N14Iron: 150
-    Wood: 1
-    Leather: 50
+    N14Iron: 1500
+    Wood: 100
+    Leather: 500
 
 - type: latheRecipe
   id: N14BPTribeWeaponTribalSword
@@ -488,9 +488,9 @@
   availableFaction:
   - Tribe
   materials:
-    N14Iron: 2
-    Leather: 1
-    Cloth: 50
+    N14Iron: 2500
+    Leather: 1200
+    Cloth: 500
 
 - type: latheRecipe
   id: N14BPTribeWeaponRevolver44TribalUpgraded
@@ -501,9 +501,9 @@
   availableFaction:
   - Tribe
   materials:
-    N14Iron: 175
-    Scrap: 1
-    Steel: 5000
+    N14Iron: 1750
+    Scrap: 1000
+    Steel: 1900
 
 - type: latheRecipe
   id: N14BPTribeWeaponPistol10mmPipe
@@ -514,9 +514,9 @@
   availableFaction:
   - Tribe
   materials:
-    Scrap: 125
-    ScrapSteel: 75
-    Wood: 25
+    Scrap: 1250
+    ScrapSteel: 750
+    Wood: 2500
 
 - type: latheRecipe
   id: N14BPTribeWeaponShotgunPipe
@@ -527,9 +527,9 @@
   availableFaction:
   - Tribe
   materials:
-    Scrap: 150
-    ScrapSteel: 1
-    Wood: 50
+    Scrap: 1500
+    ScrapSteel: 1000
+    Wood: 500
 
 # --- Tribe Tier 3 Weapons (Elder's war knowledge) ---
 - type: latheRecipe
@@ -541,10 +541,10 @@
   availableFaction:
   - Tribe
   materials:
-    Steel: 200
-    N14Iron: 175
-    Scrap: 1
-    N14Brass: 50
+    Steel: 2000
+    N14Iron: 1750
+    Scrap: 100
+    N14Brass: 500
 
 - type: latheRecipe
   id: N14BPTribeWeaponHandcannon
@@ -555,9 +555,9 @@
   availableFaction:
   - Tribe
   materials:
-    Steel: 25000
-    N14Iron: 2
-    Scrap: 1
+    Steel: 4000
+    N14Iron: 800
+    Scrap: 1500
 
 - type: latheRecipe
   id: N14BPTribeWeaponTribalBigClub
@@ -568,9 +568,9 @@
   availableFaction:
   - Tribe
   materials:
-    Wood: 3
-    N14Iron: 150
-    Leather: 1
+    Wood: 3000
+    N14Iron: 1500
+    Leather: 1000
 
 - type: latheRecipe
   id: N14BPTribeWeaponTribalSpear
@@ -581,9 +581,9 @@
   availableFaction:
   - Tribe
   materials:
-    Wood: 2
-    N14Iron: 125
-    Leather: 75
+    Wood: 2000
+    N14Iron: 1250
+    Leather: 750
 
 - type: latheRecipe
   id: N14BPTribeWeaponSMG12mmPipe
@@ -594,9 +594,9 @@
   availableFaction:
   - Tribe
   materials:
-    Scrap: 250
-    ScrapSteel: 150
-    N14Iron: 75
+    Scrap: 2500
+    ScrapSteel: 1500
+    N14Iron: 750
 
 - type: latheRecipe
   id: N14BPTribeWeaponRifle556Pipe
@@ -607,9 +607,9 @@
   availableFaction:
   - Tribe
   materials:
-    Scrap: 225
-    ScrapSteel: 150
-    Wood: 75
+    Scrap: 2250
+    ScrapSteel: 1500
+    Wood: 750
 
 # --- Tribe Tier 4 Weapons (Shaman's sacred weapons) ---
 - type: latheRecipe
@@ -621,10 +621,10 @@
   availableFaction:
   - Tribe
   materials:
-    Steel: 400
-    N14Iron: 250
-    N14Brass: 1
-    Leather: 50
+    Steel: 4000
+    N14Iron: 2500
+    N14Brass: 100
+    Leather: 500
 
 - type: latheRecipe
   id: N14BPTribeWeaponTribalBigClubDecorated
@@ -635,10 +635,10 @@
   availableFaction:
   - Tribe
   materials:
-    Wood: 4
-    N14Iron: 250
-    Leather: 150
-    N14Gold: 50
+    Wood: 1800
+    N14Iron: 2500
+    Leather: 1500
+    N14Gold: 250
 
 - type: latheRecipe
   id: N14BPTribeWeaponPolearm
@@ -649,10 +649,10 @@
   availableFaction:
   - Tribe
   materials:
-    Steel: 300
-    N14Iron: 250
-    Wood: 2
-    Leather: 75
+    Steel: 3000
+    N14Iron: 2500
+    Wood: 2000
+    Leather: 750
 
 - type: latheRecipe
   id: N14BPTribeWeaponSniper50Pipe
@@ -663,10 +663,10 @@
   availableFaction:
   - Tribe
   materials:
-    Scrap: 4
-    ScrapSteel: 3
-    N14Iron: 2
-    Wood: 1
+    Scrap: 8000
+    ScrapSteel: 3500
+    N14Iron: 5000
+    Wood: 1500
 
 - type: latheRecipe
   id: N14BPTribeWeaponSuperSledgeHammer
@@ -677,10 +677,10 @@
   availableFaction:
   - Tribe
   materials:
-    Steel: 600
-    N14Iron: 350
-    Wood: 1
-    Scrap: 1
+    Steel: 25000
+    N14Iron: 3500
+    Wood: 900
+    Scrap: 5000
 
 # =====================================================================
 # TRIBE ARMOR RECIPES
@@ -696,9 +696,9 @@
   availableFaction:
   - Tribe
   materials:
-    Leather: 1
-    Cloth: 75
-    Thread: 50
+    Leather: 100
+    Cloth: 750
+    Thread: 500
 
 - type: latheRecipe
   id: N14BPTribeArmorDrylanderSimple
@@ -709,8 +709,8 @@
   availableFaction:
   - Tribe
   materials:
-    Cloth: 1
-    Thread: 75
+    Cloth: 100
+    Thread: 750
     Leather: 50
 
 # --- Tribe Tier 2 Armor ---
@@ -724,8 +724,8 @@
   - Tribe
   materials:
     Leather: 175
-    Cloth: 125
-    Thread: 1
+    Cloth: 1250
+    Thread: 100
 
 - type: latheRecipe
   id: N14BPTribeArmorForager
@@ -738,7 +738,7 @@
   materials:
     Leather: 150
     Cloth: 150
-    Thread: 1
+    Thread: 100
 
 - type: latheRecipe
   id: N14BPTribeArmorHunter
@@ -750,8 +750,8 @@
   - Tribe
   materials:
     Leather: 175
-    Cloth: 125
-    Thread: 1
+    Cloth: 1250
+    Thread: 100
 
 - type: latheRecipe
   id: N14BPTribeArmorPoncho
@@ -762,7 +762,7 @@
   availableFaction:
   - Tribe
   materials:
-    Cloth: 2
+    Cloth: 2000
     Thread: 125
     Leather: 50
 
@@ -776,9 +776,9 @@
   availableFaction:
   - Tribe
   materials:
-    Leather: 3
-    N14Iron: 150
-    Cloth: 2
+    Leather: 300
+    N14Iron: 1500
+    Cloth: 200
     Thread: 150
 
 - type: latheRecipe
@@ -791,9 +791,9 @@
   - Tribe
   materials:
     Leather: 275
-    N14Iron: 1
-    Cloth: 175
-    Thread: 125
+    N14Iron: 100
+    Cloth: 1750
+    Thread: 1250
 
 - type: latheRecipe
   id: N14BPTribeArmorShaman
@@ -804,9 +804,9 @@
   availableFaction:
   - Tribe
   materials:
-    Cloth: 250
-    Thread: 175
-    Leather: 150
+    Cloth: 2500
+    Thread: 1750
+    Leather: 1500
 
 - type: latheRecipe
   id: N14BPTribeArmorCombatTribal
@@ -817,10 +817,10 @@
   availableFaction:
   - Tribe
   materials:
-    Leather: 3
-    Steel: 200
-    Cloth: 175
-    Thread: 150
+    Leather: 300
+    Steel: 2000
+    Cloth: 1750
+    Thread: 1500
 
 # --- Tribe Tier 4 Armor ---
 - type: latheRecipe
@@ -832,10 +832,10 @@
   availableFaction:
   - Tribe
   materials:
-    Leather: 4
-    Steel: 300
-    N14Iron: 2
-    Cloth: 2
+    Leather: 400
+    Steel: 3000
+    N14Iron: 2000
+    Cloth: 200
     Thread: 150
 
 - type: latheRecipe
@@ -848,9 +848,9 @@
   - Tribe
   materials:
     Leather: 350
-    Cloth: 2
+    Cloth: 200
     Thread: 150
-    N14Iron: 1
+    N14Iron: 1500
 
 # =====================================================================
 # TRIBE AMMO RECIPES
@@ -1035,8 +1035,8 @@
   - Vault
   materials:
     Steel: 600
-    Plastic: 100
-    Cloth: 4
+    Plastic: 1000
+    Cloth: 400
 
 # --- Vault Tier 2 Helmets (basic metal) ---
 - type: latheRecipe
@@ -1049,8 +1049,8 @@
   - Vault
   materials:
     Steel: 1200
-    Cloth: 5
-    Leather: 3
+    Cloth: 500
+    Leather: 30
 
 # --- Vault Tier 3 Helmets (combat) ---
 - type: latheRecipe
@@ -1063,9 +1063,9 @@
   - Vault
   materials:
     Steel: 2000
-    Cloth: 8
-    Leather: 4
-    Plastic: 100
+    Cloth: 800
+    Leather: 40
+    Plastic: 1000
 
 # --- Vault Tier 4 Helmets (combat MK2 / marine) ---
 - type: latheRecipe
@@ -1078,9 +1078,9 @@
   - Vault
   materials:
     Steel: 4000
-    Cloth: 10
+    Cloth: 100
     Leather: 5
-    Circuitry: 5
+    Circuitry: 50
 
 - type: latheRecipe
   id: N14BPVaultArmorHelmetMarine
@@ -1092,9 +1092,9 @@
   - Vault
   materials:
     Steel: 4000
-    Cloth: 10
-    Leather: 5
-    Circuitry: 5
+    Cloth: 1000
+    Leather: 500
+    Circuitry: 500
 
 # --- Tribe Tier 1 Helmets (head wraps / drylander) ---
 - type: latheRecipe

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_heavy_trooper.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_heavy_trooper.yml
@@ -47,14 +47,14 @@
     ears: N14ClothingHeadsetNCR               # NCR radio earpiece
     neck: ClothingNeckPinNCRSpecialist        # enlisted heavy weapons rank
     belt: ClothingBeltNCR
-    pocket1: N14WeaponLMG                  # #Misfits Tweak - Upgraded to LMG -bill
+    pocket1: N14WeaponMinigun                 # #Misfits Tweak - downgraded to minigun again -bill
     pocket2: RadioHandheld
     id: N14IDNCRDogtagWS                      # Specialist-tier dogtag
   innerClothingSkirt: N14ClothingOfficerUniformNCRDesert
   satchel: N14ClothingBackpackSatchelNCRFilled
   storage:
     back:
-    - LMGMagazine556Rifle                   # extra 5.56 box -bill 
+    - N14MagazineMinigun5mm                   # extra 5mm box -bill 
 
 - type: playTimeTracker
   id: NCRHeavyTrooper

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -514,8 +514,8 @@
       - id: ClothingBeltNCR
       - id: N14ClothingHeadHatNCRBeretRecon
       - id: N14ClothingNeckCloakNCR # Forge-Change
-      - id: N14WeaponSniper50NCRRifle
-      - id: MagazineBox50
+      - id: N14WeaponRifle308SniperRifle
+      - id: Magazine308RifleSniper
       - id: N14WeaponPistol45Colt
       - id: N14MagazinePistol45
         amount: 2


### PR DESCRIPTION
## About the PR
Increased Blueprint costs across the board for fucking everyone. I cannot be arsed to describe some 50+ blueprints.
NCR HT lost his LMG and got the minigun back since the C-27 is making up for any gaps they have AND frum are losing their .50.
NCR specialists and frumentarii have lost their NCR .50s, they got .308 snipers instead.

## Why / Balance
the .50 cal + stim meta firing line was coming back and I didn't like that direction. also, the C-27 is particularly stomping with the help of 5.56 LMG HTs (who also shred brotherhood ((who recently got nerfed))) hence the losing of their 5.56 LMGs. the miniguns are still solid.
Also increased the blueprint costs because some factions were making super sledges for .5 steel, plastic, and circuitry. Not good. Oh shittings. 

## Technical details
YML + FTL

## Media

https://github.com/user-attachments/assets/5f3dece7-9a32-4891-a227-dddc0cab5784

# Changelog

:cl: Bill Clinton
- remove: Removed fun! in the form of HTs losing 5.56 LMGs and specialists + frumentarii losing their .50 AMRs
- tweak: blueprint costs increased for... *checks my notes... everyone. Crucify me later.
- add: HTs get their minigun back and specialist snipers + frumentarii get .308 snipers with a spare mag or two.