### PR TITLE
C27 Fixes And Blueprint Cost Increase

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
@@ -9,7 +9,6 @@
   name: c-27 humanoid robot
   id: N14BaseMobC27
   parent: BaseMobSpecies
-  abstract: true
   components:
   - type: HumanoidAppearance
     species: C27
@@ -57,9 +56,10 @@
   - type: Speech
     speechVerb: Robotic
     speechSounds: Pai
-  - type: Vocal
+  - type: Vocal # Misfit change, robotic scream
+    wilhelm: "/Audio/Voice/IPC/wilhelm.ogg"
     sounds:
-      Unsexed: MaleHuman
+      Unsexed: UnisexIPC
   - type: TypingIndicator
     proto: robot
   - type: LanguageKnowledge # #Misfits Fix - use N14 language IDs (TauCetiBasic/RobotTalk are SS14 upstream only)
@@ -129,6 +129,8 @@
       - Shard
   # #Misfits Add (Phase F) - Welders restore Brute (uses upstream WeldingHealing on welders).
   - type: WeldingHealable
+   # #Misfits Adds natural welding protection.
+  - type: EyeProtection
   # #Misfits Add (Phase F) - Sleep self-repair / passive maintenance protocols. Heals all
   # supported damage groups slowly while alive or in crit. Combined with allowRevives this
   # also drives the auto-revive pull-out-of-crit loop the spec describes.
@@ -161,7 +163,6 @@
   id: N14MobC27
   parent: N14BaseMobC27
   description: A C-27 humanoid robot. Pre-war General Atomics workshop frame, retrofitted for Wasteland service.
-  categories: [ HideSpawnMenu ]
 
 # Dummy variant used by the character editor preview.
 - type: entity

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_c27.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_c27.yml
@@ -26,10 +26,10 @@
   completetime: 10
   requiresBlueprint: true
   materials:
-    Steel: 400
+    Steel: 1500
     Cloth: 200
     Thread: 150
-    Plastic: 75
+    Plastic: 750
 
 - type: latheRecipe
   id: N14BPC27HelmetMediumGeneric
@@ -50,10 +50,10 @@
   completetime: 14
   requiresBlueprint: true
   materials:
-    Steel: 700
+    Steel: 22000
     Cloth: 250
     Thread: 175
-    Plastic: 125
+    Plastic: 1000
 
 - type: latheRecipe
   id: N14BPC27HelmetHeavyGeneric
@@ -80,10 +80,10 @@
   availableFaction:
   - NCR
   materials:
-    Steel: 400
+    Steel: 1500
     Cloth: 200
     Thread: 150
-    Plastic: 75
+    Plastic: 750
 
 - type: latheRecipe
   id: N14BPC27HelmetMediumNCR
@@ -108,10 +108,10 @@
   availableFaction:
   - NCR
   materials:
-    Steel: 700
+    Steel: 22000
     Cloth: 250
     Thread: 175
-    Plastic: 125
+    Plastic: 1000
 
 - type: latheRecipe
   id: N14BPC27HelmetHeavyNCR
@@ -140,10 +140,10 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Steel: 400
+    Steel: 1500
     Cloth: 200
     Thread: 150
-    Plastic: 75
+    Plastic: 750
 
 - type: latheRecipe
   id: N14BPC27HelmetMediumBoS
@@ -168,10 +168,10 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Steel: 700
+    Steel: 22000
     Cloth: 250
     Thread: 175
-    Plastic: 125
+    Plastic: 1000
 
 - type: latheRecipe
   id: N14BPC27HelmetHeavyBoS

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/C27/c27.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/C27/c27.yml
@@ -49,7 +49,7 @@
     components:
       - type: NpcFactionMember
         factions:
-          - PlayerRobot
+          - Wastelander
 
 # --- NCR variant ---------------------------------------------------------------------
 - type: job
@@ -81,7 +81,7 @@
     components:
       - type: NpcFactionMember
         factions:
-          - PlayerRobot
+          - NCR
 
 # --- Brotherhood of Steel variant ----------------------------------------------------
 - type: job
@@ -111,7 +111,7 @@
     components:
       - type: NpcFactionMember
         factions:
-          - PlayerRobot
+          - BrotherhoodOfSteel
 
 # Starting gear, one per job. Faction kits open an UndecidedLoadoutBackpack UI that
 # now offers Light only — Medium / Heavy variants are obtained by crafting at an armor

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/wastelander.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/wastelander.yml
@@ -26,6 +26,9 @@
     - RobotRobobrain # #Misfits Fix - missing robot chassis
     - RobotRobobrainLaser # #Misfits Fix - missing variant species
     - SuperMutant
+    - C27
+    - C27NCR
+    - C27BoS
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
## About the PR
Changes some stuff, c27 now scream like bots (todo remove the auto scream function), and now they natural welding protection, is kind of silly seeing them with glasses. for fixes, Now all c27 variants are targeted by mobs, and they cant spawn anymore as wastelanders. tweak the bp cost slighty of heavy and medium armor since they where dirt cheap. I will probally make another pr to increase the cost a little bit more but need to consult with MR president.

## Why / Balance
Well them screaming like a human was uninmersive, Mobs not targeting them made them kind of meta for their faction giving them a unfair advantage. They being able to be wastelanders make them basically infinite sloths.

# Changelog

:cl:
- add: Added C27 natural welding eye protection
- tweak: Change C27 scream to a more silicon one (todo: add custom emotes for them)
- tweak: C27 Blueprints cost increased, Mainly steel consumption the Heavy armor increased to 220 steel and Medium stay cheap at 15 steel
- fix: Fixed C27 not being targeted by mobs
- fix: Fixed C27 Wastelander infinite sloths
-->
