### PR TITLE
Update Jobs Species Requirement Of Nightkin

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Followers/followers.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Followers/followers.yml
@@ -55,6 +55,7 @@
     - RobotRobobrain
     - RobotRobobrainLaser
     - SuperMutant
+    - Nightkin
   special:
   - !type:AddComponentSpecial
     components:
@@ -127,6 +128,7 @@
     - RobotRobobrain
     - RobotRobobrainLaser
     - SuperMutant
+    - Nightkin
   special:
   - !type:AddComponentSpecial
     components:
@@ -193,6 +195,7 @@
     - RobotRobobrain
     - RobotRobobrainLaser
     - SuperMutant
+    - Nightkin
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/chief_ranger.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/chief_ranger.yml
@@ -40,6 +40,7 @@
       - RobotRobobrainLaser
       - SuperMutant
       - GhoulGlowing # #Misfits Tweak - glowing ghouls not allowed in NCR Rangers
+      - Nightkin
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_chief.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_chief.yml
@@ -41,6 +41,7 @@
       - RobotRobobrain # #Misfits Fix - missing robot chassis
       - RobotRobobrainLaser # #Misfits Fix - missing variant species
       - SuperMutant
+      - Nightkin
 
 - type: startingGear
   id: RangerChiefGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -40,6 +40,7 @@
       - RobotRobobrain # #Misfits Fix - missing robot chassis
       - RobotRobobrainLaser # #Misfits Fix - missing variant species
       - SuperMutant
+      - Nightkin
       - GhoulGlowing # #Misfits Tweak - glowing ghouls not allowed in NCR Rangers
 
 - type: startingGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_veteran.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_veteran.yml
@@ -46,6 +46,7 @@
       - RobotRobobrainLaser # #Misfits Fix - missing variant species
       - SuperMutant
       - GhoulGlowing # #Misfits Tweak - glowing ghouls not allowed in NCR Rangers
+      - Nightkin
 
 - type: startingGear
   id: NCRVeteranRangerGear

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/farmer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/farmer.yml
@@ -27,6 +27,7 @@
       - RobotRobobrain # #Misfits Fix - missing robot chassis
       - RobotRobobrainLaser # #Misfits Fix - missing variant species
       - SuperMutant #Misfits Change /Add: SuperMutants cannot be Town Farmers
+      - Nightkin
   access:
   - WastelandFarmer
   - TownsPerson # Corvax-Change

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/wastelander.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/wastelander.yml
@@ -26,6 +26,7 @@
     - RobotRobobrain # #Misfits Fix - missing robot chassis
     - RobotRobobrainLaser # #Misfits Fix - missing variant species
     - SuperMutant
+    - Nightkin
     - C27
     - C27NCR
     - C27BoS


### PR DESCRIPTION
## About the PR
Added Nightkin to the blocked species for wastelander, town farmer, NCR rangers and FoTA

## Why / Balance
Updating jobs to correct nightkin species issues

## Technical details
Added - Nightkin to list of blocked species for the jobs listed, wastelander, town farmer, NCR rangers and FoTA

## Media
n/a

# Changelog

:cl:
- add: Adjusted job roles to reflect Nightkin species requirements