### PR TITLE
Various Tweaks, Gutting Of ChemChuds, and The Adding of Injector Doafters

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/armor.yml
@@ -188,8 +188,8 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/veteranarmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.1 # makes veterans a big threat (not really) -Bill
-    sprintModifier: 1.1
+    walkModifier: 1.05 # makes veterans a big threat (not really) -Bill
+    sprintModifier: 1.05
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -2419,38 +2419,38 @@
     - ClothMade
     - CottonBoll
 
-- type: entity
-  name: pyrotton boll
-  description: This will probably set you on fire.
-  id: PyrottonBol
-  parent: FoodProduceBase
-  components:
-  - type: Sprite
-    sprite: Objects/Specific/Hydroponics/pyrotton.rsi
-  - type: FlavorProfile
-    flavors:
-      - pyrotton
-  - type: Food
-    requiresSpecialDigestion: true
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Fiber
-          Quantity: 5
-        - ReagentId: Phlogiston
-          Quantity: 5
-  - type: Log
-    spawnedPrototype: MaterialPyrotton1
-    spawnCount: 2
-  - type: Produce
-    seedId: pyrotton
-  - type: Tag
-    tags:
-    - ClothMade
-    - CottonBoll
-  - type: Extractable
-    grindableSolutionName: food
+#- type: entity
+#  name: pyrotton boll
+#  description: This will probably set you on fire.
+#  id: PyrottonBol
+#  parent: FoodProduceBase
+#  components:
+#  - type: Sprite
+#    sprite: Objects/Specific/Hydroponics/pyrotton.rsi
+#  - type: FlavorProfile
+#    flavors:
+#      - pyrotton
+#  - type: Food
+#    requiresSpecialDigestion: true
+#  - type: SolutionContainerManager
+#    solutions:
+#      food:
+#        reagents:
+#        - ReagentId: Fiber
+#          Quantity: 5
+#        - ReagentId: Phlogiston
+#          Quantity: 5
+#  - type: Log
+#    spawnedPrototype: MaterialPyrotton1
+#    spawnCount: 2
+#  - type: Produce
+#    seedId: pyrotton
+#  - type: Tag
+#    tags:
+#    - ClothMade
+#    - CottonBoll
+#  - type: Extractable
+#    grindableSolutionName: food
 
 - type: entity
   name: cherry

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -657,15 +657,15 @@
     - type: Sprite
       sprite: Objects/Specific/Hydroponics/cotton.rsi
 
-- type: entity
-  parent: SeedBase
-  name: packet of pyrotton seeds
-  id: PyrottonSeeds
-  components:
-    - type: Seed
-      seedId: pyrotton
-    - type: Sprite
-      sprite: Objects/Specific/Hydroponics/pyrotton.rsi
+#- type: entity
+#  parent: SeedBase
+#  name: packet of pyrotton seeds
+#  id: PyrottonSeeds
+#  components:
+#    - type: Seed
+#      seedId: pyrotton
+#    - type: Sprite
+#      sprite: Objects/Specific/Hydroponics/pyrotton.rsi
 
 - type: entity
   parent: SeedBase

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -1800,8 +1800,8 @@
   packetPrototype: CottonSeeds
   productPrototypes:
     - CottonBol
-  mutationPrototypes:
-    - pyrotton
+#  mutationPrototypes:
+    # - pyrotton
   lifespan: 25
   maturation: 8
   production: 3
@@ -1816,32 +1816,32 @@
       Max: 10
       PotencyDivisor: 20
 
-- type: seed
-  id: pyrotton
-  name: seeds-pyrotton-name
-  noun: seeds-noun-seeds
-  displayName: seeds-pyrotton-display-name
-  plantRsi: Objects/Specific/Hydroponics/pyrotton.rsi
-  packetPrototype: PyrottonSeeds
-  productPrototypes:
-    - PyrottonBol
-  lifespan: 25
-  maturation: 8
-  production: 3
-  yield: 2
-  potency: 5
-  idealLight: 8
-  growthStages: 3
-  waterConsumption: 0.80
-  chemicals:
-    Fiber:
-      Min: 5
-      Max: 10
-      PotencyDivisor: 20
-    Phlogiston:
-      Min: 4
-      Max: 8
-      PotencyDivisor: 30
+#- type: seed
+#  id: pyrotton
+#  name: seeds-pyrotton-name
+#  noun: seeds-noun-seeds
+#  displayName: seeds-pyrotton-display-name
+#  plantRsi: Objects/Specific/Hydroponics/pyrotton.rsi
+#  packetPrototype: PyrottonSeeds
+#  productPrototypes:
+#    - PyrottonBol
+#  lifespan: 25
+#  maturation: 8
+#  production: 3
+#  yield: 2
+#  potency: 5
+#  idealLight: 8
+#  growthStages: 3
+#  waterConsumption: 0.80
+#  chemicals:
+#    Fiber:
+#      Min: 5
+#      Max: 10
+#      PotencyDivisor: 20
+#    Phlogiston:
+#      Min: 4
+#      Max: 8
+#      PotencyDivisor: 30
 
 - type: seed
   id: cherry

--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -2,13 +2,13 @@
   id: Napalm
   reactants:
     Oil:
-      amount: 1
+      amount: 20
     WeldingFuel:
-      amount: 1
+      amount: 20
     Ethanol:
-      amount: 1
+      amount: 20
   products:
-    Napalm: 3
+    Napalm: 5
 
 #- type: reaction # Corvax-Change
 #  id: Phlogiston

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/assasin.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/assasin.yml
@@ -10,14 +10,14 @@
     sprite: _Misfits/Clothing/CaesarLegion/assasin.rsi
   - type: ClothingSpeedModifier
     walkModifier: 1
-    sprintModifier: 1.20
+    sprintModifier: 1.10
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.8
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.75
+        Heat: 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.8
   - type: StaminaDamageResistance

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
@@ -229,6 +229,7 @@
     - N14BPNCRAmmoMag762Rifle
     - N14BPNCRAmmoMag10mmSMG
     - N14BPNCRAmmoMag12mmSMG
+    - N14BPNCRAmmo40mmGrenade
 
 - type: entity
   parent: N14BlueprintBase

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -1271,6 +1271,21 @@
 
     N14Gunpowder: 20
 
+- type: latheRecipe
+  id: N14BPNCRAmmo40mmGrenade
+  result: N14CartridgeGrenade40mm
+  category: N14BlueprintNCRAmmoT3
+  completetime: 8
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 800
+
+    N14Gunpowder: 1000
+
+    N14Iron: 500
+
 
 # --- NCR Tier 4 Ammo ---
 - type: latheRecipe
@@ -2362,11 +2377,11 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 2500
+    Steel: 800
 
-    N14Gunpowder: 200
+    N14Gunpowder: 1000
 
-    N14Iron: 100
+    N14Iron: 500
 
 
 # #Misfits Add - T3 ammo parity: 7.62mm for SKS, and craftable dynamite (Legion explosive doctrine)

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
@@ -13,7 +13,7 @@
   name: job-name-eighties-the-block
   description: job-description-eighties-the-block
   playTimeTracker: EightiesTheBlock
-  whitelisted: true
+  whitelisted: false
   requirements:
   - !type:MinPlayersRequirement
     min: 0
@@ -71,7 +71,7 @@
   name: job-name-eighties-cylinders
   description: job-description-eighties-cylinders
   playTimeTracker: EightiesCylinders
-  whitelisted: true
+  whitelisted: false
   requirements:
   - !type:MinPlayersRequirement
     min: 0
@@ -127,7 +127,7 @@
   name: job-name-eighties-pistons
   description: job-description-eighties-pistons
   playTimeTracker: EightiesPistons
-  whitelisted: true
+  whitelisted: false
   requirements:
   - !type:MinPlayersRequirement
     min: 0
@@ -183,7 +183,7 @@
   name: job-name-eighties-oilers
   description: job-description-eighties-oilers
   playTimeTracker: EightiesOilers
-  whitelisted: true
+  whitelisted: false
   requirements:
   - !type:MinPlayersRequirement
     min: 0
@@ -239,7 +239,7 @@
   name: job-name-eighties-road-rash
   description: job-description-eighties-road-rash
   playTimeTracker: EightiesRoadRash
-  whitelisted: true
+  whitelisted: false
   requirements:
   - !type:MinPlayersRequirement
     min: 0
@@ -247,6 +247,9 @@
     species:
     - Human
     - Ghoul
+  - !type:CharacterPlaytimeRequirement
+    tracker: Wastelander
+    min: 36000 # 10 hours
   startingGear: EightiesRoadRashGear
   alwaysUseSpawner: true
   icon: "JobIconEighties"

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
@@ -26,7 +26,6 @@
   - type: ExaminableSolution
     solution: pen
   - type: Hypospray
-    doAfterDuration: 1.5
     onlyAffectsMobs: false
     solutionName: pen
     transferAmount: 30
@@ -130,6 +129,8 @@
     tags:
     - Syringe
     - N14EmptySyringe
+  - type: UseDelay
+    delay: 0.75
 
 - type: entity
   parent: N14Stimpak
@@ -182,6 +183,8 @@
     tags:
     - Syringe
     - N14EmptySyringe
+  - type: UseDelay
+    delay: 1.5
 
 - type: entity
   parent: N14ChemicalSyringe
@@ -208,6 +211,8 @@
   - type: Tag
     tags:
     - Syringe
+  - type: UseDelay
+    delay: 0.75
 
 - type: entity
   parent: N14ChemicalSyringeAntidoteEmpty
@@ -251,6 +256,8 @@
     tags:
     - Jet
     - Syringe
+  - type: UseDelay
+    delay: 0.5
 
 - type: entity
   parent: N14JetInhaler
@@ -296,6 +303,8 @@
     tags:
     - Turbo
     - Syringe
+  - type: UseDelay
+    delay: 0.25
 
 - type: entity
   parent: N14TurboInhaler
@@ -338,6 +347,8 @@
         reagents:
         - ReagentId: DamageResistMixture
           Quantity: 20
+  - type: UseDelay
+    delay: 0.75
 
 - type: entity
   parent: N14ChemicalSyringe
@@ -367,6 +378,8 @@
     tags:
     - HydraInhaler
     - Syringe
+  - type: UseDelay
+    delay: 0.5
 
 - type: entity
   parent: N14HydraInhaler
@@ -413,6 +426,8 @@
   - type: Tag
     tags:
     - Syringe
+  - type: UseDelay
+    delay: 1.5
 
 - type: entity
   parent: N14PsychoSyringe
@@ -458,6 +473,8 @@
         reagents:
         - ReagentId: RadAway
           Quantity: 20
+  - type: UseDelay
+    delay: 1.25
 
 #MARK: RadAway Inhaler
 - type: entity
@@ -487,6 +504,8 @@
     solutions:
       pen:
         maxVol: 30
+  - type: UseDelay
+    delay: 0.5
 
 - type: entity
   parent: N14RadAwayInhalerBase
@@ -648,7 +667,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 10
+        damage: 75
       behaviors:
       - !type:SpillBehavior
         solution: food
@@ -694,7 +713,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 100
+        maxVol: 60
   - type: Sprite
     sprite: _Nuclear14/Objects/Specific/Medical/fallout2.rsi
     state: antidote
@@ -718,10 +737,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 100
+        maxVol: 60
         reagents:
         - ReagentId: Antidote
-          Quantity: 100
+          Quantity: 60
 
 - type: entity
   # #Misfits Change /Tweak/ - Smelling salts use a long resuscitation interaction instead of injecting a reagent.
@@ -867,7 +886,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 10
+        damage: 100
       behaviors:
       - !type:SpillBehavior
         solution: food

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
@@ -36,6 +36,8 @@
   - type: Tag
     tags:
     - Syringe
+  - type: DoAfter
+    doAfterDuration: 1.5
 
 - type: entity
   name: doctors syringe
@@ -76,6 +78,8 @@
   - type: Tag
     tags:
     - Syringe
+  - type: DoAfter
+    doAfterDuration: 1.5
 
 - type: entity
   parent: N14BaseSyringe
@@ -144,6 +148,8 @@
         reagents:
         - ReagentId: DirtyStimpak
           Quantity: 25
+  - type: DoAfter
+    doAfterDuration: 1.5
 
 - type: entity
   parent: N14ChemicalSyringe
@@ -735,7 +741,7 @@
     sprite: _Nuclear14/Objects/Specific/Medical/ms13_medical.rsi
     state: powder1
   - type: SmellingSalts
-    doAfterDuration: 6
+    doAfterDuration: 67
     reviveHeal:
       types:
         Asphyxiation: -40

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
@@ -26,6 +26,7 @@
   - type: ExaminableSolution
     solution: pen
   - type: Hypospray
+    doAfterDuration: 1.5
     onlyAffectsMobs: false
     solutionName: pen
     transferAmount: 30
@@ -36,8 +37,6 @@
   - type: Tag
     tags:
     - Syringe
-  - type: DoAfter
-    doAfterDuration: 1.5
 
 - type: entity
   name: doctors syringe
@@ -61,6 +60,7 @@
         maxVol: 15
   - type: Injector
     injectOnly: false
+    doAfterDuration: 1.5
   - type: ExaminableSolution
     solution: injector
   - type: Spillable
@@ -78,8 +78,6 @@
   - type: Tag
     tags:
     - Syringe
-  - type: DoAfter
-    doAfterDuration: 1.5
 
 - type: entity
   parent: N14BaseSyringe
@@ -148,8 +146,6 @@
         reagents:
         - ReagentId: DirtyStimpak
           Quantity: 25
-  - type: DoAfter
-    doAfterDuration: 1.5
 
 - type: entity
   parent: N14ChemicalSyringe

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Medical/chemicals.yml
@@ -741,7 +741,7 @@
     sprite: _Nuclear14/Objects/Specific/Medical/ms13_medical.rsi
     state: powder1
   - type: SmellingSalts
-    doAfterDuration: 67
+    doAfterDuration: 6
     reviveHeal:
       types:
         Asphyxiation: -40

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -440,7 +440,7 @@
     - LandMineExplosive  # Explosive Mine (~4 tile radius)
     - LandMineModular    # Modular Mine (empty casing, add payload)
     - N14ModularGrenade
-    - N14ChemicalPayload
+    # - N14ChemicalPayload
     - N14ExplosivePayload
     - N14FlashPayload
     # #Misfits Add: Circuits

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -440,7 +440,7 @@
     - LandMineExplosive  # Explosive Mine (~4 tile radius)
     - LandMineModular    # Modular Mine (empty casing, add payload)
     - N14ModularGrenade
-    # - N14ChemicalPayload
+    - N14ChemicalPayload
     - N14ExplosivePayload
     - N14FlashPayload
     # #Misfits Add: Circuits

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/craftingbenches.yml
@@ -645,7 +645,7 @@
     - N14Beaker
     - N14LargeBeaker
     - N14Dropper
-    - N14Syringe
+#    - N14Syringe
     - N14SyringeInjectable
     - N14PillCanister
     - N14ChemistryEmptyBottle01

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -31,17 +31,6 @@
               Airloss: -3
         - !type:ModifyBleedAmount
           amount: -2
-        - !type:HealthChange # Bonus for poison
-          conditions:
-          - !type:ReagentThreshold
-            min: 27
-          damage:
-            groups:
-              Burn: -1.0
-              Brute: -1.0
-              Airloss: -1.0
-            types:
-              Poison: 3
         - !type:GenericStatusEffect
           conditions:
           - !type:ReagentThreshold

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/chemistry.yml
@@ -32,14 +32,14 @@
     Glass: 200
     Plastic: 100
 
-- type: latheRecipe
-  id: N14Syringe
-  result: N14ChemicalSyringe
-  completetime: 2
-  category: N14Chemistry
-  materials:
-    Plastic: 100
-    Steel: 25
+#- type: latheRecipe
+#  id: N14Syringe
+#  result: N14ChemicalSyringe
+#  completetime: 2
+#  category: N14Chemistry
+#  materials:
+#    Plastic: 100
+#    Steel: 25
 
 - type: latheRecipe
   id: N14SyringeInjectable

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/weapons.yml
@@ -316,14 +316,14 @@
 
 
 # Misfits Add: Recipes for payloads because there is none for modular mines.
-#- type: latheRecipe
-#  id: N14ChemicalPayload
-#  result: ChemicalPayload # Bill from misfits14 here: chem is a cancer when used in combat and sucks to try and balance for without making normal chem dogshit. Re-enable at your own peril.
-#  category: N14Weapons
-#  completetime: 10
-#  materials:
-#    Circuitry: 300
-#    Steel: 400
+- type: latheRecipe
+  id: N14ChemicalPayload
+  result: ChemicalPayload 
+  category: N14Weapons
+  completetime: 10
+  materials:
+    Circuitry: 300
+    Steel: 400
 
 - type: latheRecipe
   id: N14ExplosivePayload

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/weapons.yml
@@ -316,14 +316,14 @@
 
 
 # Misfits Add: Recipes for payloads because there is none for modular mines.
-- type: latheRecipe
-  id: N14ChemicalPayload
-  result: ChemicalPayload
-  category: N14Weapons
-  completetime: 10
-  materials:
-    Circuitry: 300
-    Steel: 400
+#- type: latheRecipe
+#  id: N14ChemicalPayload
+#  result: ChemicalPayload # Bill from misfits14 here: chem is a cancer when used in combat and sucks to try and balance for without making normal chem dogshit. Re-enable at your own peril.
+#  category: N14Weapons
+#  completetime: 10
+#  materials:
+#    Circuitry: 300
+#    Steel: 400
 
 - type: latheRecipe
   id: N14ExplosivePayload


### PR DESCRIPTION
## About the PR
THEY ADDED 20% SPEED BOOSTED ARMOR WITH 20% ARMOR RESISTS TO VET EXPLORER. Gutted to recon armor tier instead of direct upgrade.
methods to get phlog is gutted. Napalm is expensive to make in quantity, but you can mutate for it still.
Did a requested change by Chance to make the base Road Rash 80s raider only need wastelander playtime and to de-whitelist them. 
Added 40mm to NCR BPs
Tweaked legion armors to be a little slower (vet legionnaire from 10% boost to 5%)

Added variable doafters to the injectors. Chem syringe does not have a doafter, and cannot be recrafted. Which firmly plants it as a rare and powerful medic tool. Longest doafter is 1.5 seconds on both super stim and psycho syringe.

## Why / Balance
Chem is a cancer.
Vet explorer with stats like that is fucking INSANE.
Combat injecting someone else to OD them or poison them with gigacancer is shit.
Chance asked for the 80s changes a little bit ago

## Technical details
yml

## Media

https://github.com/user-attachments/assets/2661c58f-53bf-484a-a914-f27101ccf540

# Changelog

:cl: Bill
- tweak: nerfed veteran explorer armor. 
- tweak: made phlog/napalm mix incredibly difficult to produce, so difficult that its unobtainable.
- tweak: Added very light doafters to injectors. chemical syringes do not have a doafter but cannot be crafted anymore. These are special items meant for medics to use for quick healing. 
- fix: chance asked for 80s to just need waster playtime so I obliged. Road Rash now only needs 10 hours of  wastelander playtime. 
- add: NCR now gets a 40mm grenade in their T3 ammo BP
- tweak: legion veteran armor nerfed ever so slightly.