### PR TITLE
Synthetics Tweaks

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Ears/headsets.yml
@@ -8,7 +8,6 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyCommon
       - EncryptionKeyWastelandGlobal
       - EncryptionKeyVault
   - type: Sprite

--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
@@ -277,7 +277,7 @@
   id: N14PlayerSyntheticMrGutsy
   name: mr. gutsy
   suffix: player, synthetic
-  description: A General Atomics Mr. Gutsy military combat robot, now guided by a living mind. Equipped with a plasma caster and aggressive military programming.
+  description: A General Atomics Mr. Gutsy military combat robot, now guided by a living mind. Equipped with a plasma pistol and military programming.
   components:
   - type: HumanoidAppearance
     species: RobotMrGutsy
@@ -343,7 +343,7 @@
     availableModes:
     - SemiAuto
   - type: BasicEntityAmmoProvider # #Misfits Add: limited plasma shots, auto-refills after cooldown
-    proto: BulletBigPlasma
+    proto: BulletPlasma
     capacity: 15
     count: 15
   - type: RechargeBasicEntityAmmo # #Misfits Add: recharge simulates internal capacitor cycling
@@ -356,7 +356,6 @@
         - PositronicBrain
       borg_module:
         - BorgModuleTool # #Misfits Add: military utility — field repair and maintenance tools
-        - BorgModuleGPS # #Misfits Add: military utility — navigation and scanning tools
       id: # #Misfits Change: pre-load the nav module into the id inventory slot
         - MisfitsRobotNavCard # General Atomics Navigation
       ears: # #Misfits Fix - vault comms: wasteland + vault radio for vault-assigned robot
@@ -427,7 +426,6 @@
         - PositronicBrain
       borg_module:
         - N14BorgModuleSecurity # stun baton, handcuffs, flashlight - lore-accurate detainment kit
-        - BorgModuleGPS         # navigation/patrol utility for law enforcement
       id:
         - MisfitsRobotNavCardRobCo
       ears: # #Misfits Fix - vault comms: wasteland + vault radio for vault-assigned robot
@@ -593,7 +591,7 @@
   - type: AssaultronBeamCharge # #Misfits Add: 2-second charge-up before beam fires, 3-second cooldown after
     chargeDuration: 2
     cooldownDuration: 3
-    fireDrainCharge: 900 # #Misfits Add: 50% of PowerCellHyper (1800) per shot — matches Tesla drain cost
+    fireDrainCharge: 270 # #Misfits Add: 20% of PowerCellHyper (1800) per shot
   - type: HitscanBatteryAmmoProvider # #Misfits Change: battery pool large enough for continuous fire — beam availability tied to chassis power cell
     proto: N14AssaultronHeadLaser
     fireCost: 100

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Weapons/Guns/Ammunition/hitscan.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Weapons/Guns/Ammunition/hitscan.yml
@@ -188,8 +188,8 @@
   id: N14AssaultronHeadLaser
   damage:
     types:
-      Heat: 90
-      Structural: 15
+      Heat: 30
+      Structural: 10
   tintColor: "#FF6A00"
   beamWidth: 3
   beamDuration: 3.0


### PR DESCRIPTION
## About the PR
reverted gutsy caster to plasma pistol, in line with lore, removed gps module from the few that had it cause its redundant with the map, decreased energy cost and damage on laser assaultron so its actually usable. removed common channel from synthetics because its unused

## Why / Balance
gutsy caster OP
assaultron laser was terrible and unused
gps module was worthless and half functional
removed common channel from synthetics because its unused

## Technical details
BulletBigPlasma-> BulletPlasma
assultron laser 90 heat 15 struct -> 30 heat 10 struct
900 charge drain down to 200 (hypercell holds 1800 charge when full)
took common key out of robot spawn headset

# Changelog

:cl:
- remove: took common encryption key out of robots... this is the wasteland not a space station
- remove: GPS module from police protectron and mr gutsy 
- tweak: gutsy now shoots smaller bullets again, Todd Howard called and said its only a pistol not a caster
- tweak: laser assaultron now has less damaging laser but it can be fired several times on a battery instead of once. total damage if you land every laser is theoretically higher, but takes multiple shots. 