### PR TITLE
Promethine Potency Decrease/BOS Timefix

### DIFF
--- a/Resources/Prototypes/_Misfits/Reagents/promethine.yml
+++ b/Resources/Prototypes/_Misfits/Reagents/promethine.yml
@@ -14,4 +14,7 @@
     Medicine:
       metabolismRate: 0.5
       effects:
-      - !type:GhoulReversalEffect
+        - !type:GhoulReversalEffect
+          conditions:
+            - !type:ReagentThreshold
+              min: 5

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
@@ -21,6 +21,9 @@
     - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 8h as Senior Paladin before Head Paladin
       tracker: BoSMidPaladin
       min: 28800 # 8 hours as Senior Paladin
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSMidSquire
+      min: 36000 # 10 hours
   startingGear: BoSMidPaladinCommanderGear
   alwaysUseSpawner: true
   icon: "JobIconBosMCommander" # Corvax-Change

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorpaladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_seniorpaladin.yml
@@ -20,6 +20,9 @@
     - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 8h as Paladin before Senior Paladin (matches Knight/Scribe pattern)
       tracker: BoSPaladin
       min: 28800 # 8 hours as Paladin
+    - !type:CharacterPlaytimeRequirement
+      tracker: BoSMidSquire
+      min: 36000 # 10 hours
   startingGear: BoSMidPaladinGear
   alwaysUseSpawner: true
   icon: "JobIconBosMPaladin" # Corvax-Change


### PR DESCRIPTION
## About the PR
promethine now requires minimum 5u to work, just like ambuzol plus, instead of 0.01u
added squire time from paladin to HP and SP
## Why / Balance
making any amount was enough to cure the entire server, this is not intended
chance wanted parity
## Technical details
conditions:
            - !type:ReagentThreshold
              min: 5
# Changelog
:cl:
- fix: promethine now requires 5u at once to cure, identical to AmbuzolPlus from basegame.
- fix: HP and SP now require 10 hours of squire, just like regular paladin. this wont impact anyone who meets the new paladin requirements. 