### PR TITLE
Wastelander C-27 Slots Increase And Super Mutant Passive Fix

### DIFF
--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -34,7 +34,7 @@
           SuperMutantNCRRanger: [ 0, 1 ] # #Misfits Add: NCR Ranger variant latejoin slot.
           SuperMutantNCRTrooper: [ 0, 1 ] # #Misfits Add: NCR Trooper variant latejoin slot.
           SuperMutantTribal: [ 0, 1 ] # #Misfits Add: Tribal variant latejoin slot.
-          C27: [ 0, 1 ]    # #Misfits Add - C-27 Generic latejoin slot (whitelist gates actual access).
+          C27: [ 0, 3 ]    # #Misfits Add - C-27 Generic latejoin slot (whitelist gates actual access)/// Increased to 3 from 1.
           C27NCR: [ 0, 1 ] # #Misfits Add - C-27 NCR variant latejoin slot.
           C27BoS: [ 0, 1 ] # #Misfits Add - C-27 Brotherhood variant latejoin slot.
           # WastelandScavenger: [ 3, 5 ]

--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -34,7 +34,7 @@
           SuperMutantNCRRanger: [ 0, 1 ] # #Misfits Add: NCR Ranger variant latejoin slot.
           SuperMutantNCRTrooper: [ 0, 1 ] # #Misfits Add: NCR Trooper variant latejoin slot.
           SuperMutantTribal: [ 0, 1 ] # #Misfits Add: Tribal variant latejoin slot.
-          C27: [ 0, 3 ]    # #Misfits Add - C-27 Generic latejoin slot (whitelist gates actual access)/// Increased to 3 from 1.
+          C27: [ 0, 2 ]    # #Misfits Add - C-27 Generic latejoin slot (whitelist gates actual access)/// Increased to 2 from 1.
           C27NCR: [ 0, 1 ] # #Misfits Add - C-27 NCR variant latejoin slot.
           C27BoS: [ 0, 1 ] # #Misfits Add - C-27 Brotherhood variant latejoin slot.
           # WastelandScavenger: [ 3, 5 ]

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
@@ -28,6 +28,8 @@
       - type: NpcFactionMember
         factions:
           - PlayerSuperMutant
+          - Wastelander
+      
 
 - type: playTimeTracker
   id: SuperMutant
@@ -65,6 +67,7 @@
       - type: NpcFactionMember
         factions:
           - PlayerSuperMutant
+          - Wastelander
 
 - type: playTimeTracker
   id: Nightkin
@@ -97,6 +100,7 @@
       - type: NpcFactionMember
         factions:
           - PlayerSuperMutant
+          - CaesarLegion
   - !type:AddTraitSpecial
     traits: [ LanguageLatin ]
 - type: startingGear


### PR DESCRIPTION
## About the PR
Increase the slots for generic c27, fixes gladiator and wastelander supermutant not being targeted by npcs.

# Changelog

:cl:
- tweak: Generic C27 slots increased from 1 to 3
- fix: Supermutant roles not being targeted by hostile npcs
- -->
