### PR TITLE
Gamblecore.

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Vehicles/vehicle_wrecks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Vehicles/vehicle_wrecks.yml
@@ -43,8 +43,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           SheetSteel1:
-            min: 1
-            max: 2
+            min: 18
+            max: 30
 
 - type: entity
   parent: N14VehicleBikeRust1

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/wrecks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/wrecks.yml
@@ -32,14 +32,20 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           SheetSteel1:
-            min: 1
-            max: 5
+            min: 12
+            max: 30
           N14ScrapSteel1:
-            min: 3
-            max: 10
+            min: 8
+            max: 20
           N14ScrapLead1:
-            min: 1
-            max: 4
+            min: 5
+            max: 20
+          N14Scrap1:
+            min: 20
+            max: 35
+          N14ScrapElectronic1:
+            min: 2
+            max: 5
       - !type:EmptyAllContainersBehaviour
       - !type:PlaySoundBehavior
         sound:


### PR DESCRIPTION
## About the PR
Increased materials dropped from broken cars. made broken cars drop true scrap and a little teeny bit of scrap electronics.

## Why / Balance
I break car and get maybe 2 screws and a sheet of plywood. Not good. Now you break car and can make a basic gun from it. also increases number of mats on map by a bit.

## Technical details
I LOVE YAML!!!!

## Media
https://github.com/user-attachments/assets/b886ee81-fac6-41a1-9597-7b2467761126
# Changelog

:cl: Papa Yml Khan Bill Clinton

- tweak: I feed the masses what they desire. cars drop more metal and they now drop a little electronic scrap and a shitload of normal scrap.