### PR TITLE
Synthetic Plasma Caster Parity Fix

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
@@ -343,7 +343,7 @@
     availableModes:
     - SemiAuto
   - type: BasicEntityAmmoProvider # #Misfits Add: limited plasma shots, auto-refills after cooldown
-    proto: BulletPlasma
+    proto: BulletBigPlasma
     capacity: 15
     count: 15
   - type: RechargeBasicEntityAmmo # #Misfits Add: recharge simulates internal capacitor cycling

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -38,7 +38,7 @@
     autoRecharge: true
     autoRechargeRate: 1000
   - type: ProjectileBatteryAmmoProvider
-    proto: BulletPlasma
+    proto: BulletBigPlasma
     fireCost: 100
   - type: MagazineVisuals
     magState: mag


### PR DESCRIPTION
## About the PR
changed gutsy projectile to match equivalent regular weapon


## Why / Balance
gutsy has a caster, changed bullet to match plasma caster handheld

## Technical details
BulletPlasma -> BulletBigPlasma

# Changelog
:cl:
- tweak: changed gutsy bullet type