### PR TITLE
SM Backpacks Fix

### DIFF
--- a/Resources/Prototypes/_Misfits/InventoryTemplates/supermutant_inventory_template.yml
+++ b/Resources/Prototypes/_Misfits/InventoryTemplates/supermutant_inventory_template.yml
@@ -152,15 +152,4 @@
       uiWindowPos: 3,0
       strippingWindowPos: 0,5
       displayName: Back
-    - name: back2
-      slotTexture: back
-      fullTextureName: template_small
-      slotFlags: BACK
-      slotGroup: SecondHotbar
-      stripTime: 6
-      uiWindowPos: 4,0
-      strippingWindowPos: 2,6
-      dependsOn: outerClothing
-      dependsOnComponents:
-      - type: N14BosBackpackSlot
-      displayName: Extra Back
+  


### PR DESCRIPTION
## About the PR
Removed second backpack slot from SM. 
## Why / Balance
 it wasnt supposed to be there. says dan

# Changelog
:cl:
- remove: sm second backpack slot
