### PR TITLE
Added Time as a Squire Needed to Play Paladin

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_paladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_paladin.yml
@@ -67,9 +67,9 @@
     - !type:CharacterDepartmentTimeRequirement # #Misfits Tweak - T4 faction timelock (12h BoS)
       department: BrotherhoodOfSteel
       min: 43200 # 12 hours
-    #- !type:CharacterPlaytimeRequirement # TEMP REMOVED
-    #  tracker: BoSMidSquire
-    #  min: 72000 # 20 hours
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSMidSquire
+      min: 36000 # 10 hours as paladins need to learn how to be a proper paladin via time
   startingGear: BoSPaladinGear
   alwaysUseSpawner: true
   icon: "JobIconBosMPaladin"


### PR DESCRIPTION
Adding squire time needed to play paladin as paladin quality has gone down by paladins not knowing anything about the bos or how to be a paladin, quality control (and semi lore accurate!!! 🤓)

🆑 Bradysgaming

-add: Added 10 hour time req for squire to be a paladin
