### PR TITLE
Changes Plasma Caustic To Shock

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
@@ -39,10 +39,9 @@
     impactEffect: BulletPlasmaImpactEffect
     damage:
       types:
-        Heat: 18
+        Shock: 18
         Radiation: 2
         Structural: 50
-    ignoreResistances: true
     soundHit:
       path: "/Audio/Weapons/Guns/Hits/energy_meat1.ogg"
 
@@ -58,9 +57,8 @@
     impactEffect: BulletPlasmaImpactEffect
     damage:
       types:
-        Caustic: 15
+        Shock: 15
         Structural: 25
-    ignoreResistances: true
     soundHit:
       path: "/Audio/Weapons/Guns/Hits/energy_meat1.ogg"
 
@@ -76,10 +74,9 @@
     impactEffect: BulletPlasmaImpactEffect
     damage:
       types:
-        Heat: 35
+        Shock: 35
         Radiation: 5
         Structural: 100
-    ignoreResistances: true
     soundHit:
       path: "/Audio/Weapons/Guns/Hits/energy_meat1.ogg"
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
@@ -39,9 +39,10 @@
     impactEffect: BulletPlasmaImpactEffect
     damage:
       types:
-        Caustic: 18
+        Heat: 18
         Radiation: 2
         Structural: 50
+    ignoreResistances: true
     soundHit:
       path: "/Audio/Weapons/Guns/Hits/energy_meat1.ogg"
 
@@ -59,6 +60,7 @@
       types:
         Caustic: 15
         Structural: 25
+    ignoreResistances: true
     soundHit:
       path: "/Audio/Weapons/Guns/Hits/energy_meat1.ogg"
 
@@ -74,9 +76,10 @@
     impactEffect: BulletPlasmaImpactEffect
     damage:
       types:
-        Caustic: 35
+        Heat: 35
         Radiation: 5
         Structural: 100
+    ignoreResistances: true
     soundHit:
       path: "/Audio/Weapons/Guns/Hits/energy_meat1.ogg"
 


### PR DESCRIPTION
## About the PR
Changes caustic damage to shock from the plasma shells

## Why / Balance
Caustic don't damage inorganic entities making walls and silicons players being invulnerable to plasma.

## Technical details
Yalm change

## Media
https://www.youtube.com/watch?v=6_ohQuxgPEU&list=RD6_ohQuxgPEU&start_radio=1&t=1224s

# Changelog
:cl:
- tweak: Plasma projectile damage changed from caustic to shock.
