### PR TITLE
WL Slots Increase (And A Small SM Nerf)

### DIFF
--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -31,13 +31,13 @@
           SuperMutantFollowerDoctor: [ 0, 1 ] # #Misfits Add: FOTA-aligned supermutant Doctor latejoin slot.
           Wastelander: [ -1, -1 ]
           SuperMutant: [ 0, 3 ] # #Misfits Change /Fix/: make the FEV Mutant role available for mid-round joins.
-          SuperMutantGladiator: [ 0, 1 ] # #Misfits Add: Gladiator variant latejoin slot.
+          SuperMutantGladiator: [ 0, 2 ] # #Misfits Add: Gladiator variant latejoin slot.
           SuperMutantNCRRanger: [ 0, 1 ] # #Misfits Add: NCR Ranger variant latejoin slot.
           SuperMutantNCRTrooper: [ 0, 1 ] # #Misfits Add: NCR Trooper variant latejoin slot.
           SuperMutantTribal: [ 0, 1 ] # #Misfits Add: Tribal variant latejoin slot.
           C27: [ 0, 2 ]    # #Misfits Add - C-27 Generic latejoin slot (whitelist gates actual access)/// Increased to 2 from 1.
           C27NCR: [ 0, 1 ] # #Misfits Add - C-27 NCR variant latejoin slot.
-          C27BoS: [ 0, 1 ] # #Misfits Add - C-27 Brotherhood variant latejoin slot.
+          C27BoS: [ 0, 2 ] # #Misfits Add - C-27 Brotherhood variant latejoin slot.
           # WastelandScavenger: [ 3, 5 ]
           WastelandReporter: [ 1, 2 ]
           # WastelandMusician: [ 2, 3 ]

--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Species/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Species/supermutant.yml
@@ -119,10 +119,10 @@
   - type: Oni
     modifiers:
       coefficients:
-        Blunt: 2.0
-        Slash: 2.0
-        Piercing: 2.0
-        Shock: 2.0
+        Blunt: 1.5
+        Slash: 1.5
+        Piercing: 1.5
+        Shock: 1.5
   - type: MeleeThrowOnHit
     speed: 15
     lifetime: 0.025


### PR DESCRIPTION
## About the PR
increase to two the slots of C-27 Brotherhood, Legion supermutant gladiator. Nerf supermutant melee damage to 1.5x instead of 2x.

## Why / Balance
NCR was the faction (and still is) with most WL slots, these are kind of powerfull on their own so making the other mayor players having them would balance things out. also SM are kind of overpowered on my opinion so i nerfed a little.

## Technical details
Yalm change

## Media
<img width="1079" height="633" alt="they-dont-even-ask-for-x-they-just-look-at-you-like-this" src="https://github.com/user-attachments/assets/0220914a-8193-4a76-a9f7-e18e817b4c1a" />


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added one more slots to brotherhood C-27 and Legion SM gladiator.
- tweak: SM melee bonus decreased to 1.5 instead of 2x
-->
