### PR TITLE
Added Jukebox Tunes to the Vinyls List.

### DIFF
--- a/Resources/Prototypes/_Misfits/Catalog/Fills/Boxes/vinyls.yml
+++ b/Resources/Prototypes/_Misfits/Catalog/Fills/Boxes/vinyls.yml
@@ -2,14 +2,14 @@
   id: CrateRadioStationVinyls
   parent: CrateGenericSteel
   name: vinyls crate
-  description: A crate with 12 vinyls so you'll NEVER play the same song twice, they come in sleeves!
+  description: A crate with 20 vinyls so you'll NEVER play the same song twice, they come in sleeves!
   components:
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
         tableId: RandomVinylSleeve
         rolls: !type:ConstantNumberSelector
-          value: 12
+          value: 20
 
 - type: entityTable
   id: RandomVinylDisk
@@ -96,6 +96,96 @@
     - !type:EntSelector
       id: VinylDiskBachCello
       weight: 0.6
+    - !type:EntSelector
+      id: VinylDiskAKissToBuildADreamOn
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskTexBenekeGuy
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskAintThatAKickInTheHead
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskPatrioticAmerica
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskAmericanSwing
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskColePorterAnything
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskBigIron
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskRoyBrownButcher
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskDannyKayeCivilization
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskBillieHolidayCrazy
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskPatrioticDixie
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskBillieHolidayEasy
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskGenericFox
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskPatrioticPresidential
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskPatrioticMontezuma
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskBobCrosbyHappy
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskInkspotsIDont
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskGenericJazzy
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskJingleJangleJingle
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskJoeCool
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskJohnnyGuitar
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskGenericSunning
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskRoyBrownMighty
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskSomethingsGottaGive
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskGenericSwing
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskBattleHymn
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskPatrioticStars
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskPatrioticWashington
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskBobCrosbyWay
+      weight: 2.0
+    - !type:EntSelector
+      id: VinylDiskPatrioticYankee
+      weight: 2.0
 
 - type: entityTable
   id: RandomVinylSleeve

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Fun/vinyls.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Fun/vinyls.yml
@@ -1,0 +1,329 @@
+- type: entity
+  name: "vinyl disk: Louis Armstrong - A Kiss to Build A Dream On"
+  id: VinylDiskAKissToBuildADreamOn
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Lobby/a_kiss_to_build_a_dream_on.ogg
+
+- type: entity
+  name: "vinyl disk: Tex Beneke - A Wonderful Guy"
+  id: VinylDiskTexBenekeGuy
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_texbeneke_guy_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Dean Martin - Ain't That A Kick In The Head"
+  id: VinylDiskAintThatAKickInTheHead
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Lobby/MUS_Aint_That_A_Kick_In_the_Head.ogg
+
+- type: entity
+  name: "vinyl disk: America the Beautiful"
+  id: VinylDiskPatrioticAmerica
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/MUS_Patriotic_America.ogg 
+
+- type: entity
+  name: "vinyl disk: Gerhard Trede - American Swing"
+  id: VinylDiskAmericanSwing
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Lobby/MUS_American_Swing.ogg
+
+- type: entity
+  name: "vinyl disk: Cole Porter - Anything Goes"
+  id: VinylDiskColePorterAnything
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_coleporter_anything_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Marty Robins - Big Iron"
+  id: VinylDiskBigIron
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Lobby/MUS_Big_Iron.ogg
+
+- type: entity
+  name: "vinyl disk: Roy Brown - Butcher Pete (Pt. 1)"
+  id: VinylDiskRoyBrownButcher
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_roybrown_butcher_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Danny Kaye - Civilization"
+  id: VinylDiskDannyKayeCivilization
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_dannykaye_civilization_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Billie Holiday - Crazy He Calls Me"
+  id: VinylDiskBillieHolidayCrazy
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_billieholiday_crazy_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Dixie"
+  id: VinylDiskPatrioticDixie
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/MUS_Patriotic_Dixie.ogg
+
+- type: entity
+  name: "vinyl disk: Billie Holiday - Easy Living"
+  id: VinylDiskBillieHolidayEasy
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_billieholiday_easy_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Gerhard Trede - Fox Boggie"
+  id: VinylDiskGenericFox
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_fox_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Hail Columbia"
+  id: VinylDiskPatrioticPresidential
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/MUS_Patriotic_Presidential.ogg
+
+- type: entity
+  name: "vinyl disk: Halls of Montezuma"
+  id: VinylDiskPatrioticMontezuma
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/MUS_Patriotic_Montezuma.ogg
+
+- type: entity
+  name: "vinyl disk: Bob Crosby - Happy Times"
+  id: VinylDiskBobCrosbyHappy
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_bobcrosby_happy_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Inkspots - I Don't Want to Set the World on Fire"
+  id: VinylDiskInkspotsIDont
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_inkspots_idont_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Billy Munn - Jazzy Interlude"
+  id: VinylDiskGenericJazzy
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_jazzy_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Kay Kyser - Jingle Jangle Jingle"
+  id: VinylDiskJingleJangleJingle
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Lobby/MUS_Jingle_Jangle_Jingle.ogg
+
+- type: entity
+  name: "vinyl disk: Georges Tesperin - Joe Cool"
+  id: VinylDiskJoeCool
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Lobby/MUS_Joe_Cool_CAS.ogg
+
+- type: entity
+  name: "vinyl disk: Peggy Lee - Johnny Guitar"
+  id: VinylDiskJohnnyGuitar
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Lobby/MUS_Johnny_Guitar.ogg
+
+- type: entity
+  name: "vinyl disk: Jack Shaindlin - Let's Go Sunning"
+  id: VinylDiskGenericSunning
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_sunning_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Roy Brown - Mighty Mighty Man"
+  id: VinylDiskRoyBrownMighty
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_roybrown_mighty_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Bing Crosby - Something's Gotta Give"
+  id: VinylDiskSomethingsGottaGive
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Lobby/MUS_Somethings_Gotta_Give.ogg
+
+- type: entity
+  name: "vinyl disk: Allan Gray - Swing Dooors"
+  id: VinylDiskGenericSwing
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_generic_boogie_mono.ogg
+
+- type: entity
+  name: "vinyl disk: The Battle Hymn of the Republic"
+  id: VinylDiskBattleHymn
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/MUS_Patriotic_BattleHymn_mono.ogg
+
+- type: entity
+  name: "vinyl disk: The Stars and Stripes Forever"
+  id: VinylDiskPatrioticStars
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/MUS_Patriotic_Stars.ogg
+
+- type: entity
+  name: "vinyl disk: The Washington Post"
+  id: VinylDiskPatrioticWashington
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/MUS_Patriotic_Washington.ogg
+
+- type: entity
+  name: "vinyl disk: Bob Crosby - Way Back Home"
+  id: VinylDiskBobCrosbyWay
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/Fallout3/mus_bobcrosby_way_mono.ogg
+
+- type: entity
+  name: "vinyl disk: Yankee Doodle"
+  id: VinylDiskPatrioticYankee
+  parent: BaseVinylDisk
+  components:
+  - type: Sprite
+    state: cyan-vinyl-disk
+  - type: Vinyl
+    song:
+      path: /Audio/_Nuclear14/Music/MUS_Patriotic_Yankee.ogg


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Adds over 30 new vinyls to the list of vinyls that can be bought via the vinyls crate all the same music from the jukebox now playable over the air. Made these vinyls more common compared to the silly disks.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Variety is the spice of life.

## Technical details
<!-- Summary of code changes for easier review. -->
All YML.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1080" height="1080" alt="image" src="https://github.com/user-attachments/assets/a281eb55-2e78-4f62-9a9b-7c6e03014f20" />

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: AthenaAI
- add: Adds over 30 new vinyls to the vinyls crate list all music from the jukebox now playable over the airwaves.
- tweak: The jukebox vinyls are x3 times more common than the other music ones.
- tweak: Increased the vinyl crate vinyls from 12 -> 20.
