### PR TITLE
Made the Experimental X-01 Lore Accurate

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -142,6 +142,8 @@
     sprite: _Misfits/Clothing/OuterClothing/PowerArmor/Mutant_PA.rsi
   - type: Clothing
     sprite: _Misfits/Clothing/OuterClothing/PowerArmor/Mutant_PA.rsi
+    equipDelay: 14400 # The Experimental X-01 Power armor is a living Tomb for whichever poor supermutant they put in it, so it takes the entire round to unequip/equip.
+    unequipDelay: 14400
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
@@ -151,6 +153,7 @@
         Heat: 0.70
         Caustic: 0.75
         Radiation: 0.6
+  - type: Unremoveable # This is your casket. Service garentees citizenship.
   - type: Tag
     tags:
     - SuperMutantWearable


### PR DESCRIPTION
Can no longer remove/equip it.


🆑 Bradysgaming


- tweak: Turned the Experimental X-01 Power Armor into a living, unremoveable casket. 
