### PR TITLE
Give Protectron, Mr Handy, Mr Gutsy Players Antique Power Cell

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
@@ -176,7 +176,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellHyper
+        startingItem: PowerCellAnitqueProto
 
 - type: entity
   parent: N14BasePlayerSynthetic
@@ -270,7 +270,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellHyper
+        startingItem: PowerCellAnitqueProto
 
 - type: entity
   parent: N14BasePlayerSynthetic
@@ -365,7 +365,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellHyper
+        startingItem: PowerCellAntiqueProto
 
 - type: entity
   parent: N14PlayerSyntheticProtectron

--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
@@ -176,7 +176,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellAnitqueProto
+        startingItem: PowerCellAntiqueProto
 
 - type: entity
   parent: N14BasePlayerSynthetic
@@ -270,7 +270,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellAnitqueProto
+        startingItem: PowerCellAntiqueProto
 
 - type: entity
   parent: N14BasePlayerSynthetic

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Robots/base_borg_chassis.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Robots/base_borg_chassis.yml
@@ -139,7 +139,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellHyper
+        startingItem: PowerCellAntiqueProto
   - type: Body
   - type: StatusEffects
     allowed:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->

all silicon player species, except assaultron, now start with antique power cell instead of hyper capacity cells

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

firstly, its lore accurate. silicons have nuclear reactors powering them
second, its kinda ass gameplay and adds very little to have to keep going back to a cell recharger to be able to keep playing the game.
and third, it limits silicon gameplay options a bit, as a silicon playstyle that prevents regularly having access to a recharger isnt viable.
im on the fence about giving them to assaultrons too but i think the antique cell's max power is too low for tesla so.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Tytos

- tweak: all silicons besides assaultron have antique cell now
