### PR TITLE
Update supermutant.yml

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
@@ -39,6 +39,7 @@
   id: SuperMutantVaultSuitGear
   equipment:
     jumpsuit: ClothingSuperMutantVaultSuit
+    id: N14ClothingNeckDogtags # #Misfits Change - wastelander supermutants get dogtag IDs
 
 # #Misfits Add - Nightkin variant with its own whitelist entry.
 - type: job


### PR DESCRIPTION
Adding wastelander supermutant dogtag IDs



## About the PR
Added wastelander dogtag IDs to un-factioned supermutants

## Why / Balance
IDs for players so character names appear on spawn

## Technical details
added "id: N14ClothingNeckDogtags # #Misfits Change - wastelander supermutants get dogtag IDs" to supermutant.yml

## Media
n/a

# Changelog


:cl:
- add: dogtag IDs for unfactioned supermutants

