### PR TITLE
Gravis Pattern Tooling

### DIFF
--- a/Resources/Locale/en-US/_Misfits/loadout-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/loadout-names.ftl
@@ -406,6 +406,7 @@ loadout-name-LoadoutLegionVenatorLightReconnaissanceArmor = Legion venator light
 loadout-name-LoadoutLegionCloakBlack = Legion black cloak
 loadout-name-LoadoutNeckCloakLegionWhite = Legion white cloak
 loadout-name-LoadoutNeckCloakLegionRed = Legion red cloak
+loadout-name-LoadoutLegionPrimeHeavyArmor = Legion Gravis pattern armor
 
 # Miscellaneous eyes
 loadout-name-ClothingEyesGlassesChemist = chemist glasses

--- a/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
@@ -203,3 +203,18 @@
       min: 72000
   items:
     - N14ClothingNeckCloakLegionRed
+
+- type: trait
+  id: LoadoutLegionPrimeHeavyArmor
+  category: Outer
+  cost: 14 # EVERY. SINGLE. POINT.
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - CaesarLegionPrimeDecanus    
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionPrimeDecanus 
+      min: 72000 # unrobust primes should be filtered by the 20 hour mark
+  items:
+    - N14ClothingOuterPowerArmorLegion

--- a/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
@@ -204,10 +204,10 @@
   items:
     - N14ClothingNeckCloakLegionRed
 
-- type: trait
+- type: loadout
   id: LoadoutLegionPrimeHeavyArmor
   category: Outer
-  cost: 14 # EVERY. SINGLE. POINT.
+  Cost: 14 # EVERY. SINGLE. POINT.
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
@@ -207,7 +207,7 @@
 - type: loadout
   id: LoadoutLegionPrimeHeavyArmor
   category: Outer
-  Cost: 14 # EVERY. SINGLE. POINT.
+  cost: 14 # EVERY. SINGLE. POINT.
   exclusive: true
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/legionpa.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/legionpa.yml
@@ -3,22 +3,23 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: N14ClothingOuterPowerArmorLegion
-  name: Legion PA
-  description: Look guys is jhon legion
+  name: Gravis Pattern Armor
+  description: Taken either as a trophy or found, this heavily stripped set of PA has been modified heavily by legion into a usable set of armor. Far lighter than the NCR equivalent, yet still capable and surprisingly light. Leather now acts as the joint coverings, serving to aid in movement further.
   components:
   - type: N14PowerArmor
-    requiresProficiency: false
-  - type: N14BosBackpackSlot # #Misfits Add: All power armor gets an extra backpack slot — fusion core occupies the normal back slot
+    requiresProficiency: false # #Misfits Add - waive training gate for this salvaged variant
   # #Misfits Add: Power armor integrity — separate HP pool. While intact, 98.5% of incoming
   # damage is absorbed by the armor and only 1.5% bleeds through to the wearer.
   # At 0 integrity the ArmorComponent is stripped and the wearer takes full damage.
   # Repair with a welder to restore the pool and re-enable absorption.
   - type: Damageable
   - type: PowerArmorIntegrity
-    maxIntegrity: 350 # #Misfits Tweak: +150 flat integrity buff
+    maxIntegrity: 200        # #Misfits Add - FAR lighter salvaged plating
+    brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply (35% mitigation from plates alone)
+    disableServosLock: true       # #Misfits Add - no servo-lock speed debuff when armor breaks
   - type: Repairable
     fuelCost: 10
-    doAfterDelay: 18 # #Misfits Tweak - Increased weld repair time from 5s to 30s to 18s; 5s was too fast for combat balance, 30 is too slow, current proposal is 18.
+    doAfterDelay: 10 # #Misfits Tweak - Legion salvaged PA is modified with leather and stripped. lower surface to weld makes it slightly faster to fix
     qualityNeeded: Welding
   # End Misfits Add
   - type: Sprite
@@ -27,36 +28,29 @@
     sprite: _Misfits/Clothing/CaesarLegion/legionpa.rsi
     equipDelay: 3 # Power armour should not be easily stealable, it should take time to take off or put on.
     unequipDelay: 6
-    equipSound: # Corvax-Change
-      path: /Audio/_Nuclear14/Effects/PowerArmor/PowerArmor_Enter_01.ogg
-      params:
-        volume: -12
-    unequipSound: # Corvax-Change
-      path: /Audio/_Nuclear14/Effects/PowerArmor/PowerArmor_Enter_01.ogg
-      params:
-        volume: -12
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.85
+    sprintModifier: 0.85
+  - type: ToggleableClothing
+    clothingPrototypes:
+      head: N14ClothingHeadHatLegionpa
+      gloves: N14ClothingPAGauntlets
+      shoes: N14ClothingPABoots
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.75
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.70
         Heat: 0.75
-        Caustic: 0.75
-        Radiation: 0.6
   - type: TemperatureProtection
     coefficient: 0.25
   - type: FireProtection
     reduction: 0.9
-  - type: ExplosionResistance
-    damageCoefficient: 0.15 # #Misfits Tweak: PA shrugs off most grenade blast — ~18 HP at ground zero vs 120 unarmored
   - type: HeldSpeedModifier
     mirrorClothingModifier: false
-    walkModifier: 0.5
-    sprintModifier: 0.5
+    walkModifier: 0.7
+    sprintModifier: 0.7
   - type: MultiHandedItem
   - type: Reflect # #Misfits Change Tweak: Small-caliber rounds (sub-5.56mm) ricochet off power armor at 30% chance. Innate - always active regardless of movement.
     reflects:
@@ -64,16 +58,9 @@
       - MediumCaliber
     reflectProb: 0.3
     reflectProbByType:
-      MediumCaliber: 0.15
+      MediumCaliber: 0.10 #less armor. less reflect.
     innate: true
     spread: 90
-  - type: SpearBlock # #Misfits Change Add: Power armor deflects thrown polearms; falls to ground instead of embedding.
-  - type: PowerArmorBrace # #Misfits Change Add: Grants wearer a hotkey to brace (anchor in place, immobile but can fire, slight damage resistance). 5-second cooldown between stance changes.
-    activeModifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85
   - type: EmitsSoundOnMove # Corvax-Change
     soundCollection:
       collection: N14FootstepPowerArmor
@@ -82,12 +69,15 @@
     requiresWorn: true
     distanceWalking: 2
     distanceSprinting: 3
+      # #Misfits Tweak - Disable brace stance (servos stripped); slot mismatch prevents action from being granted.
+  - type: PowerArmorBrace
+    requiredSlot: BELT
 
 - type: entity
   parent: N14ClothingHeadHatBaseHelmetMetal
   id: N14ClothingHeadHatLegionpa
-  name: Legion Panties
-  description: A ballistic helmet of the pre-war era.
+  name: Gravis Pattern Helmet
+  description: Once a T45 helmet, heavily modified by legion with a solid steel face mask and a plume of a Prime Decanus.
   components:
   - type: Sprite
     sprite: _Misfits/Clothing/CaesarLegion/legionpahelmet.rsi
@@ -96,8 +86,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.75
+        Heat: 0.8
     priceMultiplier: 0.5


### PR DESCRIPTION
## About the PR
Reworked Gravis into its niche, 15% slow salvaged with low integrity but fast (10 seconds) repair time. Less armor % compared to HT armor or true T45. 
It can be attained via 20 hours of specifically prime decanus gameplay. it costs all 14 loadout points. This is mostly for testing how it performs and to make it actually attainable without admin spawn.

## Why / Balance
This just makes it proper into its niche. Also makes it possible to actually get your hands on it for now, I can easily disable that after some live testing in game.

## Technical details
Yml and some FTL. .

## Media

https://github.com/user-attachments/assets/57782672-3e67-4c46-9edb-7de53a8217c9

# Changelog

:cl: Bill Clinton
- add: Gravis Pattern Armor, styled after a Prime Decanus.