### PR TITLE
Loadout Fix Scissors

### DIFF
--- a/Resources/Locale/en-US/_Misfits/loadout-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/loadout-names.ftl
@@ -226,6 +226,7 @@ loadout-name-N14LoadoutFoodPorkBeans = pork and beans
 loadout-name-N14CurrencyCap100 = 100 caps
 loadout-name-GeigerCounter = Geiger counter
 loadout-name-d6Dice = d6 dice
+loadout-name-LoadoutItemBarberScissors = barber scissors
 
 # Instruments
 loadout-name-N14InstrumentBanjo = banjo

--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -723,13 +723,6 @@
     - CrayonBox
 
 - type: loadout
-  id: LoadoutItemBarberScissors
-  category: Items
-  cost: 2
-  items:
-    - BarberScissors
-
-- type: loadout
   id: LoadoutSolCommonTranslator
   category: Items
   cost: 3

--- a/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
@@ -212,6 +212,13 @@
   items:
     - N14ClothingBeltUtilityFilled
 
+- type: loadout
+  id: LoadoutItemBarberScissors
+  category: Items
+  cost: 2
+  items:
+    - BarberScissors
+
 # Food
 - type: loadout
   id: N14LoadoutFoodPorkBeans


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
I put the scissors in the loadout menu somehow I didnt realize it was broken and now its back into the fallout items. So now MPs and frumentarii buff in roleplay. 😄 

## Media
<img width="388" height="75" alt="image" src="https://github.com/user-attachments/assets/91d07181-ff45-4df4-8e86-00ee473715f5" />

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Oli
- tweak: loadout code for scissors placed scissors in nuclear14 instead of regular vanilla ss14.
<!--
- add: Added fun!
-->
