### PR TITLE
Fixed SM PA Backpack Slot

### DIFF
--- a/Resources/Prototypes/_Misfits/InventoryTemplates/supermutant_inventory_template.yml
+++ b/Resources/Prototypes/_Misfits/InventoryTemplates/supermutant_inventory_template.yml
@@ -152,4 +152,16 @@
       uiWindowPos: 3,0
       strippingWindowPos: 0,5
       displayName: Back
-  
+    - name: back2 # Misfits Change - power armor extra backpack slot
+      slotTexture: back
+      fullTextureName: template_small
+      slotFlags: BACK
+      slotGroup: SecondHotbar
+      stripTime: 6
+      uiWindowPos: 4,0
+      strippingWindowPos: 2,6
+      dependsOn: outerClothing
+      hideOnDepsMissing: true
+      dependsOnComponents:
+      - type: N14BosBackpackSlot
+      displayName: Extra Back


### PR DESCRIPTION
## About the PR
 added 2nd backpack slot for SM WHEN WEARING POWERARMOR
## Why / Balance
parity with humans
## Technical details
    - name: back2 # Misfits Change - power armor extra backpack slot
      slotTexture: back
      fullTextureName: template_small
      slotFlags: BACK
      slotGroup: SecondHotbar
      stripTime: 6
      uiWindowPos: 4,0
      strippingWindowPos: 2,6
      dependsOn: outerClothing
      hideOnDepsMissing: true ##THIS WAS MISSING
      dependsOnComponents:
      - type: N14BosBackpackSlot
      displayName: Extra Back

# Changelog

:cl:
- add: Added SM PA 2nd bag slot