### PR TITLE
Adds Armor Values to SM NCR Trooper Helmet

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
@@ -309,6 +309,11 @@
   - type: Tag
     tags:
     - SuperMutantWearable
+    modifiers:
+      coefficients:
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
 
 # #Misfits Add - Extra supermutant outer outfit (outfit C) — spawnable standalone wearable.
 - type: entity

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
@@ -309,6 +309,7 @@
   - type: Tag
     tags:
     - SuperMutantWearable
+  - type: Armor # #Misfits Add - 50% physical damage resistance (head protection)
     modifiers:
       coefficients:
         Blunt: 0.5


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Adds armor values to SM NCR Trooper Helmet

## Why / Balance
Someone forgot to to give it armor (it's sharing the same values as the gladiator helmet)

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: pierow
- fix: Adds armor values to SM NCR Trooper Helmet
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
