### PR TITLE
Update warhorns.yml

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Items/Warhorns/warhorns.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Items/Warhorns/warhorns.yml
@@ -33,7 +33,7 @@
     range: 45
     volume: 1
   - type: UseDelay
-      delay: 5
+    delay: 5
 
 - type: entity
   parent: BaseWarhorn
@@ -52,7 +52,7 @@
     range: 45
     volume: 1
   - type: UseDelay
-      delay: 5
+    delay: 5
 
 - type: entity
   parent: BaseWarhorn
@@ -71,4 +71,4 @@
     range: 45
     volume: 2
   - type: UseDelay
-      delay: 5
+    delay: 5

--- a/Resources/Prototypes/_Misfits/Entities/Items/Warhorns/warhorns.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Items/Warhorns/warhorns.yml
@@ -14,7 +14,7 @@
     range: 45
     volume: 1
   - type: UseDelay
-    delay: 3
+    delay: 5
 
 - type: entity
   parent: BaseWarhorn
@@ -32,6 +32,8 @@
     sound: /Audio/_Misfits/Items/Warhorn/WarHorn02.ogg
     range: 45
     volume: 1
+  - type: UseDelay
+      delay: 5
 
 - type: entity
   parent: BaseWarhorn
@@ -49,12 +51,14 @@
     sound: /Audio/_Misfits/Items/Warhorn/WarHorn01.ogg
     range: 45
     volume: 1
+  - type: UseDelay
+      delay: 5
 
 - type: entity
   parent: BaseWarhorn
   id: WarhornNCRBugle
   name: Bugle
-  description: Fine men of California, charge!
+  description: Fine soldiers of California, charge!
   components:
   - type: Sprite
     sprite: /Textures/_Misfits/Objects/Warhorns/ncrbugle.rsi
@@ -66,3 +70,5 @@
     sound: /Audio/_Misfits/Items/Warhorn/BugleCharge.ogg
     range: 45
     volume: 2
+  - type: UseDelay
+      delay: 5


### PR DESCRIPTION

## About the PR
added delays to warhorns to reduce player ear damage. also made bugle description gender neutral cause uh its 2296

## Why / Balance
warhorns be hurting our ears when spammed

## Technical details
  - type: UseDelay
      delay: 5
      
      added to all warhorns
# Changelog
:cl:
- tweak: added use delay to warhorns
