### PR TITLE
Explorer Veteran Armor In Loadouts

### DIFF
--- a/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/Roles/loadouts_legion.yml
@@ -212,9 +212,39 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - CaesarLegionPrimeDecanus    
+        - CaesarLegionPrimeDecanus
     - !type:CharacterPlaytimeRequirement
-      tracker: CaesarLegionPrimeDecanus 
+      tracker: CaesarLegionPrimeDecanus
       min: 72000 # unrobust primes should be filtered by the 20 hour mark
   items:
     - N14ClothingOuterPowerArmorLegion
+
+- type: loadout
+  id: LoadoutLegionExplorerVeteranArmor
+  category: Outer
+  cost: 6
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - CaesarLegionExplorer
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionExplorer
+      min: 30000
+  items:
+    - MisfitsExplorerAssasin
+
+- type: loadout
+  id: LoadoutLegionExplorerVeteranHelmet
+  category: Head
+  cost: 6
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - CaesarLegionExplorer
+    - !type:CharacterPlaytimeRequirement
+      tracker: CaesarLegionExplorer
+      min: 30000
+  items:
+    - MisfitsExplorerAssasinHelmet


### PR DESCRIPTION
## About the PR
adds the new explorer Veteran Armor for the explorer role in the loadout tab

## Why / Balance
You can obtain it after playing the role for some rounds

## Technical details
Yalm change

# Changelog
:cl:
- add: Added legion explorer veteran armor to their loadout

