### PR TITLE
Salvaging Chemicals

### DIFF
--- a/Resources/Prototypes/_Misfits/Recipes/Reactions/salvaged_chemicals.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Reactions/salvaged_chemicals.yml
@@ -1,0 +1,43 @@
+﻿- type: reaction
+  id: AmmoniaBreakdown
+  source: true
+  requiredMixerCategories:
+  - Electrolysis
+  reactants: ## uses oxygen to make water to it doesnt immediately turn back into ammonia, you can then break down the water after removing nitrogen
+    Ammonia: 8
+    Oxygen: 3
+  products:
+    Nitrogen: 2
+    Water: 6
+
+- type: reaction
+  id: BananaYuccaBreakdown
+  source: true
+  requiredMixerCategories: ## electrolyse to boil off the water
+  - Electrolysis
+  reactants:
+    ExtractBananaYucca: 10
+  products:
+    Potassium: 5
+
+- type: reaction
+  id: WaterBreakdown
+  source: true
+  requiredMixerCategories:
+  - Electrolysis
+  reactants:
+    Water: 2
+  products: ##H2O so 1 water is h2 (1 hydrogen molecule) and 1 "O", (.5 oxygen molecules)
+    Hydrogen: 2
+    Oxygen: 1
+
+- type: reaction
+  id: BananaYuccaCentrifuge
+  source: true
+  requiredMixerCategories: ## if you centrifuge it it explodes!
+  - Centrifuge
+  reactants:
+    ExtractBananaYucca: 10
+  products:
+    Potassium: 5
+    Water: 5

--- a/Resources/Prototypes/_Misfits/Recipes/Reactions/salvaged_chemicals.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Reactions/salvaged_chemicals.yml
@@ -21,17 +21,6 @@
     Potassium: 5
 
 - type: reaction
-  id: WaterBreakdown
-  source: true
-  requiredMixerCategories:
-  - Electrolysis
-  reactants:
-    Water: 2
-  products: ##H2O so 1 water is h2 (1 hydrogen molecule) and 1 "O", (.5 oxygen molecules)
-    Hydrogen: 2
-    Oxygen: 1
-
-- type: reaction
   id: BananaYuccaCentrifuge
   source: true
   requiredMixerCategories: ## if you centrifuge it it explodes!

--- a/Resources/Prototypes/_Misfits/Recipes/Reactions/salvaged_chemicals.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Reactions/salvaged_chemicals.yml
@@ -3,7 +3,7 @@
   source: true
   requiredMixerCategories:
   - Electrolysis
-  reactants: ## uses oxygen to make water to it doesnt immediately turn back into ammonia, you can then break down the water after removing nitrogen
+  reactants:
     Ammonia: 8
     Oxygen: 3
   products:
@@ -13,7 +13,7 @@
 - type: reaction
   id: BananaYuccaBreakdown
   source: true
-  requiredMixerCategories: ## electrolyse to boil off the water
+  requiredMixerCategories:
   - Electrolysis
   reactants:
     ExtractBananaYucca: 10
@@ -23,7 +23,7 @@
 - type: reaction
   id: BananaYuccaCentrifuge
   source: true
-  requiredMixerCategories: ## if you centrifuge it it explodes!
+  requiredMixerCategories:
   - Centrifuge
   reactants:
     ExtractBananaYucca: 10

--- a/Resources/Prototypes/_Misfits/Recipes/Reactions/salvaged_chemicals.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Reactions/salvaged_chemicals.yml
@@ -4,8 +4,10 @@
   requiredMixerCategories:
   - Electrolysis
   reactants:
-    Ammonia: 8
-    Oxygen: 3
+    Ammonia:
+      amount: 8
+    Oxygen:
+      amount: 3
   products:
     Nitrogen: 2
     Water: 6
@@ -16,7 +18,8 @@
   requiredMixerCategories:
   - Electrolysis
   reactants:
-    ExtractBananaYucca: 10
+    ExtractBananaYucca:
+      amount: 10
   products:
     Potassium: 5
 
@@ -26,7 +29,8 @@
   requiredMixerCategories:
   - Centrifuge
   reactants:
-    ExtractBananaYucca: 10
+    ExtractBananaYucca:
+      amount: 10
   products:
     Potassium: 5
     Water: 5


### PR DESCRIPTION

## About the PR
adds some recipes to acquire water, potassium, and nitrogen from wasteland resources. dont mix them up!

## Why / Balance
chemists frequently need a little of this or a little of that to make some random chemical. adding recipes to the electrolyser and centrifuge makes the gameplay more immersive and more choices= more fun! we love player agency.
## Technical details
adds salvaged_chemical.yml, 4 recipes:

electrolysing 8 ammonia and 3 oxygen makes 2 nitrogen and 6 water 
electrolysing 10 banana yucca extract makes 5 potassium (burns off the water as hydrogen oxygen gas theoretically)
centrifuging 10 banana yucca extract makes 5 potassium and 5 water! :)

# Changelog

:cl:
- add: 3 recipes for salvaging base reagents from wasteland chemicals
