### PR TITLE
Tweaks to Vinyl Player Audio

### DIFF
--- a/Content.Server/_Goobstation/StationRadio/Systems/StationRadioSystem.cs
+++ b/Content.Server/_Goobstation/StationRadio/Systems/StationRadioSystem.cs
@@ -39,6 +39,7 @@ public sealed class StationRadioSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<StationRadioServerComponent, NewLinkEvent>(OnServerNewLink);
+        SubscribeLocalEvent<StationRadioServerComponent, PortDisconnectedEvent>(OnServerDisconnected);
         SubscribeLocalEvent<StationRadioServerComponent, DeviceNetworkPacketEvent>(OnServerRelay);
         SubscribeLocalEvent<StationRadioServerComponent, DeviceNetworkFrequencyChangedEvent>(OnServerChangeFrequency);
         SubscribeLocalEvent<StationRadioServerComponent, PowerChangedEvent>(OnServerPowerChaned);
@@ -60,6 +61,18 @@ public sealed class StationRadioSystem : EntitySystem
 
         ent.Comp.VinylPlayer = args.Source;
     }
+
+    private void OnServerDisconnected(Entity<StationRadioServerComponent> ent, ref PortDisconnectedEvent args)
+    {
+        if (!TryComp<DeviceNetworkComponent>(ent.Owner, out var network)) return;
+        
+        var stopPayload = new NetworkPayload()
+        {
+            [DeviceNetworkConstants.Command] = StopAudioCommand
+        };
+        _device.QueuePacket(ent.Owner, null, stopPayload, network.ReceiveFrequency);
+    }
+
 
     private void OnServerRelay(Entity<StationRadioServerComponent> ent, ref DeviceNetworkPacketEvent args)
     {

--- a/Content.Server/_Goobstation/StationRadio/Systems/VinylPlayerSystem.cs
+++ b/Content.Server/_Goobstation/StationRadio/Systems/VinylPlayerSystem.cs
@@ -79,7 +79,7 @@ public sealed class VinylPlayerSystem : EntitySystem
             || vinyl.Comp.Song == null)
             return;
 
-        var audio = _audio.PlayPredicted(vinyl.Comp.Song, uid, uid, AudioParams.Default.WithVolume(3f).WithMaxDistance(4.5f));
+        var audio = _audio.PlayPredicted(vinyl.Comp.Song, uid, uid, AudioParams.Default.WithVolume(-5f).WithMaxDistance(4.5f));
         if (audio != null)
             comp.SoundEntity = audio.Value.Entity;
 

--- a/Content.Shared/_Goobstation/StationRadio/Components/StationRadioReceiverComponent.cs
+++ b/Content.Shared/_Goobstation/StationRadio/Components/StationRadioReceiverComponent.cs
@@ -22,5 +22,5 @@ public sealed partial class StationRadioReceiverComponent : Component
     /// Default audio params for the played audio.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public AudioParams DefaultParams = AudioParams.Default.WithVolume(3.5f).WithMaxDistance(8f); // 8 is just the edge of the screen usually
+    public AudioParams DefaultParams = AudioParams.Default.WithVolume(-5f).WithMaxDistance(8f); // 8 is just the edge of the screen usually
 }


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Lowers the volume so its more background music than overwhelming music for the vinyl and radio players.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
No more eardrum implosions.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: AthenaAI
- tweak: Lowered the volume by 8db for when playing music on the vinyl and radio players.
- tweak: Disconnecting a radio server will pause the music for all radios.
