### PR TITLE
Power Armor Rebalance to Bring Thing's in Line with the "Power Armor Parity" PR 

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/legionpa.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/legionpa.yml
@@ -39,10 +39,10 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.75
+        Blunt: 0.55
+        Slash: 0.55
+        Piercing: 0.55
+        Heat: 0.55
   - type: TemperatureProtection
     coefficient: 0.25
   - type: FireProtection
@@ -55,7 +55,6 @@
   - type: Reflect # #Misfits Change Tweak: Small-caliber rounds (sub-5.56mm) ricochet off power armor at 30% chance. Innate - always active regardless of movement.
     reflects:
       - SmallCaliber
-      - MediumCaliber
     reflectProb: 0.3
     reflectProbByType:
       MediumCaliber: 0.10 #less armor. less reflect.

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -260,12 +260,12 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.285
-        Slash: 0.285
-        Piercing: 0.285
-        Heat: 0.285
-        Caustic: 0.285
-        Radiation: 0.25
+        Blunt: 0.25
+        Slash: 0.25
+        Piercing: 0.25
+        Heat: 0.25
+        Caustic: 0.25
+        Radiation: 0.15
   - type: ExplosionResistance
     damageCoefficient: 0.08 # #Misfits Tweak: X-01 advanced plating — ~10 HP at ground zero
   - type: UserInterface
@@ -304,11 +304,11 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.35
-        Slash: 0.35
-        Piercing: 0.35
-        Heat: 0.35
-        Caustic: 0.35
+        Blunt: 0.3
+        Slash: 0.3
+        Piercing: 0.3
+        Heat: 0.3
+        Caustic: 0.3
         Radiation: 0.25
   - type: ExplosionResistance
     damageCoefficient: 0.10 # #Misfits Tweak: X-02 blast resistance — ~12 HP at ground zero

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -260,12 +260,12 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.65
-        Heat: 0.65
-        Caustic: 0.75
-        Radiation: 0.6
+        Blunt: 0.285
+        Slash: 0.285
+        Piercing: 0.285
+        Heat: 0.285
+        Caustic: 0.285
+        Radiation: 0.25
   - type: ExplosionResistance
     damageCoefficient: 0.08 # #Misfits Tweak: X-01 advanced plating — ~10 HP at ground zero
   - type: UserInterface
@@ -304,12 +304,12 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.70
-        Caustic: 0.75
-        Radiation: 0.6
+        Blunt: 0.35
+        Slash: 0.35
+        Piercing: 0.35
+        Heat: 0.35
+        Caustic: 0.35
+        Radiation: 0.25
   - type: ExplosionResistance
     damageCoefficient: 0.10 # #Misfits Tweak: X-02 blast resistance — ~12 HP at ground zero
   - type: UserInterface
@@ -357,12 +357,12 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.70
-        Caustic: 0.75
-        Radiation: 0.5
+        Blunt: 0.20
+        Slash: 0.20
+        Piercing: 0.20
+        Heat: 0.20
+        Caustic: 0.20
+        Radiation: 0.1
   - type: ExplosionResistance
     damageCoefficient: 0.06 # #Misfits Tweak: Hellfire designed for combat — best blast resistance, ~7 HP at ground zero
   - type: UserInterface
@@ -392,12 +392,12 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.80
-        Heat: 0.80
-        Caustic: 0.75
-        Radiation: 0.65
+        Blunt: 0.45
+        Slash: 0.45
+        Piercing: 0.45
+        Heat: 0.45
+        Caustic: 0.45
+        Radiation: 0.3
   - type: ExplosionResistance
     damageCoefficient: 0.20 # #Misfits Tweak: Raider PA cobbled together — weakest blast protection, ~24 HP at ground zero
   - type: UserInterface
@@ -483,12 +483,12 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.70
-        Caustic: 0.75
-        Radiation: 0.6
+        Blunt: 0.325
+        Slash: 0.325
+        Piercing: 0.325
+        Heat: 0.325
+        Caustic: 0.325
+        Radiation: 0.25
   - type: Storage
     grid:
     - 0,0,2,1
@@ -716,12 +716,12 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.675
-        Slash: 0.675
-        Piercing: 0.675
-        Heat: 0.675
-        Caustic: 0.75
-        Radiation: 0.6
+        Blunt: 0.3
+        Slash: 0.3
+        Piercing: 0.3
+        Heat: 0.3
+        Caustic: 0.3
+        Radiation: 0.25
   - type: Storage
     grid:
     - 0,0,2,1

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -592,12 +592,12 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.80
-        Heat: 0.80
-        Caustic: 0.75
-        Radiation: 0.65
+        Blunt: 0.45
+        Slash: 0.45
+        Piercing: 0.45
+        Heat: 0.45
+        Caustic: 0.45
+        Radiation: 0.35
   - type: TemperatureProtection
     coefficient: 0.55
   - type: ExplosionResistance


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Since squaggles is changing T-45 and T-60 i thought i'd touch up everything inbetween to meet the trend that was being set for power armor , Enclave power armors being by far the toughest and scariest while Head paladin gets access to a horrifying set of t-51B , Raider power armor is also quite useful in a pinch, alongside salvaged and gravis power armor being quite scary overall

## Why / Balance
To bring all other power armors in line with squaggles PR and overall make salvaged PA user's quite a fuckass challenge to face in the field

## Technical details
like some lines of shit changed

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- changed:🔧 Power armor stats across the board , you should be feeling like a tank no-matter which set of PA you dawn. 
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
