### PR TITLE
Supermutant Ids, Headset; Nightkin Role, Stealthboy Headset

### DIFF
--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -31,7 +31,6 @@
           SuperMutantFollowerDoctor: [ 0, 1 ] # #Misfits Add: FOTA-aligned supermutant Doctor latejoin slot.
           Wastelander: [ -1, -1 ]
           SuperMutant: [ 0, 3 ] # #Misfits Change /Fix/: make the FEV Mutant role available for mid-round joins.
-          Nightkin: [ 0, 0 ] # # Misfits Add - Nightkin role for mid-round join
           SuperMutantGladiator: [ 0, 1 ] # #Misfits Add: Gladiator variant latejoin slot.
           SuperMutantNCRRanger: [ 0, 1 ] # #Misfits Add: NCR Ranger variant latejoin slot.
           SuperMutantNCRTrooper: [ 0, 1 ] # #Misfits Add: NCR Trooper variant latejoin slot.

--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -31,7 +31,7 @@
           SuperMutantFollowerDoctor: [ 0, 1 ] # #Misfits Add: FOTA-aligned supermutant Doctor latejoin slot.
           Wastelander: [ -1, -1 ]
           SuperMutant: [ 0, 3 ] # #Misfits Change /Fix/: make the FEV Mutant role available for mid-round joins.
-          Nightkin: [ 0, 1 ] # # Misfits Add - Nightkin role for mid-round join
+          Nightkin: [ 0, 0 ] # # Misfits Add - Nightkin role for mid-round join
           SuperMutantGladiator: [ 0, 1 ] # #Misfits Add: Gladiator variant latejoin slot.
           SuperMutantNCRRanger: [ 0, 1 ] # #Misfits Add: NCR Ranger variant latejoin slot.
           SuperMutantNCRTrooper: [ 0, 1 ] # #Misfits Add: NCR Trooper variant latejoin slot.

--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -31,6 +31,7 @@
           SuperMutantFollowerDoctor: [ 0, 1 ] # #Misfits Add: FOTA-aligned supermutant Doctor latejoin slot.
           Wastelander: [ -1, -1 ]
           SuperMutant: [ 0, 3 ] # #Misfits Change /Fix/: make the FEV Mutant role available for mid-round joins.
+          Nightkin: [ 0, 1 ] # # Misfits Add - Nightkin role for mid-round join
           SuperMutantGladiator: [ 0, 1 ] # #Misfits Add: Gladiator variant latejoin slot.
           SuperMutantNCRRanger: [ 0, 1 ] # #Misfits Add: NCR Ranger variant latejoin slot.
           SuperMutantNCRTrooper: [ 0, 1 ] # #Misfits Add: NCR Trooper variant latejoin slot.

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
@@ -39,7 +39,9 @@
   id: SuperMutantVaultSuitGear
   equipment:
     jumpsuit: ClothingSuperMutantVaultSuit
-
+    id: N14ClothingNeckDogtags # #Misfits Change - wastelander supermutants get dogtag IDs
+    ears: MisfitsClothingHeadsetWastelandScrap
+    
 # #Misfits Add - Nightkin variant with its own whitelist entry.
 - type: job
   id: Nightkin
@@ -55,7 +57,7 @@
   whitelisted: true
   hideWithoutWhitelist: true
   spawnLoadout: true
-  startingGear: SuperMutantVaultSuitGear
+  startingGear: NightkinVaultSuitGear # #Misfits changed to nightkin starting gear
   applyTraits: true
   requirements:
     - !type:CharacterSpeciesRequirement
@@ -69,6 +71,14 @@
           - PlayerSuperMutant
           - Wastelander
 
+# #Misfits changed to nightkin starting gear
+- type: startingGear
+  id: NightkinVaultSuitGear
+  equipment:
+    jumpsuit: ClothingSuperMutantVaultSuit
+    ears: MisfitsClothingHeadsetWastelandScrap
+  inhand:
+    -  MisfitsStealthBoy # # Misfits: Add - stealthboy for nightkin role on spawn
 - type: playTimeTracker
   id: Nightkin
 


### PR DESCRIPTION


## About the PR
Added back unfactioned SM ids and added their headset, and an empty role for nightkin whitelist as well as headset and stealthboy for their ID

## Why / Balance
To fix the deleted SM id before and add a headset for all players and to begin adding/correcting things for nightkin roles

## Technical details
Updates supermutant for spawn items, and wendover map to add nightkin role only for those whitelisted as a nightkin species.

## Media
n/a

# Changelog



:cl:
- add: Unfactioned Supermutant IDs and headset, working on Nightkin updates

