### PR TITLE
Rangerarmor

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -1071,8 +1071,8 @@
   - type: ExplosionResistance
     damageCoefficient: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 1.05
-    sprintModifier: 1.05
+    walkModifier: 1.1 # Same bonus as the Legion kind
+    sprintModifier: 1.1
 
 #MARK: Veteran
 
@@ -1091,11 +1091,15 @@
       coefficients:
         Blunt: 0.75
         Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
+        Piercing: 0.70 # Isn't this suppose to be the better armor, why does this armor have only 25 reduction?
+        Heat: 0.70
     priceMultiplier: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 1.1 # Same bonus as the Legion armor
+    sprintModifier: 1.1
+
 
 - type: entity
   parent: N14ClothingOuterBase
@@ -1501,8 +1505,8 @@
   - type: ExplosionResistance
     damageCoefficient: 0.8
   - type: ClothingSpeedModifier # Forge-Change
-    walkModifier: 1.05
-    sprintModifier: 1.05
+    walkModifier: 1.1 
+    sprintModifier: 1.1
 
 # New Midwest BoS stuff after rework
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
@@ -112,13 +112,10 @@
 
 
 - type: loadout
-  id: N14GoliathFistCent
+  id: N14GoliathFist
   category: Hands
-  cost: 3
+  cost: 4
   requirements:
-    - !type:CharacterJobRequirement
-      jobs:
-      - CaesarLegionCenturion
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutHands
   items:

--- a/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
@@ -127,17 +127,3 @@
     - N14ClothingHandsPowerFistGoliath
 
 
-- type: loadout
-  id: N14GoliathFist
-  category: Hands
-  cost: 8
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: N14LoadoutHands    
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - CaesarLegion
-        - Tribal
-  items:
-    - N14ClothingHandsPowerFistGoliath
-

--- a/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
@@ -120,6 +120,6 @@
       jobs:
       - CaesarLegionCenturion
     - !type:CharacterItemGroupRequirement
-      group: N14LoadoutMelee
+      group: N14LoadoutHands
   items:
     - N14ClothingHandsPowerFistGoliath

--- a/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
@@ -117,7 +117,7 @@
   cost: 3
   requirements:
     - !type:CharacterJobRequirement
-      traits:
+      jobs:
       - CaesarLegionCenturion
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutMelee

--- a/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
@@ -111,12 +111,33 @@
     - N14ClothingHandsGlovesNitrilePurple
 
 
+
 - type: loadout
-  id: N14GoliathFist
+  id: N14GoliathFistLeader
   category: Hands
   cost: 4
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutHands
+    - !type:CharacterJobRequirement
+      job:
+        - CaesarLegionCenturion 
+        - TribalElder
   items:
     - N14ClothingHandsPowerFistGoliath
+
+
+- type: loadout
+  id: N14GoliathFist
+  category: Hands
+  cost: 8
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHands    
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - CaesarLegion
+        - Tribal
+  items:
+    - N14ClothingHandsPowerFistGoliath
+

--- a/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/hands.yml
@@ -109,3 +109,17 @@
       - Overseer
   items:
     - N14ClothingHandsGlovesNitrilePurple
+
+
+- type: loadout
+  id: N14GoliathFistCent
+  category: Hands
+  cost: 3
+  requirements:
+    - !type:CharacterJobRequirement
+      traits:
+      - CaesarLegionCenturion
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMelee
+  items:
+    - N14ClothingHandsPowerFistGoliath

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -486,10 +486,6 @@
   category: Weapons
   cost: 3
   requirements:
-    - !type:CharacterTraitRequirement
-      traits:
-      - LanguageLatin
-      - LanguageNerd 
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutMelee
     - !type:CharacterDepartmentRequirement
@@ -518,11 +514,6 @@
   category: Weapons
   cost: 5
   requirements:
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-      - LanguageLatin
-      - LanguageNerd 
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutMelee    
     - !type:CharacterDepartmentRequirement

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -502,6 +502,10 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutMelee
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - BrotherhoodOfSteel 
   items:
     - N14LongSword
 
@@ -511,7 +515,11 @@
   cost: 5
   requirements:
     - !type:CharacterItemGroupRequirement
-      group: N14LoadoutMelee
+      group: N14LoadoutMelee    
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - CaesarLegion
   items:
     - N14Gladius
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -536,7 +536,7 @@
   cost: 5
   requirements:
     - !type:CharacterJobRequirement
-      traits:
+      jobs:
       - CaesarLegionCenturion
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutMelee

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -467,6 +467,34 @@
   items:
     - N14TribalSword
 
+    
+- type: loadout
+  id: N14LongSwordBoS
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMelee
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - BrotherhoodOfSteel # Longsword with the medieval themed faction
+  items:
+    - N14LongSword
+
+- type: loadout
+  id: N14GladiusLegion
+  category: Weapons
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMelee
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - CaesarLegion # Basically free for some roles, others don't get that
+  items:
+    - N14Gladius
+
+
 - type: loadout
   id: N14LongSword
   category: Weapons
@@ -476,6 +504,16 @@
       group: N14LoadoutMelee
   items:
     - N14LongSword
+
+- type: loadout
+  id: N14Gladius
+  category: Weapons
+  cost: 5
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMelee
+  items:
+    - N14Gladius
 
 - type: loadout
   id: N14ChineseSword
@@ -490,3 +528,17 @@
       group: N14LoadoutMelee
   items:
     - N14ChineseSword
+
+
+- type: loadout
+  id: N14CeremonialSwordCent
+  category: Weapons
+  cost: 5
+  requirements:
+    - !type:CharacterJobRequirement
+      traits:
+      - CaesarLegionCenturion
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutMelee
+  items:
+    - N14CeremonialSword

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -486,6 +486,10 @@
   category: Weapons
   cost: 3
   requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+      - LanguageLatin
+      - LanguageNerd 
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutMelee
     - !type:CharacterDepartmentRequirement
@@ -514,6 +518,11 @@
   category: Weapons
   cost: 5
   requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+      - LanguageLatin
+      - LanguageNerd 
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutMelee    
     - !type:CharacterDepartmentRequirement


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Hey I know yall hate buffing the bears, I do too. However after playing with legion armor's 10% increase in speed, I found it odd that the ranger armor(ncr's scouts) are weirdly only at 5% increase in speed, also the armor the field ranger spawns with, not only lack a speed boost, but is also worse than the recon for some reason.

Second I just find it odd that no rangers spawn with the recon coat, and instead spawn with a combat armor.
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: recon ranger and ranger armor now both have a speed boost, and ranger armor is slightly better
- tweak: patrol ranger now starts with recon ranger armor, instead of ncr combat armor
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
