### PR TITLE
Proper Offsetting System for Construction Ghosts.

### DIFF
--- a/Content.Client/Construction/ConstructionPlacementHijack.cs
+++ b/Content.Client/Construction/ConstructionPlacementHijack.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Content.Shared.Construction.Prototypes;
+using Robust.Client.GameObjects;
 using Robust.Client.Placement;
 using Robust.Client.Utility;
 using Robust.Shared.Map;
@@ -46,6 +47,17 @@ namespace Content.Client.Construction
         {
             base.StartHijack(manager);
             manager.CurrentTextures = _prototype?.Layers.Select(sprite => sprite.DirFrame0()).ToList();
+
+            // Misfits Add: Offsets the placement ghost entity apparently its different from the construction ghost.
+            if (_prototype != null && manager.CurrentPlacementOverlayEntity is { } overlayEnt)
+            {
+                var entManager = IoCManager.Resolve<IEntityManager>();
+                if (entManager.TryGetComponent<SpriteComponent>(overlayEnt, out var sprite))
+                {
+                    sprite.Offset = _prototype.Offset;
+                }
+            }
+            // Misfits End
         }
     }
 }

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -219,6 +219,8 @@ namespace Content.Client.Construction
                 sprite.LayerSetVisible(i, true);
             }
 
+            sprite.Offset = prototype.Offset; // Misfits Add: Basically makes it so you can offset the sprite of the construction ghost
+
             if (prototype.CanBuildInImpassable)
                 EnsureComp<WallMountComponent>(ghost.Value).Arc = new(Math.Tau);
 

--- a/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
+++ b/Content.Shared/Construction/Prototypes/ConstructionPrototype.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.Construction.Conditions;
 using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
@@ -58,6 +59,12 @@ public sealed partial class ConstructionPrototype : IPrototype
     /// </summary>
     [DataField("layers")]
     private List<SpriteSpecifier>? _layers;
+
+    /// <summary>
+    ///     Misfits Add: Makes it so the construction and placement ghosts are offsetted just copy the offset of the prototpe sprite.
+    /// </summary>
+    [DataField("offset")]
+    public Vector2 Offset = new Vector2(0);
 
     /// <summary>
     ///     If you can start building or complete steps on impassable terrain.

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -12,7 +12,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.75,-0.3,0.75,0.3"
+          bounds: "-0.25,-0.3,1.25,0.3"
         density: 3000
         mask:
         - MachineMask

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -22,7 +22,7 @@
     sprite: _Nuclear14/Structures/Misc/workbenches.rsi
     state: workbench
     # Misfit Remove: Fix the offset issue with construction benches
-    #offset: 0.5, 0
+    offset: 0.5, 0
   - type: Lathe
   - type: MaterialStorage
   - type: ActivatableUI
@@ -535,6 +535,7 @@
 - type: entity
   parent: BaseStructure
   id: N14WorkbenchChemistrysetFrame
+  categories: [ HideSpawnMenu ]
   description: A chemistry set for crafting drugs and compounds. This one is still being built!
   name: chemical set frame
   components:

--- a/Resources/Prototypes/_Nuclear14/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Construction/machines.yml
@@ -78,6 +78,7 @@
   icon:
     sprite: _Nuclear14/Structures/Misc/workbenches.rsi
     state: workbench
+  offset: 0.5, 0 #Misfits Add
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
@@ -96,6 +97,7 @@
   icon:
     sprite: _Nuclear14/Structures/Misc/workbenches.rsi
     state: ammobench
+  offset: 0.5, 0 #Misfits Add: Copy the offset of the sprite
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
@@ -132,6 +134,7 @@
   icon:
     sprite: _Nuclear14/Structures/Misc/forgeworkbench.rsi
     state: forgeicon
+  offset: 0.5, 0 #Misfits Add: Copy the offset of the sprite
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
@@ -150,6 +153,7 @@
   icon:
     sprite: _Nuclear14/Structures/Misc/workbenches.rsi
     state: tinkerbench
+  offset: 0.5, 0 #Misfits Add: Copy the offset of the sprite
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
@@ -168,6 +172,7 @@
   icon:
     sprite: _Nuclear14/Structures/Misc/workbenches.rsi
     state: armorbench
+  offset: 0.5, 0 #Misfits Add: Copy the offset of the sprite
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
@@ -186,6 +191,7 @@
   icon:
     sprite: _Nuclear14/Structures/Misc/workbenches.rsi
     state: weaponbench
+  offset: 0.5, 0 #Misfits Add: Copy the offset of the sprite
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Added a offset variable to ConstructionPrototype default Value 0 so stuff like workbenches can have their offsets back to be in two tiles and it will reflect on their construction and placement ghosts. Also tweaks the hitboxes again to match the new visuals.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previously I removed the offset on workbenches due to them being a pain to build since you didn't know where the building would go but it just made things worse and made mapping look funky. Instead I implement a custom offsetting system for placement and construction ghosts just copy the offset you are using on the construction graph. I'd have updated to the wizden system but it seems the server is incompatible with it when I tried to update it. 

## Technical details
<!-- Summary of code changes for easier review. -->
All it really adds is a new variable on the constructionPrototype called Offset. This variable is used at ConstructionPlacementHijack.cs and ConstructionSystem.cs to offset their respective ghosts.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="215" height="439" alt="AmmoShowcase" src="https://github.com/user-attachments/assets/c1908c19-a560-4fd5-af3b-32bbe5e360c0" />
<img width="195" height="420" alt="ArmorShowcase" src="https://github.com/user-attachments/assets/1ea57637-4d52-4298-8a73-5007e489a5fc" />
<img width="256" height="461" alt="ForgeShowcase" src="https://github.com/user-attachments/assets/bffa5e4b-5b56-40e1-98fc-34b09e2e54cd" />
<img width="210" height="492" alt="TinkerShowcase" src="https://github.com/user-attachments/assets/606f133b-b4bf-499c-b1fe-612f0a57aabb" />
<img width="184" height="469" alt="WeaponShowcase" src="https://github.com/user-attachments/assets/6e78dcfa-b0e6-48ce-be49-b9703892bad9" />
<img width="248" height="500" alt="WorkbenchShowcase" src="https://github.com/user-attachments/assets/b292af13-e7c1-4711-bd06-8848bf999455" />

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: AthenaAI
- tweak: Readded the offset to the workbenches so they are in 2 tiles but now their construciton ghosts match wherever they are placed.

