### PR TITLE
Small Mirelurk Pet Fix

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Mobs/NPCs/mirelurks.yml
+++ b/Resources/Prototypes/Corvax/Entities/Mobs/NPCs/mirelurks.yml
@@ -18,7 +18,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-            radius: 0.5
+            radius: 0.3
         density: 20
         mask:
         - MobMask
@@ -67,6 +67,8 @@
   - type: Body # #Misfits Add - override N14Animal with N14PetAnimal to include heart (Medicine/Poison metabolizer)
     prototype: N14PetAnimal
   - type: Hands # #Misfits Add - allows player-controlled mirelurk pets to drag items
+  - type: Puller
+    needsHands: false
   - type: MisfitsPetNoPickup # #Misfits Add - cancels PickupAttemptEvent; drag only, no item pickup
   - type: PassiveDamage # #Misfits Add - slow natural regeneration for player-controlled pet mirelurks
     allowedStates:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Reduce mirelurk collision size so it do not get stuck everywhere and add the ability to drag.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because playing Mirelurk was kinda strange to play even the brahmin can pull stuff and go to into 1 tile spaces.

## Technical details
<!-- Summary of code changes for easier review. -->
Since the Mirelurk pet and the mob are the same for some reason, well now they mobs can also enter normal places too, maybe later they can become two different entities.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->
:cl:
- fix:  reduce mirelurk size so it do not get stuck everywhere and add the ability to drag.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
