### PR TITLE
Update supermutant_clothing.yml for SM Trooper Helmet

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
@@ -309,6 +309,11 @@
   - type: Tag
     tags:
     - SuperMutantWearable
+    modifiers:
+      coefficients:
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
 
 # #Misfits Add - Extra supermutant outer outfit (outfit C) — spawnable standalone wearable.
 - type: entity


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Makes the Supermutant Trooper Helmet actually have armor (same as the gladiator helmet) 

## Why / Balance
Because it's not fair that the gladiator helmet gets armor and the trooper helmet doesn't xD 

## Technical details
  Blunt: 0.5
  Slash: 0.5
  Piercing: 0.5 

## Media
<!-- N/A -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->


:cl: pierow
- fix: Adds armor to SM Trooper helmet
