### PR TITLE
The Copper Age and Other Things

### DIFF
--- a/Resources/Locale/en-US/storage/components/secret-stash-component.ftl
+++ b/Resources/Locale/en-US/storage/components/secret-stash-component.ftl
@@ -9,3 +9,4 @@ comp-secret-stash-on-examine-found-hidden-item = There is something hidden insid
 
 secret-stash-part-plant = the plant
 secret-stash-part-toilet = the toilet cistern
+secret-stash-part-vent = the vent

--- a/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
@@ -38,7 +38,11 @@
         - CapacitorStockPart
     - type: Tag
       tags:
+        # Misfits Change: Make N14 Capacitors compatible with the other capacitors and vice versa
         - CapacitorStockPart
+        - N14Capacitor
+        - JunkItem
+        - Trash
 
 - type: entity
   id: MicroManipulatorStockPart

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -5,6 +5,7 @@
   description: This one says 'BLAST DONGER'.
   components:
   - type: AccessReader
+    containerAccessProvider: board
   - type: Sprite
     sprite: Structures/Doors/Shutters/blastdoor.rsi
     layers:

--- a/Resources/Prototypes/Entities/Structures/Wallmount/wallmounts.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmount/wallmounts.yml
@@ -14,14 +14,23 @@
   - type: Sprite
     drawdepth: Overdoors
     sprite: Structures/Storage/storage.rsi
-    state: vent
+    layers:
+    - state: vent
+      map: [ "DoorVisualState.DoorOpen" ]
   - type: SecretStash
     secretPartName: secret-stash-part-vent
     maxItemSize: Normal
+    openableStash: true
   - type: ContainerContainer
     containers:
       stash: !type:ContainerSlot {}
-  - type: PottedPlantHide # TODO: This needs changed to be generic stash hide?
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.StashVisuals.DoorVisualState:
+        DoorVisualState.DoorOpen:
+          DoorOpen: { state: vent-open }
+          DoorClosed: { state: vent }
 
 - type: entity
   parent: WallmountVent
@@ -29,17 +38,23 @@
   suffix: damaged
   components:
   - type: Sprite
-    sprite: Structures/Storage/storage.rsi
-    state: vent-damaged
-
+    layers:
+    - state: vent-damaged
+      map: [ "DoorVisualState.DoorOpen" ]
+  - type: SecretStash
+    toggleOpen: true
+      
 - type: entity
   parent: WallmountVent
   id: WallmountVentOpen
   suffix: open
   components:
   - type: Sprite
-    sprite: Structures/Storage/storage.rsi
-    state: vent-open
+    layers:
+    - state: vent-open
+      map: [ "DoorVisualState.DoorOpen" ]
+  - type: SecretStash
+    toggleOpen: true
 
 
 # First Aid

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/blast_door.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/blast_door.yml
@@ -9,7 +9,7 @@
             - !type:SetAnchor
               value: false
           steps:
-            - material: Plasteel
+            - material: Lead #Misfits Changed
               amount: 10
               doAfter: 3
 
@@ -45,13 +45,13 @@
           conditions:
             - !type:EntityAnchored {}
           steps:
-            - tag: DoorElectronics
-              store: board
-              name: Door Electronics
-              icon:
-                sprite: "Objects/Misc/module.rsi"
-                state: "door_electronics"
-              doAfter: 2
+          - component: DoorElectronics
+            store: board
+            name: "door electronics circuit board"
+            icon:
+              sprite: "Objects/Misc/module.rsi"
+              state: "door_electronics"
+            doAfter: 3
         - to: frame1
           completed:
             - !type:SpawnPrototype
@@ -99,6 +99,7 @@
 
     - node: blastdoor
       entity: BlastDoorOpen
+      doNotReplaceInheritingEntities: true
       edges:
         - to: frame4
           conditions:

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -834,6 +834,7 @@
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: true
+  hide: false
 
 - type: construction
   name: catwalk

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/machine.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/machine.yml
@@ -41,11 +41,9 @@
     state: service
   - type: MachineBoard
     prototype: TapeDeck
+    requirements:
+        Capacitor: 2
     tagRequirements:
-      N14Capacitor:
-        ExamineName: capacitor
-        DefaultPrototype: N14JunkComponentCapacitor1
-        Amount: 2
       N14Fuse: 
         ExamineName: fuse
         DefaultPrototype: N14JunkComponentFuse1
@@ -69,11 +67,9 @@
       Steel: 10
       Plastic: 10
       Cable: 5
+    requirements:
+        Capacitor: 2
     tagRequirements: 
-      N14Capacitor:
-        ExamineName: capacitor
-        DefaultPrototype: N14JunkComponentCapacitor1
-        Amount: 2
       N14Diode:
         ExamineName: diode
         DefaultPrototype: N14JunkComponentDiode1
@@ -97,11 +93,9 @@
       Steel: 5
       Glass: 5
       Cable: 3
+    requirements:
+        Capacitor: 1
     tagRequirements: 
-      N14Capacitor:
-        ExamineName: capacitor
-        DefaultPrototype: N14JunkComponentCapacitor1
-        Amount: 1
       N14Fuse: 
         ExamineName: fuse
         DefaultPrototype: N14JunkComponentFuse1

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Head/helmets.yml
@@ -22,6 +22,6 @@
   description: An antler skull headdress traditionally worn by the spiritually inclined.
   components:
   - type: Sprite
-    sprite: _Misfits\Clothing\Head\antlerhelm.rsi
+    sprite: _Misfits/Clothing/Head/antlerhelm.rsi
   - type: Clothing
-    sprite: _Misfits\Clothing\Head\antlerhelm.rsi
+    sprite: _Misfits/Clothing/Head/antlerhelm.rsi

--- a/Resources/Prototypes/_Misfits/Recipes/Construction/Graphs/structures/bunker_doors.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Construction/Graphs/structures/bunker_doors.yml
@@ -1,0 +1,163 @@
+- type: constructionGraph
+  id: N14DoorBunker
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: n14assembly
+      completed:
+      - !type:SetAnchor
+        value: false
+      steps:
+      - material: Steel
+        amount: 4
+        doAfter: 2
+
+  - node: n14assembly
+    entity: N14DoorBunkerAssembly
+    actions:
+    - !type:SnapToGrid {}
+    - !type:SetAnchor {}
+    edges:
+    - to: n14wired
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Cable
+        amount: 5
+        doAfter: 3
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 4
+      - !type:DeleteEntity {}
+      steps:
+      - tool: Welding
+        doAfter: 3
+
+  - node: n14wired
+    entity: N14DoorBunkerAssembly
+    edges:
+    - to: n14electronics
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - component: DoorElectronics
+        store: board
+        name: "door electronics circuit board"
+        icon:
+          sprite: "Objects/Misc/module.rsi"
+          state: "door_electronics"
+        doAfter: 3
+    - to: n14assembly
+      completed:
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 5
+      steps:
+      - tool: Cutting
+        doAfter: 3
+
+  - node: n14electronics
+    edges:
+    - to: bunker
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tool: Screwing
+        doAfter: 3
+    - to: n14glassElectronics
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: ReinforcedGlass
+        amount: 1
+        doAfter: 2
+    - to: n14wired
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
+      steps:
+      - tool: Prying
+        doAfter: 5
+
+  - node: n14glassElectronics
+    entity: N14DoorBunkerAssembly
+    edges:
+    - to: glassBunker
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: ReinforcedGlass
+        amount: 1
+        doAfter: 2
+      - tool: Screwing
+        doAfter: 3
+    - to: n14wired
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
+      - !type:SpawnPrototype
+        prototype: SheetRGlass1
+        amount: 1
+      steps:
+      - tool: Prying
+        doAfter: 5
+
+## Glass airlock
+  - node: glassBunker
+    entity: N14DoorBunkerGlass
+    doNotReplaceInheritingEntities: true
+    actions:
+    - !type:SetWiresPanelSecurity
+      wiresAccessible: true
+    edges:
+    - to: n14glassElectronics
+      conditions:
+      - !type:EntityAnchored {}
+      - !type:DoorWelded {}
+      - !type:DoorBolted
+        value: false
+      - !type:WirePanel {}
+      - !type:AllWiresCut
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetRGlass1
+        amount: 1
+      steps:
+      - tool: Prying
+        doAfter: 2
+
+## Standard airlock
+  - node: bunker
+    entity: N14DoorBunker
+    doNotReplaceInheritingEntities: true
+    actions:
+    - !type:SetWiresPanelSecurity
+      wiresAccessible: true
+    edges:
+    - to: n14wired
+      conditions:
+      - !type:EntityAnchored {}
+      - !type:DoorWelded {}
+      - !type:DoorBolted
+        value: false
+      - !type:WirePanel {}
+      - !type:AllWiresCut
+      completed:
+      - !type:EmptyAllContainers
+        pickup: true
+        emptyAtUser: true
+      steps:
+      - tool: Prying
+        doAfter: 5

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/electronics.yml
@@ -2,19 +2,21 @@
   abstract: true
   parent: BaseElectronicsRecipe
   id: N14BaseCircuitboardRecipe
+  category: Circuitry
   completetime: 4
   materials:
     Circuitry: 200
-    Steel: 300
+    N14Copper: 300
 
 - type: latheRecipe
   abstract: true
   parent: BaseElectronicsRecipe
   id: N14BaseCircuitboardGoldRecipe
+  category: Circuitry
   completetime: 4
   materials:
     Circuitry: 200
-    Steel: 300
+    N14Copper: 300
     N14Gold: 100
 
 - type: latheRecipe
@@ -41,3 +43,23 @@
   id: N14StationRadioCircuitboard
   parent: N14BaseCircuitboardRecipe
   result: StationRadioCircuitboard
+
+- type: latheRecipe
+  id: N14ElectrolysisUnitMachineCircuitboard
+  parent: N14BaseCircuitboardRecipe
+  result: ElectrolysisUnitMachineCircuitboard
+
+- type: latheRecipe
+  id: N14CentrifugeMachineCircuitboard
+  parent: N14BaseCircuitboardRecipe
+  result: CentrifugeMachineCircuitboard
+
+- type: latheRecipe
+  id: N14DoorElectronics
+  parent: N14BaseCircuitboardRecipe
+  result: DoorElectronics
+
+- type: latheRecipe
+  id: N14JukeboxCircuitBoard
+  parent: N14BaseCircuitboardRecipe
+  result: JukeboxCircuitBoard

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Food/pre-warfood.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Food/pre-warfood.yml
@@ -312,6 +312,10 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
+  #Misfits Add: Allow people to use this tin can for grenades
+  - type: Tag
+    tags:
+    - Tincan
 
 - type: entity
   parent: N14FoodPacketTrash

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
@@ -107,6 +107,8 @@
   - type: PhysicalComposition
     materialComposition:
       Plastic: 50
+  - type: Item
+    storedRotation: 90
 
 - type: entity
   parent: N14JunkItemBase
@@ -380,6 +382,7 @@
   - type: Tag
     tags:
     - JunkKettle
+
 - type: entity
   parent: N14JunkItemBasePlastic
   id: N14JunkTimer
@@ -798,9 +801,17 @@
   components:
   - type: Tag # Corvax-Change
     tags:
+    # Misfits Change: Make N14 Capacitors compatible with the other capacitors and vice versa
+    - CapacitorStockPart
     - N14Capacitor
     - JunkItem
     - Trash
+  - type: MachinePart
+    part: Capacitor
+    rating: 1
+  - type: ReverseEngineering # Nyano
+    recipes:
+      - CapacitorStockPart
   - type: Sprite
     state: capacitor_1
 
@@ -865,6 +876,9 @@
   - type: Tag
     tags:
     - Mainboard
+  - type: Item
+    size: Small
+    storedRotation: 90
 
 - type: entity
   parent: N14JunkComponentElectronic
@@ -940,6 +954,8 @@
   - type: PhysicalComposition
     materialComposition:
       Circuitry: 20
+  - type: Item
+    size: Tiny
 
 - type: entity
   parent: N14JunkComponentElectronic
@@ -986,6 +1002,8 @@
     - JunkItem
     - Trash
     - Screw
+  - type: Item
+    size: Tiny
 
 - type: entity
   parent: N14JunkComponentElectronic
@@ -998,6 +1016,9 @@
   - type: Tag
     tags:
     - Sensor
+  - type: Item
+    size: Small
+    storedRotation: 90
 
 - type: entity
   parent: N14JunkComponentElectronic
@@ -1012,7 +1033,7 @@
     - SensorModule
 
 - type: entity
-  parent: N14JunkItemBasePlastic
+  parent: N14JunkComponentElectronic
   id: N14JunkComponentSwitch
   name: switch module #Misfits Change: Why was this called a sensor module if its a switch??
   description: An electronics switch.

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
@@ -394,6 +394,16 @@
   - type: Tag
     tags: 
     - JunkTimer
+  - type: PayloadTrigger
+    components:
+    - type: OnUseTimerTrigger
+      delay: 5
+      delayOptions: [3, 5, 10, 15, 30]
+      initialBeepDelay: 0
+      beepSound:
+        path: /Audio/Machines/Nuke/general_beep.ogg
+        params:
+          volume: -2
 
 - type: entity
   parent: FoodTinBaseTrash

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/junk.yml
@@ -1053,6 +1053,16 @@
   - type: Tag
     tags:
     - Switch
+    - SignalTrigger
+  - type: PayloadTrigger
+    components:
+    - type: TriggerOnSignal
+    - type: DeviceNetwork
+      deviceNetId: Wireless
+      receiveFrequencyId: BasicDevice
+    - type: WirelessNetworkConnection
+      range: 200
+    - type: DeviceLinkSink
 
 - type: entity
   parent: N14JunkComponentElectronic

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/FalloutDoors/airlocks.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/FalloutDoors/airlocks.yml
@@ -36,6 +36,11 @@
   components:
   - type: Sprite
     sprite: _Nuclear14/Structures/Doors/FalloutDoors/bunkerdoor.rsi
+  - type: Construction
+    graph: N14DoorBunker
+    node: bunker
+    containers:
+    - board
 
 - type: entity
   parent: N14Airlock
@@ -47,3 +52,19 @@
     enabled: false
   - type: Sprite
     sprite: _Nuclear14/Structures/Doors/FalloutDoors/glassbunkerdoor.rsi
+  - type: Construction
+    graph: N14DoorBunker
+    node: glassBunker
+    containers:
+    - board
+
+- type: entity
+  parent: AirlockAssembly
+  id: N14DoorBunkerAssembly
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Structures/Doors/FalloutDoors/bunkerdoor.rsi
+    state: closed
+  - type: Construction
+    graph: N14DoorBunker
+    node: n14assembly

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/chalkboardfloor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/chalkboardfloor.yml
@@ -45,7 +45,7 @@
   suffix: suck
   components:
   - type: Sprite
-    state: board_mess1
+    state: board_mess2
     
 - type: entity
   parent: N14ChalkboardFloor

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -423,14 +423,14 @@
     #Misc
     - N14FlashlightLantern
     - N14GlowstickRed
-    - DoorElectronics
-    - CapacitorStockPart
     - MicroManipulatorStockPart
     - MatterBinStockPart
     - N14JunkComponentSensorModule #Misfits Add: For Modular Mines
     - N14JunkComponentCapacitor1
     - N14JunkComponentDiode1
     - N14JunkComponentFuse1
+    - CassetteTape
+    - TapeRecorder
     # Explosives - Misfits Add
     - N14LandMine        # Anti-Personnel Mine
     - LandMineKick       # Concussion Mine (non-lethal)
@@ -439,16 +439,16 @@
     - N14ChemicalPayload
     - N14ExplosivePayload
     - N14FlashPayload
-    # #Misfits Add: Expose vanilla centrifuge machine board so players can rebuild MachineCentrifuge via machine frame.
-    - CentrifugeMachineCircuitboard
+    # #Misfits Add: Circuits
+    - N14JukeboxCircuitBoard
+    - N14ElectrolysisUnitMachineCircuitboard
+    - N14CentrifugeMachineCircuitboard
     - N14VinylPlayerCircuitboard
     - N14TapeDeckCircuitboard
     - N14StationRadioServerCircuitboard
     - N14StationRadioRigCircuitboard
     - N14StationRadioCircuitboard
-    # #Misfits Add: Electrolyzer machine board so players can make electrolyzers via machine frame.
-    - ElectrolysisUnitMachineCircuitboard
-    - CassetteTape
+    - N14DoorElectronics    
   - type: ActivatableUIRequiresPower
 
 - type: entity
@@ -637,6 +637,7 @@
     - N14WeaponSprayNozzle
     - N14ClothingBackpackWaterTank
     # Chemistry
+    - N14Vial
     - N14Beaker
     - N14LargeBeaker
     - N14Dropper

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -436,6 +436,7 @@
     - LandMineKick       # Concussion Mine (non-lethal)
     - LandMineExplosive  # Explosive Mine (~4 tile radius)
     - LandMineModular    # Modular Mine (empty casing, add payload)
+    - N14ModularGrenade
     - N14ChemicalPayload
     - N14ExplosivePayload
     - N14FlashPayload

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -420,6 +420,7 @@
     - N14HandheldRadio
     - N14GeigerCounter
     - N14HandheldHealthAnalyzer
+    - N14RemoteSignaller
     #Misc
     - N14FlashlightLantern
     - N14GlowstickRed
@@ -429,6 +430,8 @@
     - N14JunkComponentCapacitor1
     - N14JunkComponentDiode1
     - N14JunkComponentFuse1
+    - N14JunkComponentSwitch
+    - N14JunkTimer
     - CassetteTape
     - TapeRecorder
     # Explosives - Misfits Add

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Wallmount/chalkboardwall.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Wallmount/chalkboardwall.yml
@@ -52,7 +52,7 @@
   suffix: gecko
   components:
   - type: Sprite
-    state: board_mess1
+    state: board_mess2
 
 - type: entity
   parent: N14ChalkboardWall

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Wallmount/wallmounts.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Wallmount/wallmounts.yml
@@ -13,12 +13,24 @@
     arc: 360
   - type: Sprite
     drawdepth: Overdoors
-    snapCardinals: true
-    sprite: _Nuclear14/Structures/Storage/storage.rsi
-    state: vent
+    sprite: Structures/Storage/storage.rsi
+    layers:
+    - state: vent
+      map: [ "DoorVisualState.DoorOpen" ]
+  - type: SecretStash
+    secretPartName: secret-stash-part-vent
+    maxItemSize: Normal
+    openableStash: true
   - type: ContainerContainer
     containers:
       stash: !type:ContainerSlot {}
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.StashVisuals.DoorVisualState:
+        DoorVisualState.DoorOpen:
+          DoorOpen: { state: vent-open }
+          DoorClosed: { state: vent }
 
 - type: entity
   parent: N14WallmountVent
@@ -26,8 +38,11 @@
   suffix: damaged
   components:
   - type: Sprite
-    sprite: _Nuclear14/Structures/Storage/storage.rsi
-    state: vent-damaged
+    layers:
+    - state: vent-damaged
+      map: [ "DoorVisualState.DoorOpen" ]
+  - type: SecretStash
+    toggleOpen: true
 
 - type: entity
   parent: N14WallmountVent
@@ -35,8 +50,10 @@
   suffix: open
   components:
   - type: Sprite
-    sprite: _Nuclear14/Structures/Storage/storage.rsi
-    state: vent-open
-
+    layers:
+    - state: vent-open
+      map: [ "DoorVisualState.DoorOpen" ]
+  - type: SecretStash
+    toggleOpen: true
 
 # First Aid

--- a/Resources/Prototypes/_Nuclear14/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Construction/structures.yml
@@ -38,6 +38,42 @@
   conditions:
     - !type:TileNotBlocked
 
+- type: construction
+  name: bunker door
+  id: N14DoorBunker
+  graph: N14DoorBunker
+  startNode: start
+  targetNode: bunker
+  category: construction-category-structures
+  description: It opens, it closes, it might crush you, and there might be only radiation and monsters behind it. Has to be manually activated.
+  icon:
+    sprite: _Nuclear14/Structures/Doors/FalloutDoors/bunkerdoor.rsi
+    state: closed
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  name: bunker glass airlock
+  id: N14DoorBunkerGlass
+  graph: N14DoorBunker
+  startNode: start
+  targetNode: glassBunker
+  category: construction-category-structures
+  description: It opens, it closes, it might crush you, and there might be only radiation and monsters behind it. Has to be manually activated.
+  icon:
+    sprite: _Nuclear14/Structures/Doors/FalloutDoors/glassbunkerdoor.rsi
+    state: closed
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  hide: false
+  conditions:
+    - !type:TileNotBlocked
+
 # Slanted Structures
 ## Walls
 - type: construction

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/chemistry.yml
@@ -1,4 +1,13 @@
 - type: latheRecipe
+  id: N14Vial
+  result: BaseChemistryEmptyVial
+  completetime: 2
+  category: N14Chemistry
+  materials:
+    Glass: 50
+    WoodPlank: 25
+
+- type: latheRecipe
   id: N14Beaker
   result: Beaker
   completetime: 2

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/chemistry.yml
@@ -5,7 +5,7 @@
   category: N14Chemistry
   materials:
     Glass: 50
-    WoodPlank: 25
+    Wood: 25
 
 - type: latheRecipe
   id: N14Beaker

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/misc.yml
@@ -4,7 +4,7 @@
   category: N14Lights
   completetime: 2
   materials:
-    Steel: 50
+    N14Copper: 50 #Misfits Change: Makes More sense
     Glass: 100 # Forge-Change
 
 - type: latheRecipe
@@ -13,7 +13,7 @@
   category: N14Lights
   completetime: 2
   materials:
-    Steel: 50
+    N14Copper: 50 #Misfits Change: Makes More sense
     Glass: 100 # Forge-Change
 
 - type: latheRecipe
@@ -22,7 +22,7 @@
   category: N14Lights
   completetime: 2
   materials:
-    Steel: 50
+    N14Copper: 50 #Misfits Change: Makes More sense
     Glass: 100 # Forge-Change
 
 - type: latheRecipe
@@ -31,7 +31,7 @@
   category: N14Lights
   completetime: 2
   materials:
-    Steel: 50
+    N14Copper: 50 #Misfits Change: Makes More sense
     Glass: 100 # Forge-Change
 
 - type: latheRecipe
@@ -40,7 +40,7 @@
   category: N14Lights
   completetime: 2
   materials:
-    Steel: 50
+    N14Copper: 50 #Misfits Change: Makes More sense
     Glass: 100 # Forge-Change
 
 - type: latheRecipe
@@ -49,7 +49,7 @@
   category: N14Lights
   completetime: 2
   materials:
-    Steel: 50
+    N14Copper: 50 #Misfits Change: Makes More sense
     Glass: 100 # Forge-Change
 
 - type: latheRecipe
@@ -75,7 +75,8 @@
   category: N14Lights
   completetime: 2
   materials:
-    Steel: 100
+    Steel: 50 
+    N14Copper: 50 #Misfits Change: Makes More sense
     Glass: 100
     Plastic: 100
 
@@ -144,60 +145,60 @@
 - type: latheRecipe
   id: N14JunkComponentScrew
   result: N14JunkComponentScrew
-  category: N14Parts
+  category: Parts
   completetime: 2
   materials:
-    Steel: 100 # Forge-Change
+    N14Copper: 100 # Forge-Change
 
 #Misfits Add: Recipes for some other useful junk.
 - type: latheRecipe
   id: N14JunkComponentGearSmall
   result: N14JunkComponentGearSmall
-  category: N14Parts
+  category: Parts
   completetime: 2
   materials:
-    Steel: 150 
+    N14Copper: 150 
 
 - type: latheRecipe
   id: N14JunkComponentGearLarge
   result: N14JunkComponentGearLarge
-  category: N14Parts
+  category: Parts
   completetime: 2
   materials:
-    Steel: 200
+    N14Copper: 200
 
 - type: latheRecipe
   id: N14JunkComponentSensorModule
   result: N14JunkComponentSensorModule
-  category: N14Parts
+  category: Parts
   completetime: 2
   materials:
     Circuitry: 100
-    Steel: 50
+    N14Copper: 50
 
 - type: latheRecipe
   id: N14JunkComponentCapacitor1
   result: N14JunkComponentCapacitor1
-  category: N14Parts
+  category: Parts
   completetime: 2
   materials:
     Circuitry: 50
-    Steel: 25
+    N14Copper: 25
 
 - type: latheRecipe
   id: N14JunkComponentDiode1
   result: N14JunkComponentDiode1
-  category: N14Parts
+  category: Parts
   completetime: 2
   materials:
     Circuitry: 50
-    Steel: 25
+    N14Copper: 25
 
 - type: latheRecipe
   id: N14JunkComponentFuse1
   result: N14JunkComponentFuse1
-  category: N14Parts
+  category: Parts
   completetime: 2
   materials:
     Circuitry: 50
-    Steel: 25
+    N14Copper: 25

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/misc.yml
@@ -202,3 +202,22 @@
   materials:
     Circuitry: 50
     N14Copper: 25
+
+- type: latheRecipe
+  id: N14JunkComponentSwitch
+  result: N14JunkComponentSwitch
+  category: Parts
+  completetime: 2
+  materials:
+    Circuitry: 100
+    Plastic: 50
+    N14Copper: 25
+
+- type: latheRecipe
+  id: N14JunkTimer
+  result: N14JunkTimer
+  category: Parts
+  completetime: 2
+  materials:
+    Circuitry: 50
+    N14Copper: 25

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/tools.yml
@@ -44,7 +44,7 @@
   category: N14Parts
   completetime: 1
   materials:
-    Steel: 10
+    N14Copper: 10 #Misfits Change: Makes More sense
     Cloth: 1
 
 - type: latheRecipe
@@ -53,7 +53,7 @@
   category: N14Parts
   completetime: 1
   materials:
-    Steel: 20
+    N14Copper: 20 #Misfits Change: Makes More sense
     Cloth: 5
 
 - type: latheRecipe
@@ -62,7 +62,7 @@
   category: N14Parts
   completetime: 2
   materials:
-    Steel: 30
+    N14Copper: 30 #Misfits Change: Makes More sense
     Cloth: 10
 
 - type: latheRecipe
@@ -97,7 +97,7 @@
   category: N14Tools
   completetime: 2
   materials:
-    Steel: 200
+    N14Copper: 200 #Misfits Change: Makes More sense
     Plastic: 400
 
 - type: latheRecipe
@@ -106,7 +106,7 @@
   category: N14Tools
   completetime: 2
   materials:
-    Steel: 200
+    N14Copper: 200 #Misfits Change: Makes More sense
     Plastic: 200
 
 - type: latheRecipe
@@ -115,7 +115,8 @@
   category: N14Tools
   completetime: 2
   materials:
-    Steel: 600
+    N14Copper: 500 #Misfits Change: Makes More sense
+    Steel: 100
     Plastic: 200
 
 - type: latheRecipe
@@ -124,7 +125,8 @@
   category: N14Tools
   completetime: 2
   materials:
-    Plastic: 500
+    Plastic: 300
+    N14Copper: 200 #Misfits Change: Makes More sense
     Glass: 300
 
 - type: latheRecipe
@@ -133,7 +135,8 @@
   category: N14Tools
   completetime: 2
   materials:
-    Plastic: 500
+    Plastic: 300
+    N14Copper: 200 #Misfits Change: Makes More sense
     Glass: 300
 
 - type: latheRecipe
@@ -142,7 +145,8 @@
   category: N14Tools
   completetime: 2
   materials:
-    Plastic: 500
+    Plastic: 300
+    N14Copper: 200 #Misfits Change: Makes More sense
     Glass: 300
 
 - type: latheRecipe
@@ -170,7 +174,8 @@
   category: N14Tools
   completetime: 3
   materials:
-    Steel: 500
+    Steel: 300
+    N14Copper: 200 #Misfits Change: Makes More sense
     Plastic: 100
 
 - type: latheRecipe

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/tools.yml
@@ -263,3 +263,13 @@
     N14Gold: 50
     Plastic: 300
     Circuitry: 100
+
+- type: latheRecipe
+  id: N14RemoteSignaller
+  result: RemoteSignaller
+  category: N14Tools
+  completetime: 2
+  materials:
+    N14Copper: 50
+    Plastic: 300
+    Circuitry: 100

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/weapons.yml
@@ -303,6 +303,18 @@
   materials:
     Steel: 600
 
+- type: latheRecipe
+  id: N14ModularGrenade
+  icon:
+    sprite: Objects/Weapons/Grenades/modular.rsi
+    state: empty
+  result: ModularGrenade
+  category: N14Weapons
+  completetime: 10
+  materials:
+    Steel: 300
+
+
 # Misfits Add: Recipes for payloads because there is none for modular mines.
 - type: latheRecipe
   id: N14ChemicalPayload


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->
## About the PR
<!-- What did you change? -->
Adjusted recipes for circuit boards, bulbs, cables, some tools to fully or partially use copper instead of steel. 
Made the junk capacitor and the other capacitor be the same so no more capacitor mismatch.
Jukebox circuit, remote signaler, taper recorder, modular grenade case, vials, timers, switch modules are craftable.
Timers and switch modules act as timer trigger and signal trigger respectively.
Blast doors and bunker doors are buildable.
Blast doors obey the access given to them by their electronic circuits when it comes to linking no more BoS pranking.
Vents now work properly for stashing first gotta pry it open. 
Empty tin can given from canned food can now be used for nukanade and tinnades.
Electronic junk is now tiny sized except for the boards.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just lots of QoL things and giving some purpose to copper as well as matching items with the same names.

## Technical details
<!-- Summary of code changes for easier review. -->
All YML fellas.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/4aea0f87-bc91-4c90-9de5-1df96a21b900" />

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: AthenaAI
- tweak: Adjusted recipes for circuit boards, bulbs, cables, some tools to fully or partially use copper instead of steel. 
- tweak: Made the junk capacitor and the other capacitor be the same so no more capacitor mismatch.
- add: Jukebox circuit, remote signaler, taper recorder, modular grenade case, vials, timers, switch modules are craftable.
- tweak: Timers and switch modules act as timer trigger and signal trigger respectively.
- add: Blast doors and bunker doors are buildable.
- tweak: Blast doors obey the access given to them by their electronic circuits when it comes to linking no more BoS pranking.
- fix: Vents now work properly for stashing first gotta pry it open. 
- fix: Empty tin can given from canned food can now be used for nukanade and tinnades.
- tweak: Electronic junk is now tiny sized except for the boards.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
