### PR TITLE
Enables RMC Scope System To Some Weapons

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -227,9 +227,14 @@
             - N14Cartridge762Rifle
   - type: StaticPrice
     price: 125
-  # #Misfits Add — built-in scope on marksman carbine (description already states it has a scope)
-  # - type: N14Scope
-  #   eyeOffset: 5
+  - type: Scope #Misfits Add - scope for rifles with scopes...
+    requireWielding: true
+    zoomLevels:
+    - name: 4x
+      zoom: 1.0
+      offset: 15
+      allowMovement: true
+      doAfter: 0.4
 
 - type: entity
   name: service rifle
@@ -339,9 +344,14 @@
         whitelist:
           tags:
             - N14Cartridge556Rifle
-  # #Misfits Add — built-in scope on scoped service rifle (explicitly described as having an optic)
-  # - type: N14Scope
-  #   eyeOffset: 5
+  - type: Scope #Misfits Add - scope for rifles with scopes...
+    requireWielding: true
+    zoomLevels:
+    - name: 4x
+      zoom: 1.0
+      offset: 15
+      allowMovement: true
+      doAfter: 0.4
 
 - type: entity
   name: scout rifle
@@ -764,6 +774,14 @@
             - N14Cartridge762Rifle
   - type: StaticPrice
     price: 175
+  - type: Scope #Misfits Add - scope for rifles with scopes...
+    requireWielding: true
+    zoomLevels:
+    - name: 4x
+      zoom: 1.0
+      offset: 15
+      allowMovement: true
+      doAfter: 0.4
 
 - type: entity
   name: chinese marksman rifle
@@ -818,6 +836,14 @@
             - N14Cartridge308Rifle
   - type: StaticPrice
     price: 175
+  - type: Scope #Misfits Add - scope for rifles with scopes...
+    requireWielding: true
+    zoomLevels:
+    - name: 4x
+      zoom: 1.0
+      offset: 15
+      allowMovement: true
+      doAfter: 0.8
 
 - type: entity
   name: SKS chinese carbine

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -135,12 +135,31 @@
           tags:
             - N14Cartridge50
             - N14Cartridge50HEIAP
-      # #Misfits Add — scope attachment slot on anti-materiel rifle
-      # gun_scope:
-      #   name: Scope Slot
-      #   whitelist:
-      #     tags:
-      #     - RifleScope
+  - type: Scope #Misfits Add - scope for rifles with scopes...
+    requireWielding: true
+    zoomLevels:
+    - name: 4x
+      zoom: 1.0
+      offset: 15
+      allowMovement: false
+      doAfter: 0.8
+  - type: ChamberMagazineAmmoProvider
+    autoCycle: false
+    autoEject: true
+    soundAutoEject:
+      path: /Audio/_Goobstation/Weapons/Guns/MagOut/garand_eject.ogg
+    soundRack:
+      path: /Audio/Weapons/Guns/Cock/batrifle_cock.ogg
+      params:
+        volume: -3
+    soundBoltClosed:
+      path: /Audio/Weapons/Guns/Bolt/lever_bolt_closed.ogg
+      params:
+        volume: -3
+    soundBoltOpened:
+      path: /Audio/Weapons/Guns/Bolt/lever_bolt_opened.ogg
+      params:
+        volume: -3
   - type: MagazineVisuals
     magState: mag
     steps: 1
@@ -188,6 +207,14 @@
     backStrength: 3
   - type: StaticPrice
     price: 175
+  - type: Scope #Misfits Add - scope for rifles with scopes...
+    requireWielding: true
+    zoomLevels:
+    - name: 4x
+      zoom: 1.0
+      offset: 15
+      allowMovement: false
+      doAfter: 0.8
   # #Misfits Add — scope attachment slot on .50 NCR rifle
   # - type: ItemSlots
   #   slots:
@@ -460,6 +487,14 @@
     backStrength: 3
   - type: StaticPrice
     price: 90
+  - type: Scope #Misfits Add - scope for rifles with scopes...
+    requireWielding: true
+    zoomLevels:
+    - name: 4x
+      zoom: 1.0
+      offset: 15
+      allowMovement: false
+      doAfter: 0.8
 
 - type: entity
   name: F1 sniper rifle
@@ -479,6 +514,14 @@
     backStrength: 3
   - type: StaticPrice
     price: 150
+  - type: Scope #Misfits Add - scope for rifles with scopes...
+    requireWielding: true
+    zoomLevels:
+    - name: 4x
+      zoom: 1.0
+      offset: 15
+      allowMovement: false
+      doAfter: 0.8
 
 - type: entity
   name: ross rifle
@@ -563,6 +606,14 @@
     backStrength: 3
   - type: StaticPrice
     price: 175
+  - type: Scope #Misfits Add - scope for rifles with scopes...
+    requireWielding: true
+    zoomLevels:
+    - name: 4x
+      zoom: 1.0
+      offset: 15
+      allowMovement: false
+      doAfter: 0.8
 # Forge-add-end
 
 # #Misfits Add — Cowboy Repeater, Paciencia, Ratslayer, M1 Carbine, Rangemaster


### PR DESCRIPTION
## About the PR
 Adds the scope component ported a while ago from RMC to a few weapons. Snipers rifles such as the AMR, 50 cal regular rifle, 308 snipers rifles. And marksmans rifles with the ability to move while on aiming mode. Also makes the AMR to need manual bolting now teheehehe.

## Why / Balance
My inmersion is broken when i hold a sniper rifle and cant use the scope

# Changelog
:cl:
- add: Adds a scope action to numerous sniper rifles. 50 cal rifles, 308 rifles.
- add: Adds a scope action to marksman rifles. 
-->
