### PR TITLE
Makes Lead and Sulfur Ore Stackable

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/ore.yml
@@ -4,9 +4,9 @@
   name: lead ore
   suffix: Full
   components:
-  # - type: Stack
-    # stackType: N14LeadOre
-    # count: 10
+  - type: Stack
+    stackType: N14LeadOre
+    count: 10
   - type: Sprite
     sprite: /Textures/_Nuclear14/Objects/Misc/materials.rsi
     state: lead
@@ -27,9 +27,9 @@
   id: N14LeadOre1
   parent: N14LeadOre
   suffix: Single
-  # components:
-    # - type: Stack
-      # count: 1
+  components:
+  - type: Stack
+    count: 1
 
 - type: entity
   parent: OreBase
@@ -169,9 +169,9 @@
   name: sulfur ore
   suffix: Full
   components:
-  # - type: Stack
-    # stackType: SulfurOre
-    # count: 10
+  - type: Stack
+    stackType: SulfurOre
+    count: 10
   - type: Sprite
     sprite: /Textures/_Nuclear14/Objects/Misc/materials.rsi
     state: sulfur
@@ -192,9 +192,9 @@
   id: SulfurOre1
   parent: SulfurOre
   suffix: Single
-  # components:
-    # - type: Stack
-      # count: 1
+  components:
+  - type: Stack
+    count: 1
 
 - type: entity
   parent: OreBase


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->

title. these two ores can now be stacked like all the others

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

i thought this was a bug at first but apparently its intentionally commented out? either way, i dont see the justification for this. sulfur and lead are apparently more valuable to sell but 99% of the time factions dont sell them they just use them to make more supplies. and even if they were super valuable and got sold, so what? if a player has done the work and invested the time to mine all that sulfur and lead, they have earned it. all making them unstackable does is add an anti-qol feature of having to manually place every piece in a box and make it take up more space in crates. its dumb.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: sulfur and lead ore is stackable now


