### PR TITLE
NCR C-27 Rank & Progression

### DIFF
--- a/Resources/Prototypes/_Misfits/NCR/ncr_rank_pin_progressions.yml
+++ b/Resources/Prototypes/_Misfits/NCR/ncr_rank_pin_progressions.yml
@@ -13,6 +13,7 @@
 #   NCRWeaponSpecialist  — NCR Weapon Specialist
 #   NCRHeavyTrooper      — NCR Heavy Trooper
 #   NCRTrooper           — NCR Trooper
+#   C27NCR               — NCR C27
 
 # Command Officers: Captain (O-3) → Major (O-4) at 20h NCR dept time
 - type: ncrRankPinProgression
@@ -120,3 +121,18 @@
       entity: ClothingNeckPinNCRPrivate1st
     - min: 216000  # 60 hours
       entity: ClothingNeckPinNCRSpecialist
+      
+# C-27: Sergeant (E-5) ->  1st Sergeant (E-6) -> Master Sergeant (E-8)
+- type: ncrRankPinProgression
+  id: NCRC27Pins
+  jobs:
+    - C27NCR
+  tracker: C27NCR
+  departmentTracker: false
+  thresholds:
+    - min: 0
+      entity: ClothingNeckPinNCRSergeant
+    - min: 36000  # 10 hours
+      entity: ClothingNeckPinNCRSergeant1st
+    - min: 72000  # 20 hours
+      entity: ClothingNeckPinNCRMasterSergeant


### PR DESCRIPTION
## About the PR
NCR C-27 now has a rank and progression.

## Why / Balance
Cool flavor for RP, also gives a sense of progression for what is the most underplayed C-27 role. Ranks were chosen loosely based on Synthetic's honorary ranks from CM13. Whitelist holders should recognize they still have zero command authority within the NCR, similar to if you were to see a 'Sergeant Gusty' or something within the NCR.

## Technical details
waiter waiter! more yaml please!!!

## Media

# Changelog

:cl: sssaaagggeee
- add: NCR C-27 ranks and progression, going from E-5 -> E-6 -> E-8
