### PR TITLE
Generators and some Workbench Adjustments.

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -12,7 +12,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.25,-0.3,1.25,0.3"
+          bounds: "-0.25,0,1.25,0.3"
         density: 3000
         mask:
         - MachineMask

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Power/generators.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Power/generators.yml
@@ -291,6 +291,7 @@
     layers:
     - state: generator_off
       map: [ "enum.GeneratorVisualLayers.Body" ]
+    offset: 0.5, 0
   - type: GenericVisualizer
     visuals:
       enum.GeneratorVisuals.Running:

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Power/generators.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Power/generators.yml
@@ -122,8 +122,8 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "-0.2,-0.2,1.2,0.5"
-        density: 190
+            bounds: "-0.5,-0.2,1.5,0.4"
+        density: 3000
         mask:
         - MachineMask
         layer:
@@ -150,7 +150,7 @@
         shape:
           !type:PhysShapeAabb
             bounds: "-0.5,-0.5,0.5,0.8"
-        density: 190
+        density: 1000
         mask:
         - MachineMask
         layer:
@@ -202,15 +202,15 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "-0.5,-0.5,0.5,0.8"
-        density: 190
+            bounds: "-0.5,-0.1,0.5,0.8"
+        density: 1900
         mask:
         - MachineMask
         layer:
         - MachineLayer
   - type: Sprite
     sprite: _Nuclear14/Structures/Power/enclave.rsi
-    drawdepth: Overdoors
+    #drawdepth: Overdoors
     offset: 0, 0.5
     layers:
     - state: generator_enclave_off
@@ -257,8 +257,8 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "-0.3,-0.2,1,0.4"
-        density: 190
+          bounds: "-0.4,-0.1,1.2,0.5"
+        density: 4900
         mask:
         - MachineMask
         layer:
@@ -304,6 +304,17 @@
       output:
         !type:CableDeviceNode
         nodeGroupID: HVPower
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.1,1.2,0.5"
+        density: 4900
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
   - type: PowerMonitoringDevice
     group: Generator
     loadNode: output
@@ -359,6 +370,17 @@
     layers:
     - state: reactoroff
     - state: norm0
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+            bounds: "-1.0,0,1.0,0.5"
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
   - type: PointLight
     radius: 3
     energy: 4.5
@@ -383,7 +405,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "-0.7,0,0.7,0.7"
+            bounds: "-1.0,0,1.0,0.5"
         density: 190
         mask:
         - MachineMask


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Fixes the pre-war uranium reactor not having a property offset causing it to clip into tiles. Also updates the hitboxes for generators and workbenches. to better match the sprites but left a gap for visuals and increases the weight on some of them since they are big and chunky guys.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Make life easier for mappers and make it look good in game.

## Technical details
<!-- Summary of code changes for easier review. -->
All yml.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
<img width="701" height="578" alt="image" src="https://github.com/user-attachments/assets/cf89adc1-76f1-4c98-ac54-5383c8c99053" />

After:
<img width="782" height="524" alt="image" src="https://github.com/user-attachments/assets/5a203046-b3ed-4325-a4e6-ec40af7c14d0" />

Updated hitboxes:
Before you ask why is there a gap at the bottom? I have found out its for aesthetic purposes so it looks like the person can walk up to it. 
Example:
<img width="420" height="255" alt="image" src="https://github.com/user-attachments/assets/044fe65c-580a-4d19-bd88-0cab59b72082" />

Fusion Generator:
<img width="370" height="208" alt="image" src="https://github.com/user-attachments/assets/3d850ae5-eba8-435c-a0f2-40b7b3aadad0" />

Pre-war uranium and fuel generator use the same hitbox and sprite
<img width="285" height="175" alt="image" src="https://github.com/user-attachments/assets/659ef70e-7ee1-489c-9a8f-fba1576c90b1" />

The floor generator hitboxes:
<img width="478" height="196" alt="image" src="https://github.com/user-attachments/assets/2d7df16f-0c92-4295-931d-fb0b3a5ae37f" />

Workbenches:
<img width="1025" height="149" alt="image" src="https://github.com/user-attachments/assets/bdcdcd96-be07-4069-abd5-f4c91f80e3e6" />




# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: AthenaAI
- tweak: Adjusts the offset sprite of the pre-war uranium generator so it actually uses an offset instead of clipping.
- tweak: Adjusted the hitboxes of the workbenches and generators.
- tweak: Adjusted the weight on all generators so they are harder to just take but still possible.
