### PR TITLE
SPECIAL Rebalancing + Changes

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -41,6 +41,7 @@ using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 using Content.Server.Shuttles.Components;
 using Content.Server._Misfits.Supporter; // #Misfits Add - Supporter chat integration
+using Content.Shared._Misfits.Special;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics.Joints;
 
@@ -75,6 +76,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     [Dependency] private readonly LanguageSystem _language = default!;
     [Dependency] private readonly TelepathicChatSystem _telepath = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     // Forge-Change Moved to shared
     // public const int VoiceRange = 10; // how far voice goes in world units
@@ -958,13 +960,14 @@ public sealed partial class ChatSystem : SharedChatSystem
         var languageDisplay = language.IsVisibleLanguage
             ? Loc.GetString("chat-manager-language-prefix", ("language", language.ChatName))
             : "";
+        var fontSize = _special.GetCharismaChatFontSize(source, language.SpeechOverride.FontSize ?? speech.FontSize);
 
         return Loc.GetString(wrapId,
             ("color", color),
             ("entityName", entityName),
             ("verb", Loc.GetString(verbId)),
             ("fontType", language.SpeechOverride.FontId ?? speech.FontId),
-            ("fontSize", language.SpeechOverride.FontSize ?? speech.FontSize),
+            ("fontSize", fontSize),
             ("message", message),
             ("language", languageDisplay));
     }

--- a/Content.Server/LandMines/LandMineSystem.cs
+++ b/Content.Server/LandMines/LandMineSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.DoAfter;
 using Content.Server.Explosion.EntitySystems;
 using Content.Shared._Misfits.LandMines;
+using Content.Shared._Misfits.Special;
 using Robust.Shared.GameObjects;
 using Content.Shared.Audio;
 using Content.Shared.Construction.Components;
@@ -30,6 +31,7 @@ public sealed class LandMineSystem : EntitySystem
     [Dependency] private readonly SharedAmbientSoundSystem _ambientSound = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     public override void Initialize()
     {
@@ -133,7 +135,7 @@ public sealed class LandMineSystem : EntitySystem
                         Loc.GetString("land-mine-disarm-start", ("mine", uid)),
                         uid, args.User);
 
-                    var da = new DoAfterArgs(EntityManager, args.User, TimeSpan.FromSeconds(4),
+                    var da = new DoAfterArgs(EntityManager, args.User, GetPerceptionMineDelay(args.User, 4f),
                         new LandMineDisarmDoAfterEvent(), uid, target: uid)
                     {
                         BreakOnDamage = true,
@@ -162,7 +164,7 @@ public sealed class LandMineSystem : EntitySystem
                         Loc.GetString("land-mine-arm-start", ("mine", uid)),
                         uid, args.User);
 
-                    var da = new DoAfterArgs(EntityManager, args.User, TimeSpan.FromSeconds(2),
+                    var da = new DoAfterArgs(EntityManager, args.User, GetPerceptionMineDelay(args.User, 2f),
                         new LandMineArmDoAfterEvent(), uid, target: uid)
                     {
                         BreakOnDamage = true,
@@ -235,5 +237,18 @@ public sealed class LandMineSystem : EntitySystem
             _transform.Unanchor(uid, xform);
 
         _hands.TryPickupAnyHand(args.User, uid);
+    }
+
+    private TimeSpan GetPerceptionMineDelay(EntityUid user, float baseSeconds)
+    {
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            user,
+            SpecialStat.Perception,
+            tuning.PerceptionMineDelayPenaltyAtOne,
+            -tuning.PerceptionMineDelayReductionAtTen);
+        var seconds = MathF.Max(0.5f, baseSeconds * (1f + modifier));
+
+        return TimeSpan.FromSeconds(seconds);
     }
 }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -601,11 +601,11 @@ namespace Content.Server.Lathe
                 return baseTime;
 
             var intelligence = _special.GetEffective(user.Value, SpecialStat.Intelligence, special);
-            if (intelligence >= SpecialProfile.Maximum)
-                return TimeSpan.Zero;
-
+            var tuning = _special.GetTuning();
+            var minMultiplier = Math.Clamp(tuning.IntelligenceLatheMinimumTimeMultiplierAtTen, 0.1f, 1f);
             var multiplier = intelligence >= SpecialProfile.DefaultValue
-                ? 1f - (intelligence - SpecialProfile.DefaultValue) * 0.2f
+                ? 1f - (1f - minMultiplier) * (intelligence - SpecialProfile.DefaultValue) /
+                    (SpecialProfile.Maximum - SpecialProfile.DefaultValue)
                 : 1f + (SpecialProfile.DefaultValue - intelligence) * 0.15f;
 
             return baseTime * MathF.Max(0.1f, multiplier);

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Chat.Systems;
 using Content.Server.Language;
 using Content.Server.Power.Components;
 using Content.Server.Radio.Components;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Language;
@@ -33,6 +34,7 @@ public sealed class RadioSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly LanguageSystem _language = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     // set used to prevent radio feedback loops.
     private readonly HashSet<string> _messages = new();
@@ -317,6 +319,7 @@ public sealed class RadioSystem : EntitySystem
             ? Loc.GetString("chat-manager-language-prefix", ("language", language.ChatName))
             : "";
         var messageColor = language.IsVisibleLanguage ? languageColor : channel.Color;
+        var fontSize = _special.GetCharismaChatFontSize(source, language.SpeechOverride.FontSize ?? speech.FontSize);
 
         string channelText;
         if (channel.ShowFrequency && frequency.HasValue)
@@ -329,7 +332,7 @@ public sealed class RadioSystem : EntitySystem
             ("languageColor", languageColor),
             ("messageColor", messageColor),
             ("fontType", language.SpeechOverride.FontId ?? speech.FontId),
-            ("fontSize", language.SpeechOverride.FontSize ?? speech.FontSize),
+            ("fontSize", fontSize),
             ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
             ("channel", channelText),
             ("name", name),

--- a/Content.Server/Telephone/TelephoneSystem.cs
+++ b/Content.Server/Telephone/TelephoneSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using System.Linq;
 using Content.Shared._NC.TTS;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Silicons.StationAi;
 using Content.Shared.Silicons.Borgs.Components;
 
@@ -37,6 +38,7 @@ public sealed class TelephoneSystem : SharedTelephoneSystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IReplayRecordingManager _replay = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     // Has set used to prevent telephone feedback loops
     private HashSet<(EntityUid, string, Entity<TelephoneComponent>)> _recentChatMessages = new();
@@ -359,7 +361,7 @@ public sealed class TelephoneSystem : SharedTelephoneSystem
         var wrappedMessage = Loc.GetString(speech.Bold ? "chat-telephone-message-wrap-bold" : "chat-telephone-message-wrap",
             ("color", Color.White),
             ("fontType", speech.FontId),
-            ("fontSize", speech.FontSize),
+            ("fontSize", _special.GetCharismaChatFontSize(messageSource, speech.FontSize)),
             ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
             ("name", name),
             ("message", content));

--- a/Content.Server/_Misfits/SpecialStats/SpecialPenaltySystem.cs
+++ b/Content.Server/_Misfits/SpecialStats/SpecialPenaltySystem.cs
@@ -16,7 +16,7 @@ public sealed class SpecialPenaltySystem : EntitySystem
 
     private const int LowCharismaThreshold = 5;
     private const int LowIntelligenceThreshold = 2;
-    private const int ClumsyLuckThreshold = 4;
+    private const int ClumsyLuckThreshold = 3;
 
     public override void Initialize()
     {

--- a/Content.Server/_NC/Trade/Contracts/Claim/NcContractSystem.Claim.Execute.cs
+++ b/Content.Server/_NC/Trade/Contracts/Claim/NcContractSystem.Claim.Execute.cs
@@ -102,7 +102,7 @@ public sealed partial class NcContractSystem : EntitySystem
             switch (reward.Type)
             {
                 case StoreRewardType.Currency:
-                    _logic.GiveCurrency(ctx.User, reward.Id, reward.Amount);
+                    _logic.GiveCurrency(ctx.User, reward.Id, _logic.ApplyCharismaSellReward(ctx.User, reward.Amount));
                     break;
 
                 case StoreRewardType.Item:

--- a/Content.Server/_NC/Trade/Store/Runtime/MassSell/NcStoreLogicSystem.MassSellExecutor.cs
+++ b/Content.Server/_NC/Trade/Store/Runtime/MassSell/NcStoreLogicSystem.MassSellExecutor.cs
@@ -15,7 +15,7 @@ public sealed partial class NcStoreLogicSystem
         var cached = _inventory.GetOrBuildDeepItemsCacheCompacted(container);
         items.AddRange(cached);
 
-        var plan = ComputeMassSellPlanFromCachedItems(store, container, items);
+        var plan = ComputeMassSellPlanFromCachedItems(store, container, items, user);
         if (plan.Steps.Count == 0 || plan.IncomeByCurrency.Count == 0)
             return false;
 

--- a/Content.Server/_NC/Trade/Store/Runtime/MassSell/NcStoreLogicSystem.MassSellPlanner.cs
+++ b/Content.Server/_NC/Trade/Store/Runtime/MassSell/NcStoreLogicSystem.MassSellPlanner.cs
@@ -9,24 +9,25 @@ public sealed partial class NcStoreLogicSystem
 {
     private readonly Dictionary<string, int> _inheritanceDepthCache = new(StringComparer.Ordinal);
 
-    public MassSellPlan ComputeMassSellPlan(NcStoreComponent store, EntityUid container)
+    public MassSellPlan ComputeMassSellPlan(NcStoreComponent store, EntityUid container, EntityUid? user = null)
     {
         _inventory.InvalidateInventoryCache(container);
         var cached = _inventory.GetOrBuildDeepItemsCacheCompacted(container);
-        return ComputeMassSellPlanInternal(store, cached);
+        return ComputeMassSellPlanInternal(store, cached, user);
     }
 
     public MassSellPlan ComputeMassSellPlanFromCachedItems(
         NcStoreComponent store,
         EntityUid container,
-        IReadOnlyList<EntityUid> cachedItems
+        IReadOnlyList<EntityUid> cachedItems,
+        EntityUid? user = null
     ) =>
-        ComputeMassSellPlanInternal(store, cachedItems);
+        ComputeMassSellPlanInternal(store, cachedItems, user);
 
     public Dictionary<string, int> GetMassSellValue(NcStoreComponent store, EntityUid container) =>
         ComputeMassSellPlan(store, container).IncomeByCurrency;
 
-    private MassSellPlan ComputeMassSellPlanInternal(NcStoreComponent store, IEnumerable<EntityUid> items)
+    private MassSellPlan ComputeMassSellPlanInternal(NcStoreComponent store, IEnumerable<EntityUid> items, EntityUid? user)
     {
         var incomeByCurrency = new Dictionary<string, int>(StringComparer.Ordinal);
         var unitsByListingId = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -88,7 +89,11 @@ public sealed partial class NcStoreLogicSystem
             if (l.Mode != StoreMode.Sell)
                 continue;
             if (TryPickCurrencyForSell(store, l, out _, out var price))
+            {
+                if (user is { } userUid)
+                    price = ApplyCharismaSellReward(userUid, price);
                 listingPrices[l.Id] = price;
+            }
             else
                 listingPrices[l.Id] = 0;
         }
@@ -139,12 +144,14 @@ public sealed partial class NcStoreLogicSystem
             }
         }
 
-var stackName = _compFactory.GetComponentName(typeof(StackComponent));
+        var stackName = _compFactory.GetComponentName(typeof(StackComponent));
 
         foreach (var listing in sellListings)
         {
             if (!TryPickCurrencyForSell(store, listing, out var currencyId, out var unitPrice))
                 continue;
+            if (user is { } userUid)
+                unitPrice = ApplyCharismaSellReward(userUid, unitPrice);
             if (unitPrice <= 0 || string.IsNullOrWhiteSpace(currencyId))
                 continue;
 

--- a/Content.Server/_NC/Trade/Store/Runtime/NcStoreLogicSystem.Core.cs
+++ b/Content.Server/_NC/Trade/Store/Runtime/NcStoreLogicSystem.Core.cs
@@ -1,5 +1,6 @@
 using Content.Server.Storage.Components;
 using Content.Server.Storage.EntitySystems;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Movement.Pulling.Components;
@@ -22,6 +23,7 @@ public sealed partial class NcStoreLogicSystem : EntitySystem
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] public readonly NcStoreInventorySystem _inventory = default!;
     [Dependency] public readonly IPrototypeManager _protos = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
     [Dependency] public readonly SharedStackSystem _stacks = default!;
 
     public override void Initialize()

--- a/Content.Server/_NC/Trade/Store/Runtime/Services/NcStoreLogicSystem.Services.cs
+++ b/Content.Server/_NC/Trade/Store/Runtime/Services/NcStoreLogicSystem.Services.cs
@@ -1,4 +1,6 @@
 using Content.Shared._NC.Trade;
+using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Stacks;
 using Robust.Shared.Prototypes;
@@ -35,6 +37,30 @@ public sealed partial class NcStoreLogicSystem
 
     public void GiveCurrency(EntityUid user, string stackType, int amount) =>
         _currency.GiveCurrency(user, stackType, amount);
+
+    public int ApplyCharismaBuyPrice(EntityUid user, int amount) =>
+        ApplyCharismaTradeValue(user, amount, buying: true);
+
+    public int ApplyCharismaSellReward(EntityUid user, int amount) =>
+        ApplyCharismaTradeValue(user, amount, buying: false);
+
+    private int ApplyCharismaTradeValue(EntityUid user, int amount, bool buying)
+    {
+        if (amount <= 0 || !TryComp<SpecialComponent>(user, out var special))
+            return amount;
+
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            user,
+            SpecialStat.Charisma,
+            buying ? tuning.CharismaTradePenaltyAtOne : -tuning.CharismaTradePenaltyAtOne,
+            buying ? -tuning.CharismaTradeBonusAtTen : tuning.CharismaTradeBonusAtTen,
+            special);
+        var multiplier = MathF.Max(0.05f, 1f + modifier);
+        var adjusted = (int) Math.Round(amount * multiplier, MidpointRounding.AwayFromZero);
+
+        return Math.Max(1, adjusted);
+    }
 
 
     private sealed class StoreSpawnService

--- a/Content.Server/_NC/Trade/Store/Runtime/Transactions/NcStoreLogicSystem.Transactions.cs
+++ b/Content.Server/_NC/Trade/Store/Runtime/Transactions/NcStoreLogicSystem.Transactions.cs
@@ -22,6 +22,8 @@ public sealed partial class NcStoreLogicSystem
         if (!TryPickCurrencyForBuy(store, listing, snap, out var currency, out var unitPrice, out var balance))
             return false;
 
+        unitPrice = ApplyCharismaBuyPrice(user, unitPrice);
+
         var unitsPerPurchase = Math.Max(1, listing.UnitsPerPurchase);
 
         var maxByRemainingPurchases = listing.RemainingCount >= 0 ? listing.RemainingCount : int.MaxValue;
@@ -101,7 +103,7 @@ public sealed partial class NcStoreLogicSystem
         if (store == null)
             return false;
         return TrySellScenario(listingId, store, user, container, count, out var sold) &&
-            LogSellFromContainer(sold, listingId, store, container);
+            LogSellFromContainer(sold, listingId, store, container, user);
     }
 
     private bool TrySellScenario(
@@ -122,6 +124,7 @@ public sealed partial class NcStoreLogicSystem
             return false;
         if (!TryPickCurrencyForSell(store, listing, out var currency, out var unitPrice) || unitPrice <= 0)
             return false;
+        unitPrice = ApplyCharismaSellReward(user, unitPrice);
 
         _inventory.InvalidateInventoryCache(root);
 
@@ -160,7 +163,7 @@ public sealed partial class NcStoreLogicSystem
         return true;
     }
 
-    private bool LogSellFromContainer(int sold, string listingId, NcStoreComponent store, EntityUid container)
+    private bool LogSellFromContainer(int sold, string listingId, NcStoreComponent store, EntityUid container, EntityUid user)
     {
         if (sold <= 0)
             return false;
@@ -170,6 +173,7 @@ public sealed partial class NcStoreLogicSystem
             return true;
         if (!TryPickCurrencyForSell(store, listing, out var currency, out var unitPrice) || unitPrice <= 0)
             return true;
+        unitPrice = ApplyCharismaSellReward(user, unitPrice);
         Sawmill.Info(
             $"TrySellFromContainer: OK {listing.ProductEntity} x{sold} for {unitPrice} {currency} each (container={ToPrettyString(container)})");
         return true;
@@ -200,6 +204,7 @@ public sealed partial class NcStoreLogicSystem
 
         if (!TryPickCurrencyForSell(store, listing, out var currencyId, out var rewardPerUnit) || rewardPerUnit <= 0)
             return false;
+        rewardPerUnit = ApplyCharismaSellReward(user, rewardPerUnit);
 
         if (!_inventory.TryTakeProductUnitsFromRootCached(
             user,

--- a/Content.Server/_NC/Trade/Store/UI/Structured/StoreStructuredSystem.Core.cs
+++ b/Content.Server/_NC/Trade/Store/UI/Structured/StoreStructuredSystem.Core.cs
@@ -493,36 +493,6 @@ public sealed partial class StoreStructuredSystem : EntitySystem
         if (!_ui.IsUiOpen(store, StoreUiKey.Key, user))
             return;
 
-        if (_catalogCache.TryGetValue(store, out var cached) && cached.Revision == comp.CatalogRevision)
-        {
-            var cachedList = cached.List;
-
-            var hasBuy = false;
-            var hasSell = false;
-
-            foreach (var l in cachedList)
-            {
-                if (l.Mode == StoreMode.Buy)
-                    hasBuy = true;
-                else if (l.Mode == StoreMode.Sell)
-                    hasSell = true;
-
-                if (hasBuy && hasSell)
-                    break;
-            }
-
-            var msg = new StoreCatalogMessage(
-                comp.CatalogRevision,
-                cachedList,
-                hasBuy,
-                hasSell,
-                comp.ContractPresets.Count > 0
-            );
-            _ui.ServerSendUiMessage((store, null), StoreUiKey.Key, msg, user);
-            return;
-        }
-
-
         var list = new List<StoreListingStaticData>(comp.Listings.Count);
 
         foreach (var l in comp.Listings)
@@ -532,7 +502,7 @@ public sealed partial class StoreStructuredSystem : EntitySystem
 
             var cat = l.Categories.Count > 0 ? l.Categories[0] : Loc.GetString("nc-store-category-fallback");
 
-            if (!TryPickUiCurrencyAndPrice(comp, l, out var cur, out var price))
+            if (!TryPickUiCurrencyAndPrice(comp, l, user, out var cur, out var price))
                 continue;
 
             list.Add(
@@ -546,8 +516,6 @@ public sealed partial class StoreStructuredSystem : EntitySystem
                     l.UnitsPerPurchase
                 ));
         }
-
-        _catalogCache[store] = (comp.CatalogRevision, list);
 
         {
             var hasBuy = false;
@@ -675,6 +643,7 @@ public sealed partial class StoreStructuredSystem : EntitySystem
     private bool TryPickUiCurrencyAndPrice(
         NcStoreComponent comp,
         NcStoreListingDef listing,
+        EntityUid user,
         out string currencyId,
         out int price
     )
@@ -690,7 +659,7 @@ public sealed partial class StoreStructuredSystem : EntitySystem
             if (listing.Cost.TryGetValue(cur, out var p) && p > 0)
             {
                 currencyId = cur;
-                price = p;
+                price = ApplyUiCharismaPrice(listing, user, p);
                 return true;
             }
         }
@@ -709,11 +678,21 @@ public sealed partial class StoreStructuredSystem : EntitySystem
             return false;
 
         currencyId = best.Value.Key;
-        price = best.Value.Value;
+        price = ApplyUiCharismaPrice(listing, user, best.Value.Value);
         return true;
     }
 
-    private ContractClientData MapContractToClient(ContractServerData c)
+    private int ApplyUiCharismaPrice(NcStoreListingDef listing, EntityUid user, int price)
+    {
+        return listing.Mode switch
+        {
+            StoreMode.Buy => _logic.ApplyCharismaBuyPrice(user, price),
+            StoreMode.Sell or StoreMode.Exchange => _logic.ApplyCharismaSellReward(user, price),
+            _ => price,
+        };
+    }
+
+    private ContractClientData MapContractToClient(ContractServerData c, EntityUid user)
     {
         var targets = new List<ContractTargetClientData>();
 
@@ -740,9 +719,17 @@ public sealed partial class StoreStructuredSystem : EntitySystem
                 });
         }
 
-        var rewards = c.Rewards is { Count: > 0, }
-            ? new(c.Rewards)
-            : new List<ContractRewardData>();
+        var rewards = new List<ContractRewardData>();
+        if (c.Rewards is { Count: > 0, })
+        {
+            foreach (var reward in c.Rewards)
+            {
+                var amount = reward.Type == StoreRewardType.Currency
+                    ? _logic.ApplyCharismaSellReward(user, reward.Amount)
+                    : reward.Amount;
+                rewards.Add(reward with { Amount = amount });
+            }
+        }
 
         return new(
             c.Id,

--- a/Content.Server/_NC/Trade/Store/UI/Structured/StoreStructuredSystem.DynamicState.cs
+++ b/Content.Server/_NC/Trade/Store/UI/Structured/StoreStructuredSystem.DynamicState.cs
@@ -106,7 +106,7 @@ public sealed partial class StoreStructuredSystem : EntitySystem
 
         if (hasSellTab && needCrateScan && crateUid is { } crate)
         {
-            var plan = _logic.ComputeMassSellPlanFromCachedItems(comp, crate, _deepCrateItemsScratch);
+            var plan = _logic.ComputeMassSellPlanFromCachedItems(comp, crate, _deepCrateItemsScratch, user);
             foreach (var kvp in plan.UnitsByListingId)
                 if (!string.IsNullOrWhiteSpace(kvp.Key) && kvp.Value > 0)
                     buf.CrateUnitsById[kvp.Key] = kvp.Value;
@@ -125,7 +125,7 @@ public sealed partial class StoreStructuredSystem : EntitySystem
         {
             foreach (var c in comp.Contracts.Values)
             {
-                var cd = MapContractToClient(c);
+                var cd = MapContractToClient(c, user);
                 // #Misfits Add — lock contract if this tier is not yet unlocked by the player
                 if (unlockedTiers != null && !unlockedTiers.Contains(c.Difficulty))
                     cd.Locked = true;

--- a/Content.Shared/Carrying/CarryingSlowdownSystem.cs
+++ b/Content.Shared/Carrying/CarryingSlowdownSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Misfits.SpecialStats;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.GameStates;
 
@@ -41,6 +42,13 @@ namespace Content.Shared.Carrying
         private void OnRefreshMoveSpeed(EntityUid uid, CarryingSlowdownComponent component, RefreshMovementSpeedModifiersEvent args)
         {
             args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+
+            if (component.WalkModifier >= 1f && component.SprintModifier >= 1f)
+                return;
+
+            var specialEv = new SpecialCarryPullSpeedModifierEvent(uid);
+            RaiseLocalEvent(uid, ref specialEv, true);
+            args.ModifySpeed(specialEv.Multiplier);
         }
     }
 }

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using Content.Shared._Misfits.SpecialStats;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
@@ -276,6 +277,13 @@ public sealed class PullingSystem : EntitySystem
     private void OnRefreshMovespeed(EntityUid uid, PullerComponent component, RefreshMovementSpeedModifiersEvent args)
     {
         args.ModifySpeed(component.WalkSpeedModifier, component.SprintSpeedModifier);
+
+        if (component.Pulling == null)
+            return;
+
+        var specialEv = new SpecialCarryPullSpeedModifierEvent(uid);
+        RaiseLocalEvent(uid, ref specialEv, true);
+        args.ModifySpeed(specialEv.Multiplier);
     }
 
     private void OnPullableMoveInput(EntityUid uid, PullableComponent component, ref MoveInputEvent args)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -112,6 +112,8 @@ public abstract partial class SharedGunSystem
 
     private void OnGunSelected(EntityUid uid, GunComponent component, HandSelectedEvent args)
     {
+        RefreshModifiers((uid, component));
+
         var fireDelay = 1f / component.FireRateModified;
         if (fireDelay.Equals(0f))
             return;

--- a/Content.Shared/_Misfits/Special/Components/SpecialComponent.cs
+++ b/Content.Shared/_Misfits/Special/Components/SpecialComponent.cs
@@ -56,4 +56,13 @@ public sealed partial class SpecialComponent : Component
 
     [DataField]
     public float AppliedHealthThresholdModifier;
+
+    [DataField]
+    public float AppliedHungerDecayMultiplier = 1f;
+
+    [DataField]
+    public float AppliedThirstDecayMultiplier = 1f;
+
+    [DataField]
+    public float AppliedStaminaRecoveryMultiplier = 1f;
 }

--- a/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
+++ b/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
@@ -14,7 +14,19 @@ public sealed partial class SpecialTuningPrototype : IPrototype
     public string ID { get; private set; } = default!;
 
     [DataField("strengthMeleeDamageMultiplierPerPoint")]
-    public float StrengthMeleeDamageMultiplierPerPoint = 0.015f;
+    public float StrengthMeleeDamageMultiplierPerPoint = 0.02f;
+
+    [DataField("strengthCarryPullSpeedPenaltyAtOne")]
+    public float StrengthCarryPullSpeedPenaltyAtOne = 0.08f;
+
+    [DataField("strengthCarryPullSpeedBonusAtTen")]
+    public float StrengthCarryPullSpeedBonusAtTen = 0.10f;
+
+    [DataField("strengthHeavyGunPenaltyAtOne")]
+    public float StrengthHeavyGunPenaltyAtOne = 0.18f;
+
+    [DataField("strengthHeavyGunReductionAtTen")]
+    public float StrengthHeavyGunReductionAtTen = 0.10f;
 
     [DataField("perceptionSpreadReductionPerPoint")]
     public float PerceptionSpreadReductionPerPoint = 0.004f;
@@ -25,33 +37,78 @@ public sealed partial class SpecialTuningPrototype : IPrototype
     [DataField("perceptionSpreadReductionAtTen")]
     public float PerceptionSpreadReductionAtTen = 0.25f;
 
+    [DataField("perceptionMineDelayPenaltyAtOne")]
+    public float PerceptionMineDelayPenaltyAtOne = 0.25f;
+
+    [DataField("perceptionMineDelayReductionAtTen")]
+    public float PerceptionMineDelayReductionAtTen = 0.25f;
+
+    [DataField("perceptionFireDelayPenaltyAtOne")]
+    public float PerceptionFireDelayPenaltyAtOne = 0.08f;
+
+    [DataField("perceptionFireDelayReductionAtTen")]
+    public float PerceptionFireDelayReductionAtTen = 0.10f;
+
     [DataField("enduranceStaminaCritThresholdPerPoint")]
     public float EnduranceStaminaCritThresholdPerPoint = 4f;
 
     [DataField("enduranceHealthPenaltyAtOne")]
-    public float EnduranceHealthPenaltyAtOne = 25f;
+    public float EnduranceHealthPenaltyAtOne = 20f;
 
     [DataField("enduranceHealthBonusAtTen")]
-    public float EnduranceHealthBonusAtTen = 25f;
+    public float EnduranceHealthBonusAtTen = 20f;
+
+    [DataField("enduranceNeedDecayPenaltyAtOne")]
+    public float EnduranceNeedDecayPenaltyAtOne = 0.15f;
+
+    [DataField("enduranceNeedDecayReductionAtTen")]
+    public float EnduranceNeedDecayReductionAtTen = 0.12f;
+
+    [DataField("enduranceStaminaRecoveryPenaltyAtOne")]
+    public float EnduranceStaminaRecoveryPenaltyAtOne = 0.15f;
+
+    [DataField("enduranceStaminaRecoveryBonusAtTen")]
+    public float EnduranceStaminaRecoveryBonusAtTen = 0.20f;
+
+    [DataField("enduranceToxinDamagePenaltyAtOne")]
+    public float EnduranceToxinDamagePenaltyAtOne = 0.12f;
+
+    [DataField("enduranceToxinDamageReductionAtTen")]
+    public float EnduranceToxinDamageReductionAtTen = 0.15f;
+
+    [DataField("charismaTradePenaltyAtOne")]
+    public float CharismaTradePenaltyAtOne = 0.10f;
+
+    [DataField("charismaTradeBonusAtTen")]
+    public float CharismaTradeBonusAtTen = 0.10f;
+
+    [DataField("intelligenceLatheMinimumTimeMultiplierAtTen")]
+    public float IntelligenceLatheMinimumTimeMultiplierAtTen = 0.50f;
 
     [DataField("agilityMovementSpeedMultiplierPerPoint")]
     public float AgilityMovementSpeedMultiplierPerPoint = 0.004f;
 
     [DataField("agilityMovementSpeedPenaltyAtOne")]
-    public float AgilityMovementSpeedPenaltyAtOne = 0.10f;
+    public float AgilityMovementSpeedPenaltyAtOne = 0.075f;
 
     [DataField("agilityMovementSpeedBonusAtTen")]
-    public float AgilityMovementSpeedBonusAtTen = 0.10f;
+    public float AgilityMovementSpeedBonusAtTen = 0.075f;
+
+    [DataField("agilityActionDelayPenaltyAtOne")]
+    public float AgilityActionDelayPenaltyAtOne = 0.08f;
+
+    [DataField("agilityActionDelayReductionAtTen")]
+    public float AgilityActionDelayReductionAtTen = 0.10f;
 
     [DataField("luckCriticalChancePerPoint")]
     public float LuckCriticalChancePerPoint = 0.005f;
 
     [DataField("luckSingleShotCriticalChanceAtTen")]
-    public float LuckSingleShotCriticalChanceAtTen = 0.3f;
+    public float LuckSingleShotCriticalChanceAtTen = 0.25f;
 
     [DataField("luckCriticalDamageMultiplier")]
     public float LuckCriticalDamageMultiplier = 1.5f;
 
     [DataField("luckLootChancePerPoint")]
-    public float LuckLootChancePerPoint = 0.03f;
+    public float LuckLootChancePerPoint = 0.025f;
 }

--- a/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
+++ b/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
@@ -164,6 +164,13 @@ public sealed class SharedSpecialSystem : EntitySystem
         return (int) Math.Round(GetCurvedEffectDelta(charisma) * 2f, MidpointRounding.AwayFromZero);
     }
 
+    public int GetCharismaChatFontSize(EntityUid uid, int baseFontSize, SpecialComponent? component = null)
+    {
+        return GetEffective(uid, SpecialStat.Charisma, component) >= 7
+            ? baseFontSize + 2
+            : baseFontSize;
+    }
+
     public bool HasRequirement(EntityUid uid, SpecialStat stat, int minimum, SpecialComponent? component = null)
     {
         return GetEffective(uid, stat, component) >= minimum;

--- a/Content.Shared/_Misfits/SpecialStats/SpecialAgilitySystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialAgilitySystem.cs
@@ -1,0 +1,41 @@
+using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Components;
+using Content.Shared.Weapons.Melee.Events;
+
+namespace Content.Shared._Misfits.SpecialStats;
+
+/// <summary>
+/// Applies Agility to close-quarters action cadence.
+/// </summary>
+public sealed class SpecialAgilitySystem : EntitySystem
+{
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GetMeleeAttackRateEvent>(OnMeleeAttackRate);
+    }
+
+    private void OnMeleeAttackRate(ref GetMeleeAttackRateEvent args)
+    {
+        if (!TryComp<SpecialComponent>(args.User, out var special))
+            return;
+
+        args.Multipliers *= GetActionDelayMultiplier(args.User, special);
+    }
+
+    private float GetActionDelayMultiplier(EntityUid uid, SpecialComponent special)
+    {
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            uid,
+            SpecialStat.Agility,
+            tuning.AgilityActionDelayPenaltyAtOne,
+            -tuning.AgilityActionDelayReductionAtTen,
+            special);
+
+        return MathF.Max(0.1f, 1f + modifier);
+    }
+}

--- a/Content.Shared/_Misfits/SpecialStats/SpecialCarryPullSpeedModifierEvent.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialCarryPullSpeedModifierEvent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared._Misfits.SpecialStats;
+
+[ByRefEvent]
+public record struct SpecialCarryPullSpeedModifierEvent(EntityUid User, float Multiplier = 1f)
+{
+    public void ModifySpeed(float multiplier)
+    {
+        Multiplier *= multiplier;
+    }
+}

--- a/Content.Shared/_Misfits/SpecialStats/SpecialEnduranceSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialEnduranceSystem.cs
@@ -1,10 +1,13 @@
 using Content.Shared._Misfits.Special;
 using Content.Shared._Misfits.Special.Components;
+using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Nutrition.Components;
+using Robust.Shared.Maths;
 
 namespace Content.Shared._Misfits.SpecialStats;
 
@@ -23,12 +26,22 @@ public sealed class SpecialEnduranceSystem : EntitySystem
         MobState.Dead,
     ];
 
+    private static readonly string[] EnduranceResistedDamageTypes =
+    [
+        "Poison",
+        "Radiation",
+        "Caustic",
+        "Cellular",
+    ];
+
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<SpecialComponent, SpecialChangedEvent>(OnSpecialChanged);
         SubscribeLocalEvent<SpecialComponent, SpecialStatsReadyEvent>(OnStatsReady);
+        SubscribeLocalEvent<SpecialComponent, SpecialShutdownEvent>(OnSpecialShutdown);
+        SubscribeLocalEvent<SpecialComponent, DamageModifyEvent>(OnDamageModify);
     }
 
     private void OnSpecialChanged(Entity<SpecialComponent> ent, ref SpecialChangedEvent args)
@@ -41,10 +54,56 @@ public sealed class SpecialEnduranceSystem : EntitySystem
         ApplyEndurance(ent, false);
     }
 
+    private void OnSpecialShutdown(Entity<SpecialComponent> ent, ref SpecialShutdownEvent args)
+    {
+        ApplyEndurance(ent, true);
+    }
+
+    private void OnDamageModify(Entity<SpecialComponent> ent, ref DamageModifyEvent args)
+    {
+        if (!args.Damage.AnyPositive())
+            return;
+
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            ent.Owner,
+            SpecialStat.Endurance,
+            tuning.EnduranceToxinDamagePenaltyAtOne,
+            -tuning.EnduranceToxinDamageReductionAtTen,
+            ent.Comp);
+        var multiplier = MathF.Max(0.1f, 1f + modifier);
+
+        if (MathHelper.CloseTo(multiplier, 1f))
+            return;
+
+        var damage = new DamageSpecifier(args.Damage);
+        var modified = false;
+
+        foreach (var type in EnduranceResistedDamageTypes)
+        {
+            if (!damage.DamageDict.TryGetValue(type, out var value) || value <= FixedPoint2.Zero)
+                continue;
+
+            damage.DamageDict[type] = value * multiplier;
+            modified = true;
+        }
+
+        if (modified)
+            args.Damage = damage;
+    }
+
     private void ApplyEndurance(Entity<SpecialComponent> ent, bool reset)
     {
         ClearLegacyStaminaModifier(ent);
 
+        ApplyHealthThresholds(ent, reset);
+        ApplyHungerDecay(ent, reset);
+        ApplyThirstDecay(ent, reset);
+        ApplyStaminaRecovery(ent, reset);
+    }
+
+    private void ApplyHealthThresholds(Entity<SpecialComponent> ent, bool reset)
+    {
         if (!TryComp<MobThresholdsComponent>(ent.Owner, out var thresholds))
             return;
 
@@ -74,6 +133,96 @@ public sealed class SpecialEnduranceSystem : EntitySystem
         ent.Comp.AppliedHealthThresholdModifier = desired;
 
         Dirty(ent.Owner, ent.Comp);
+    }
+
+    private void ApplyHungerDecay(Entity<SpecialComponent> ent, bool reset)
+    {
+        if (!TryComp<HungerComponent>(ent.Owner, out var hunger))
+            return;
+
+        var desired = reset ? 1f : GetNeedDecayMultiplier(ent);
+        var previous = ent.Comp.AppliedHungerDecayMultiplier <= 0f
+            ? 1f
+            : ent.Comp.AppliedHungerDecayMultiplier;
+
+        if (MathHelper.CloseTo(desired, previous))
+            return;
+
+        var ratio = desired / previous;
+        hunger.BaseDecayRate *= ratio;
+        hunger.ActualDecayRate *= ratio;
+        ent.Comp.AppliedHungerDecayMultiplier = desired;
+
+        Dirty(ent.Owner, hunger);
+        Dirty(ent.Owner, ent.Comp);
+    }
+
+    private void ApplyThirstDecay(Entity<SpecialComponent> ent, bool reset)
+    {
+        if (!TryComp<ThirstComponent>(ent.Owner, out var thirst))
+            return;
+
+        var desired = reset ? 1f : GetNeedDecayMultiplier(ent);
+        var previous = ent.Comp.AppliedThirstDecayMultiplier <= 0f
+            ? 1f
+            : ent.Comp.AppliedThirstDecayMultiplier;
+
+        if (MathHelper.CloseTo(desired, previous))
+            return;
+
+        var ratio = desired / previous;
+        thirst.BaseDecayRate *= ratio;
+        thirst.ActualDecayRate *= ratio;
+        ent.Comp.AppliedThirstDecayMultiplier = desired;
+
+        Dirty(ent.Owner, thirst);
+        Dirty(ent.Owner, ent.Comp);
+    }
+
+    private void ApplyStaminaRecovery(Entity<SpecialComponent> ent, bool reset)
+    {
+        if (!TryComp<StaminaComponent>(ent.Owner, out var stamina))
+            return;
+
+        var desired = reset ? 1f : GetStaminaRecoveryMultiplier(ent);
+        var previous = ent.Comp.AppliedStaminaRecoveryMultiplier <= 0f
+            ? 1f
+            : ent.Comp.AppliedStaminaRecoveryMultiplier;
+
+        if (MathHelper.CloseTo(desired, previous))
+            return;
+
+        stamina.Decay *= desired / previous;
+        ent.Comp.AppliedStaminaRecoveryMultiplier = desired;
+
+        Dirty(ent.Owner, stamina);
+        Dirty(ent.Owner, ent.Comp);
+    }
+
+    private float GetNeedDecayMultiplier(Entity<SpecialComponent> ent)
+    {
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            ent.Owner,
+            SpecialStat.Endurance,
+            tuning.EnduranceNeedDecayPenaltyAtOne,
+            -tuning.EnduranceNeedDecayReductionAtTen,
+            ent.Comp);
+
+        return MathF.Max(0.1f, 1f + modifier);
+    }
+
+    private float GetStaminaRecoveryMultiplier(Entity<SpecialComponent> ent)
+    {
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            ent.Owner,
+            SpecialStat.Endurance,
+            -tuning.EnduranceStaminaRecoveryPenaltyAtOne,
+            tuning.EnduranceStaminaRecoveryBonusAtTen,
+            ent.Comp);
+
+        return MathF.Max(0.1f, 1f + modifier);
     }
 
     private void ClearLegacyStaminaModifier(Entity<SpecialComponent> ent)

--- a/Content.Shared/_Misfits/SpecialStats/SpecialGunRefreshSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialGunRefreshSystem.cs
@@ -1,0 +1,51 @@
+using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Components;
+using Content.Shared.Hands;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+
+namespace Content.Shared._Misfits.SpecialStats;
+
+/// <summary>
+/// Refreshes held gun modifiers when holder-based SPECIAL effects can change.
+/// </summary>
+public sealed class SpecialGunRefreshSystem : EntitySystem
+{
+    [Dependency] private readonly SharedGunSystem _gun = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SpecialChangedEvent>(OnSpecialChanged);
+        SubscribeLocalEvent<SpecialStatsReadyEvent>(OnStatsReady);
+        SubscribeLocalEvent<GunComponent, GotEquippedHandEvent>(OnGunEquipped);
+        SubscribeLocalEvent<GunComponent, GotUnequippedHandEvent>(OnGunUnequipped);
+    }
+
+    private void OnSpecialChanged(ref SpecialChangedEvent args)
+    {
+        RefreshActiveGun(args.ChangedEntity);
+    }
+
+    private void OnStatsReady(ref SpecialStatsReadyEvent args)
+    {
+        RefreshActiveGun(args.Entity);
+    }
+
+    private void OnGunEquipped(Entity<GunComponent> ent, ref GotEquippedHandEvent args)
+    {
+        _gun.RefreshModifiers((ent.Owner, ent.Comp));
+    }
+
+    private void OnGunUnequipped(Entity<GunComponent> ent, ref GotUnequippedHandEvent args)
+    {
+        _gun.RefreshModifiers((ent.Owner, ent.Comp));
+    }
+
+    private void RefreshActiveGun(EntityUid user)
+    {
+        if (_gun.TryGetGun(user, out var gunUid, out var gun))
+            _gun.RefreshModifiers((gunUid, gun));
+    }
+}

--- a/Content.Shared/_Misfits/SpecialStats/SpecialPerceptionSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialPerceptionSystem.cs
@@ -5,7 +5,7 @@ using Content.Shared.Weapons.Ranged.Events;
 namespace Content.Shared._Misfits.SpecialStats;
 
 /// <summary>
-/// Reduces gun spread and camera recoil proportionally based on the holder's Perception.
+/// Applies Perception to gun precision and firing cadence.
 /// </summary>
 public sealed class SpecialPerceptionSystem : EntitySystem
 {
@@ -38,5 +38,23 @@ public sealed class SpecialPerceptionSystem : EntitySystem
         args.MaxAngle = new Angle((double) args.MaxAngle * keepFraction);
         args.AngleIncrease = new Angle((double) args.AngleIncrease * keepFraction);
         args.CameraRecoilScalar *= (float) keepFraction;
+
+        if (args.FireRate <= 0f)
+            return;
+
+        args.FireRate *= 1f / GetFireDelayMultiplier(holder, special);
+    }
+
+    private float GetFireDelayMultiplier(EntityUid uid, SpecialComponent special)
+    {
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            uid,
+            SpecialStat.Perception,
+            tuning.PerceptionFireDelayPenaltyAtOne,
+            -tuning.PerceptionFireDelayReductionAtTen,
+            special);
+
+        return MathF.Max(0.1f, 1f + modifier);
     }
 }

--- a/Content.Shared/_Misfits/SpecialStats/SpecialStrengthSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialStrengthSystem.cs
@@ -1,0 +1,66 @@
+using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Components;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Wieldable.Components;
+using Robust.Shared.Maths;
+
+namespace Content.Shared._Misfits.SpecialStats;
+
+/// <summary>
+/// Applies Strength to heavy handling outside of direct melee damage.
+/// </summary>
+public sealed class SpecialStrengthSystem : EntitySystem
+{
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SpecialCarryPullSpeedModifierEvent>(OnCarryPullSpeedModifier);
+        SubscribeLocalEvent<GunRefreshModifiersEvent>(OnGunRefreshModifiers);
+    }
+
+    private void OnCarryPullSpeedModifier(ref SpecialCarryPullSpeedModifierEvent args)
+    {
+        if (!TryComp<SpecialComponent>(args.User, out var special))
+            return;
+
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            args.User,
+            SpecialStat.Strength,
+            -tuning.StrengthCarryPullSpeedPenaltyAtOne,
+            tuning.StrengthCarryPullSpeedBonusAtTen,
+            special);
+        var multiplier = MathF.Max(0.1f, 1f + modifier);
+
+        args.ModifySpeed(multiplier);
+    }
+
+    private void OnGunRefreshModifiers(ref GunRefreshModifiersEvent args)
+    {
+        if (!HasComp<GunRequiresWieldComponent>(args.Gun.Owner) &&
+            !HasComp<WieldableComponent>(args.Gun.Owner))
+            return;
+
+        var holder = Transform(args.Gun.Owner).ParentUid;
+        if (!TryComp<SpecialComponent>(holder, out var special))
+            return;
+
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            holder,
+            SpecialStat.Strength,
+            tuning.StrengthHeavyGunPenaltyAtOne,
+            -tuning.StrengthHeavyGunReductionAtTen,
+            special);
+        var keepFraction = Math.Clamp(1.0 + modifier, 0.70, 1.40);
+
+        args.MinAngle = new Angle((double) args.MinAngle * keepFraction);
+        args.MaxAngle = new Angle((double) args.MaxAngle * keepFraction);
+        args.AngleIncrease = new Angle((double) args.AngleIncrease * keepFraction);
+        args.CameraRecoilScalar *= (float) keepFraction;
+    }
+}

--- a/Resources/Prototypes/_Misfits/Special/special_tuning.yml
+++ b/Resources/Prototypes/_Misfits/Special/special_tuning.yml
@@ -1,13 +1,32 @@
 - type: specialTuning
   id: MisfitsSpecialTuning
-  strengthMeleeDamageMultiplierPerPoint: 0.015
+  strengthMeleeDamageMultiplierPerPoint: 0.02
+  strengthCarryPullSpeedPenaltyAtOne: 0.08
+  strengthCarryPullSpeedBonusAtTen: 0.10
+  strengthHeavyGunPenaltyAtOne: 0.18
+  strengthHeavyGunReductionAtTen: 0.10
   perceptionSpreadPenaltyAtOne: 0.15
   perceptionSpreadReductionAtTen: 0.25
-  enduranceHealthPenaltyAtOne: 25
-  enduranceHealthBonusAtTen: 25
-  agilityMovementSpeedPenaltyAtOne: 0.10
-  agilityMovementSpeedBonusAtTen: 0.10
+  perceptionMineDelayPenaltyAtOne: 0.25
+  perceptionMineDelayReductionAtTen: 0.25
+  perceptionFireDelayPenaltyAtOne: 0.08
+  perceptionFireDelayReductionAtTen: 0.10
+  enduranceHealthPenaltyAtOne: 20
+  enduranceHealthBonusAtTen: 20
+  enduranceNeedDecayPenaltyAtOne: 0.15
+  enduranceNeedDecayReductionAtTen: 0.12
+  enduranceStaminaRecoveryPenaltyAtOne: 0.15
+  enduranceStaminaRecoveryBonusAtTen: 0.20
+  enduranceToxinDamagePenaltyAtOne: 0.12
+  enduranceToxinDamageReductionAtTen: 0.15
+  charismaTradePenaltyAtOne: 0.10
+  charismaTradeBonusAtTen: 0.10
+  intelligenceLatheMinimumTimeMultiplierAtTen: 0.50
+  agilityMovementSpeedPenaltyAtOne: 0.075
+  agilityMovementSpeedBonusAtTen: 0.075
+  agilityActionDelayPenaltyAtOne: 0.08
+  agilityActionDelayReductionAtTen: 0.10
   luckCriticalChancePerPoint: 0.005
-  luckSingleShotCriticalChanceAtTen: 0.3
+  luckSingleShotCriticalChanceAtTen: 0.25
   luckCriticalDamageMultiplier: 1.5
-  luckLootChancePerPoint: 0.03
+  luckLootChancePerPoint: 0.025


### PR DESCRIPTION
## Why / Balance
Balancing changes + additions.

### Changes:
## Strength

Strength now affects carrying, pulling, and heavy gun handling.

- Strength offsets carrying and pulling slowdowns.
- Strength affects wieldable/heavy gun spread and recoil.

### Updated melee damage scaling

- 1 STR: 90%
- 2 STR: 93%
- 3 STR: 95.5%
- 4 STR: 98%
- 5 STR: 100%
- 6 STR: 102%
- 7 STR: 104.5%
- 8 STR: 107.5%
- 9 STR: 111%
- 10 STR: 115%

---

## Perception

Perception now affects mine handling.

- Higher Perception arms and disarms landmines faster.
- Lower Perception makes landmine handling slower.

### Updated spread/recoil scaling

- 1 PER: 115%
- 2 PER: 110.5%
- 3 PER: 106.75%
- 4 PER: 103%
- 5 PER: 100%
- 6 PER: 96.67%
- 7 PER: 92.5%
- 8 PER: 87.5%
- 9 PER: 81.67%
- 10 PER: 75%

---

## Endurance

Endurance now affects hunger, thirst, stamina recovery, and toxin-style damage taken.

- Higher Endurance reduces hunger and thirst decay.
- Higher Endurance improves stamina recovery.
- Higher Endurance reduces Poison, Radiation, Caustic, and Cellular damage.
- Lower Endurance increases Poison, Radiation, Caustic, and Cellular damage.

### Updated health threshold modifier

- 1 END: -20 HP
- 2 END: -14 HP
- 3 END: -9 HP
- 4 END: -4 HP
- 5 END: normal
- 6 END: +2.67 HP
- 7 END: +6 HP
- 8 END: +10 HP
- 9 END: +14.67 HP
- 10 END: +20 HP

---

## Charisma

Charisma now affects trade, reward payouts, and text size.

- Charisma affects vendor prices.
- Charisma affects sell payouts.
- Charisma affects exchange rewards.
- Charisma affects mass-sell crate totals.
- Charisma affects contract currency rewards.
- Higher Charisma improves trade value.
- Lower Charisma worsens trade value.
- Higher Charisma makes your text appear larger.

### New trade scaling

- 1 CHA: 110% buy price, 90% sell/reward payout
- 5 CHA: normal
- 10 CHA: 90% buy price, 110% sell/reward payout

---

## Intelligence

Intelligence now has updated lathe crafting scaling.

### Updated lathe crafting

- 1–3 INT: cannot open/use lathes
- 4 INT: 115% crafting time
- 5 INT: 100% crafting time
- 6 INT: 90% crafting time
- 7 INT: 80% crafting time
- 8 INT: 70% crafting time
- 9 INT: 60% crafting time
- 10 INT: 50% crafting time

---

## Agility

Agility now affects combat action delay.

- Higher Agility reduces melee attack delay.
- Higher Agility reduces gun fire delay.
- Lower Agility increases combat action delay.

### Updated movement speed modifier

- 1 AGI: 92.5%
- 2 AGI: 94.75%
- 3 AGI: 96.6%
- 4 AGI: 98.5%
- 5 AGI: 100%
- 6 AGI: 101%
- 7 AGI: 102.25%
- 8 AGI: 103.75%
- 9 AGI: 105.5%
- 10 AGI: 107.5%

### New combat action delay

- 1 AGI: 108% delay
- 5 AGI: normal
- 10 AGI: 90% delay

---

## Luck

Luck has updated critical hit, lucky loot, and Clumsy scaling.

- Critical hit chance has been reduced from the previous curve.
- Lucky junk loot chance has been reduced from the previous curve.
- The Clumsy threshold is now below 3 LCK.

### Updated melee and single-shot weapon crit chance

- 6 LCK: 3.33%
- 7 LCK: 7.5%
- 8 LCK: 12.5%
- 9 LCK: 18.33%
- 10 LCK: 25%

### Updated Clumsy

- Below 3 LCK, characters gain the Clumsy trait.
- Clumsy can cause affected interactions to fail, including:
  - Hyposprays
  - Defibrillators
  - Some guns
  - Climbing/table interactions

### Updated lucky loot chance

- 6 LCK: 2.5%
- 7 LCK: 5.63%
- 8 LCK: 9.38%
- 9 LCK: 13.75%
- 10 LCK: 18.75%

# Changelog

:cl:
- tweak: Fixes numbers + adds interesting mechanics.
