### PR TITLE
Slightly Buffs Recon and Field Ranger Armor

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -1071,8 +1071,8 @@
   - type: ExplosionResistance
     damageCoefficient: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 1.05
-    sprintModifier: 1.05
+    walkModifier: 1.1
+    sprintModifier: 1.1
 
 #MARK: Veteran
 
@@ -1091,11 +1091,15 @@
       coefficients:
         Blunt: 0.75
         Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
+        Piercing: 0.7 # Slight buff
+        Heat: 0.7
     priceMultiplier: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 1.1
+    sprintModifier: 1.1
+
 
 - type: entity
   parent: N14ClothingOuterBase
@@ -1501,8 +1505,8 @@
   - type: ExplosionResistance
     damageCoefficient: 0.8
   - type: ClothingSpeedModifier # Forge-Change
-    walkModifier: 1.05
-    sprintModifier: 1.05
+    walkModifier: 1.1 # consistency and yes I know we don't have bluprints of these 
+    sprintModifier: 1.1
 
 # New Midwest BoS stuff after rework
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -1071,7 +1071,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 1.1
+    walkModifier: 1.1 # same as legion recon armor
     sprintModifier: 1.1
 
 #MARK: Veteran
@@ -1097,8 +1097,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 1.1
-    sprintModifier: 1.1
+
 
 
 - type: entity


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Makes the Recon's 5% increase in speed, into a 10%(same as legion armor)
Field Ranger Armor Value buff to 30% heat and pierce, cause it was just the recon without speed.
Look I know we hate buffing Ncrs, but this is just something I found odd about the ranger armors
I recently played some legion with their yknow 10% speed armor, and it was great. Going to get my ranger hours, I found that the recon only has 5% despite not being that good(at least comparing to Veteran, but like most legionaries run that armor so its not a crazy difference, vet armor has 35% pierce with that speed)
And Field Ranger armor, just has 25% which is just weird.
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Wazura
- tweak: Recon Ranger Armor Speed set to 10%(5% increase)
- tweak: Ranger Coat Armor Vault set to 30% for Both Pierce and Heat(5% increase)
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
