### PR TITLE
Uranium as a Catalyst for Dexalin

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/reagents.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/reagents.ftl
@@ -291,6 +291,12 @@ reagent-desc-daytripper = The perfect escape for your horrible life.
 reagent-name-fev = FEV
 reagent-desc-fev = A megavirus protected by a protein shell, strengthened with ionized hydrogen molecules.
 
+reagent-name-epoetine = epoetine
+reagent-desc-epoetine = A medicine that stimulates the lungs and encourages bloodflow.
+
+reagent-name-beta-epoetine = beta epoetine
+reagent-desc-beta-epoetine = A more potent medicine that stimulates the lungs and encourages bloodflow.
+
 # Meta
 reagent-name-movespeedmod-mixture = jet
 reagent-desc-movespeedmod-mixture = A mixture of reagents that makes you move fast.

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -107,7 +107,7 @@
   reactants:
     Oxygen:
       amount: 2
-    Uranium: ##changed from plasma to facilitate wasteland usage
+    Plasma:
       amount: 1
       catalyst: true
   products:

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -107,7 +107,7 @@
   reactants:
     Oxygen:
       amount: 2
-    Plasma:
+    Uranium: ##changed from plasma to facilitate wasteland usage
       amount: 1
       catalyst: true
   products:

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -585,7 +585,6 @@
 - type: reagent
   id: Epoetine
   name: reagent-name-epoetine
-  group: Chems
   desc: reagent-desc-epoetine
   physicalDesc: reagent-physical-desc-refreshing
   color: "#0041a8"
@@ -609,7 +608,6 @@
 - type: reagent
   id: BetaEpoetine
   name: reagent-name-beta-epoetine
-  group: Medicine
   desc: reagent-desc-beta-epoetine
   physicalDesc: reagent-physical-desc-tangy
   color: "#4da0bd"

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -26,8 +26,8 @@
         - !type:HealthChange
           damage:
             groups:
-              Burn: -9 # 9/3 = 3 | 3*25 = 75 of every type in 25 seconds. 
-              Brute: -9 # 9/3 = 3 | 3*25 = 75 of every type in 25 seconds. 
+              Burn: -9 # 9/3 = 3 | 3*25 = 75 of every type in 25 seconds.
+              Brute: -9 # 9/3 = 3 | 3*25 = 75 of every type in 25 seconds.
               Airloss: -3
         - !type:ModifyBleedAmount
           amount: -2
@@ -612,7 +612,6 @@
   group: Medicine
   desc: reagent-desc-beta-epoetine
   physicalDesc: reagent-physical-desc-tangy
-  flavor: medicine
   color: "#4da0bd"
   metabolisms:
     Medicine:

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -581,3 +581,82 @@
       # conditions:
       # - !type:ReagentThreshold
       #   min: 25
+      -
+- type: reaction
+  id: epoetine
+  reactants:
+    Oxygen:
+      amount: 2
+    Uranium:
+      amount: 1
+      catalyst: true
+  products:
+    Epoetine: 3
+
+- type: reagent
+  id: Epoetine
+  name: reagent-name-epoetine
+  group: Chems
+  desc: reagent-desc-epoetine
+  physicalDesc: reagent-physical-desc-refreshing
+  color: "#0041a8"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Asphyxiation: -1
+            Bloodloss: -0.5
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+        damage:
+          types:
+            Asphyxiation: 3
+            Cold: 1
+
+- type: reaction
+  id: BetaEpoetine
+  reactants:
+    Epoetine:
+      amount: 1
+    Carbon:
+      amount: 1
+    Iron:
+      amount: 1
+  products:
+    BetaEpoetine: 3
+
+- type: reagent
+  id: BetaEpoetine
+  name: reagent-name-beta-epoetine
+  group: Medicine
+  desc: reagent-desc-beta-epoetine
+  physicalDesc: reagent-physical-desc-tangy
+  flavor: medicine
+  color: "#4da0bd"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Asphyxiation: -3.5
+            Bloodloss: -3
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          reagent: HeartbreakerToxin
+          min: 1
+        reagent: HeartbreakerToxin
+        amount: -3
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 25
+        damage:
+          types:
+            Asphyxiation: 5
+            Cold: 3

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -581,7 +581,7 @@
       # conditions:
       # - !type:ReagentThreshold
       #   min: 25
-      -
+
 - type: reagent
   id: Epoetine
   name: reagent-name-epoetine

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -583,7 +583,7 @@
       #   min: 25
       -
 - type: reaction
-  id: epoetine
+  id: Epoetine
   reactants:
     Oxygen:
       amount: 2

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -582,17 +582,6 @@
       # - !type:ReagentThreshold
       #   min: 25
       -
-- type: reaction
-  id: Epoetine
-  reactants:
-    Oxygen:
-      amount: 2
-    Uranium:
-      amount: 1
-      catalyst: true
-  products:
-    Epoetine: 3
-
 - type: reagent
   id: Epoetine
   name: reagent-name-epoetine
@@ -616,18 +605,6 @@
           types:
             Asphyxiation: 3
             Cold: 1
-
-- type: reaction
-  id: BetaEpoetine
-  reactants:
-    Epoetine:
-      amount: 1
-    Carbon:
-      amount: 1
-    Iron:
-      amount: 1
-  products:
-    BetaEpoetine: 3
 
 - type: reagent
   id: BetaEpoetine

--- a/Resources/Prototypes/_Nuclear14/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Reactions/medicine.yml
@@ -172,3 +172,26 @@
   effects:
     - !type:CreateEntityReactionEffect
       entity: N14Ointment1
+
+- type: reaction
+  id: Epoetine
+  reactants:
+    Oxygen:
+      amount: 2
+    Uranium:
+      amount: 1
+      catalyst: true
+  products:
+    Epoetine: 3
+
+- type: reaction
+  id: BetaEpoetine
+  reactants:
+    Epoetine:
+      amount: 1
+    Carbon:
+      amount: 1
+    Iron:
+      amount: 1
+  products:
+    BetaEpoetine: 3


### PR DESCRIPTION
## About the PR

Added Epoetine and Beta Epoetine, which are practically dex/dexp but more fallout coded

## Why / Balance
currently the only two ways to treat Bloodloss type damage is via CPR or blood packs. Blood packs are somewhat scarce and only heal 5 bloodloss per set of 10, resulting in CPR being required to revive anyone who bleeds out. which is an extremely frequent cause of death in the wasteland. 

one of the main tenets of game design is to make games fun. this is done by allowing players to make choices, and letting them see the results. By forcing doctors to sit at their computers waiting for cpr to be over, working on only one patient at a time we are not only providing no good options to decide between, they are forced to not do anything else concurrently. 

creating oxygen is labor intensive enough and epoetine is not that potent, so CPR is still a viable free option, or if you have multiple people helping it still helps. 

beta epoetine can be made from epoetine, requiring a lot of iron and carbon, which will also be somewhat labor intensive, and make the faction decide if they want to use iron ore for medicine or for more bullets, another decision to make. 

acquiring the uranium ore is not easy either, and will facilitate trade and more adventuring.

## Technical details
swapped "Plasma" for "Uranium" in the dexalin reaction, made it its own chem in our prototypes called epoetine

# Changelog
:cl:
- add: Epoetine (dexalin but different), uses uranium instead of plasma
- add: Beta Epoetine (dexp but different)
