### PR TITLE
NCR Medical Rank Changes

### DIFF
--- a/Resources/Prototypes/_Misfits/NCR/ncr_rank_pin_progressions.yml
+++ b/Resources/Prototypes/_Misfits/NCR/ncr_rank_pin_progressions.yml
@@ -19,9 +19,21 @@
   id: NCRCommandOfficerPins
   jobs:
     - NCRCommander
-    - NCRDoctor
   tracker: NCR
   departmentTracker: true
+  thresholds:
+    - min: 0
+      entity: ClothingNeckPinNCRCaptain
+    - min: 72000   # 20 hours
+      entity: ClothingNeckPinNCRMajor
+
+# Medical Officers: Captain (O-3) → Major (O-4) at 20h NCR dept time
+- type: ncrRankPinProgression
+  id: NCRMedicalOfficerPins
+  jobs:
+    - NCRDoctor
+  tracker: NCRMedicalDoctor
+  departmentTracker: false
   thresholds:
     - min: 0
       entity: ClothingNeckPinNCRCaptain
@@ -60,13 +72,27 @@
     - min: 216000  # 60 hours
       entity: ClothingNeckPinNCRMasterSergeant
 
+# Medic: PFC (E-3) → SPC (E-4) at 20h NCR dept → SGT (E-5) at 40h NCR dept
+- type: ncrRankPinProgression
+  id: NCRMedicPins
+  jobs:
+    - NCRMedic
+  tracker: NCRMedic
+  departmentTracker: false
+  thresholds:
+    - min: 0
+      entity: ClothingNeckPinNCRPrivate1st
+    - min: 72000   # 20 hours
+      entity: ClothingNeckPinNCRSpecialist
+    - min: 144000  # 40 hours
+      entity: ClothingNeckPinNCRSergeant
+
 # Specialists: PV2 (E-2) → PFC (E-3) at 20h NCR dept → SPC (E-4) at 40h NCR dept
 - type: ncrRankPinProgression
   id: NCRSpecialistPins
   jobs:
     - NCRWS
     - NCREngineer
-    - NCRMedic
     - NCRHeavyTrooper
   tracker: NCR
   departmentTracker: true

--- a/Resources/Prototypes/_Misfits/NCR/ncr_rank_pin_progressions.yml
+++ b/Resources/Prototypes/_Misfits/NCR/ncr_rank_pin_progressions.yml
@@ -27,7 +27,7 @@
     - min: 72000   # 20 hours
       entity: ClothingNeckPinNCRMajor
 
-# Medical Officers: Captain (O-3) → Major (O-4) at 20h NCR dept time
+# Medical Officers: Captain (O-3) → Major (O-4) at 20h
 - type: ncrRankPinProgression
   id: NCRMedicalOfficerPins
   jobs:
@@ -72,7 +72,7 @@
     - min: 216000  # 60 hours
       entity: ClothingNeckPinNCRMasterSergeant
 
-# Medic: PFC (E-3) → SPC (E-4) at 20h NCR dept → SGT (E-5) at 40h NCR dept
+# Medic: PFC (E-3) → SPC (E-4) at 20h NCR dept → SGT (E-5) at 40h
 - type: ncrRankPinProgression
   id: NCRMedicPins
   jobs:


### PR DESCRIPTION
## About the PR
NCR medical doctor rank up now requires medical doctor time to rank up. NCR Medic is now PFC (E-3) -> SPC (E-4) -> SGT (E-5)

## Why / Balance
NCR playtime is not equivalent to NCR medic or medical doctor playtime, in line with how SL uses its own tracker due to the different skills (leadership) required.

As for the E-5 medic, Medics also typically need to be higher ranked than the average trooper to ensure their health and safety.

In addition, please refer to STP 8-91W15-SM-TG SOLDIER'S MANUAL AND TRAINER'S GUIDE, MOS 91W, HEALTH CARE SPECIALIST, SKILL LEVELS 1/2/3/4/5, Chapter 1, Page 4. A medic ranking E-2 would still be undergoing training and not field duty and from what I can gather online, promotion to Sergeant is typical for long-standing medics in the army, coming with slight leadership responsibilities but still tasked with field work. Sourcing the US army because that's what the NCR is based off of.

## Technical details
ymlslop

## Media

# Changelog

:cl: sssaaagggeee
- tweak: NCR Doctor now requires NCR doctor playtime to rank up
- tweak: NCR Medic now requires NCR medic playtime to rank up
- tweak: NCR medic promotions are now E3 -> E4 -> E5
