### PR TITLE
Scissor Loadout Point Change

### DIFF
--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -725,7 +725,7 @@
 - type: loadout
   id: LoadoutItemBarberScissors
   category: Items
-  cost: 4
+  cost: 2
   items:
     - BarberScissors
 


### PR DESCRIPTION

## About the PR
What this PR does is puts the scissors to 2 points rather then 4.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Oli
- tweak: Scissors to 2 from 4
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
