### PR TITLE
C 27 Killing

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Melee/shields.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Melee/shields.yml
@@ -7,7 +7,7 @@
     - type: Reflect # #Misfits Change Add: Metal heater shield deflects sub-5.56mm pistol rounds at 30%; degrades while moving.
       reflects:
         - SmallCaliber
-      reflectProb: 0.3
+      reflectProb: 0.10 # It is incrediblly cheap as a shield.
       spread: 90
     - type: SpearBlock # #Misfits Change Add: Legionnaire heater shield deflects thrown polearms.
     - type: Construction
@@ -28,10 +28,10 @@
     - type: Blocking
       passiveBlockModifier:
         coefficients:
-          Blunt: 0.9
-          Slash: 0.9
-          Piercing: 0.9
-          Heat: 0.9
+          Blunt: 0.5
+          Slash: 0.5
+          Piercing: 0.5
+          Heat: 0.5
       activeBlockModifier:
         coefficients:
           Blunt: 0.8
@@ -47,13 +47,13 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 300
+            damage: 150
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
         - trigger:
             !type:DamageTrigger
-            damage: 120 #Weaker shield
+            damage: 60 #Weaker shield
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_armor.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_armor.yml
@@ -78,7 +78,7 @@
         Radiation: 0.0 # explicit immunity (also in MisfitsC27Silicon modset)
   - type: Repairable  # #Misfits Add - weld repair for heavy plating
     fuelCost: 10
-    doAfterDelay: 100
+    doAfterDelay: 30
     qualityNeeded: Welding
   - type: Reflect # #Misfits Add - 20% ricochet on heavy plating; hardened combat chassis deflects most small/medium rounds. .50 bypasses via ignoreResistances:true ALSO BECAUSE OF SHITCODE I CANT REMOVE ENERGY DEFLECT BY ITSELF THE AI THEY HAD CODE REFLECT DECIDED REFLECT IN ITSELF DOES ENERGY DEFLECT
     reflects:

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_armor.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_armor.yml
@@ -47,15 +47,14 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.667   # #Misfits Tweak - 33% DR → 600 effective HP
-        Slash: 0.667
-        Piercing: 0.667
+        Blunt: 0.65   # #Misfits Tweak - 33% DR → 600 effective HP
+        Slash: 0.65
+        Piercing: 0.65
         Heat: 0.70     # slightly weaker heat resist than physical — chassis cooling limits
   - type: Reflect # #Misfits Add - 30% ricochet on medium plating; stacks on top of bare chassis 10% (outermost check wins)
     reflects:
       - SmallCaliber
-      - MediumCaliber
-    reflectProb: 0.30
+    reflectProb: 0.20
     innate: true
     spread: 90
   - type: ClothingSpeedModifier
@@ -79,18 +78,18 @@
         Radiation: 0.0 # explicit immunity (also in MisfitsC27Silicon modset)
   - type: Repairable  # #Misfits Add - weld repair for heavy plating
     fuelCost: 10
-    doAfterDelay: 30
+    doAfterDelay: 100
     qualityNeeded: Welding
-  - type: Reflect # #Misfits Add - 60% ricochet on heavy plating; hardened combat chassis deflects most small/medium rounds. .50 bypasses via ignoreResistances:true
+  - type: Reflect # #Misfits Add - 20% ricochet on heavy plating; hardened combat chassis deflects most small/medium rounds. .50 bypasses via ignoreResistances:true ALSO BECAUSE OF SHITCODE I CANT REMOVE ENERGY DEFLECT BY ITSELF THE AI THEY HAD CODE REFLECT DECIDED REFLECT IN ITSELF DOES ENERGY DEFLECT
     reflects:
       - SmallCaliber
       - MediumCaliber
-    reflectProb: 0.60
+    reflectProb: 0.20
     innate: true
     spread: 90
   - type: ClothingSpeedModifier
-    walkModifier: 0.80 # #Misfits Tweak - 20% penalty; meaningful tradeoff for the DR
-    sprintModifier: 0.80
+    walkModifier: 0.75 # #Misfits Tweak - 25% penalty; meaningful tradeoff for the DR
+    sprintModifier: 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.15 # #Misfits Tweak - 85% explosion reduction
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Shields/shields.yml
@@ -24,7 +24,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 100
+            damage: 50
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
@@ -51,8 +51,8 @@
           Slash: 0.5
           Piercing: 0.5
           Heat: 1
-    - type: Reflect # #Misfits Change Tweak: Reduced small-arms ricochet from 50% to 30%
-      reflectProb: 0.3
+    - type: Reflect # #Made the deflect change 15% to interact with the heavy shields double
+      reflectProb: 0.15
       spread: 150
     - type: SpearBlock # #Misfits Change Add: Shields deflect thrown polearms; falls to ground instead of embedding.
     - type: ClothingSpeedModifier
@@ -93,7 +93,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 200 # Forge-Change
+            damage: 100 # Half'd durabillity due to insanely cheap cost
           behaviors:
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
@@ -115,18 +115,18 @@
           Slash: 0.8
           Piercing: 0.85 # Forge-Change
           Heat: 0.8
-        flatReductions: 
+        flatReductions:
           Blunt: 0.5 # Forge-Change
           Slash: 0.5 # Forge-Change
           Piercing: 0.5 # Forge-Change
           Heat: 1 # Forge-Change
-    - type: Reflect # #Misfits Change Tweak: Reduced small-arms ricochet from 50% to 30%
-      reflectProb: 0.3
+    - type: Reflect # # Made reflect to 20 because the shield is insane
+      reflectProb: 0.20
       spread: 150
     - type: ClothingSpeedModifier
-      walkModifier: 0.85 # Forge-Change 
+      walkModifier: 0.85 # Forge-Change
       sprintModifier: 0.85 # Forge-Change
-    - type: HeldSpeedModifier 
+    - type: HeldSpeedModifier
       mirrorClothingModifier: false
       walkModifier: 0.875 # Forge-Change
       sprintModifier: 0.875 # Forge-Change


### PR DESCRIPTION
## About the PR
Nerfed various C-27 gear and also some incrediblly cheap shields for what they do.

## Why / Balance
As of before this PR, the C-27 humanoid robot could deflect about 2 bren mags TO THE FACE and only have the shield break. That is absolutely insane. Also the shields are used by mostly every fake robust person as they would be basically immortal. Beforehand you could have the innate 60% from the armor and then the 30 from the heavy shield combined to be basically unkillable.

## Technical details
Severely toned down reflect chance for C-27 heavy armor down to 20 (the plan was to remove energy but the componet itself applies the energy deflect tag which is evil and makes it not possible right now to remove only that.


🆑 Bradysgaming

- tweak: Lowerd reflect chance for C-27 Heavy armor drastically 
- tweak: Reduced reflect chance and durabillity for certain often used shields that are VERY cheap
- tweak: Made C-27 Heavy armor 5% slower.