### PR TITLE
Extra Guitars to Loadout 

### DIFF
--- a/Resources/Locale/en-US/_Misfits/loadout-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/loadout-names.ftl
@@ -237,6 +237,9 @@ loadout-name-N14InstrumentFlute = flute
 loadout-name-N14InstrumentClarinet = clarinet
 loadout-name-N14InstrumentTrumpet = trumpet
 loadout-name-N14InstrumentTrombone = trombone
+loadout-name-N14InstrumentElectricGuitar = electric guitar
+loadout-name-N14InstrumentBassGuitar = bass guitar
+loadout-name-N14InstrumentRockGuitar = rock guitar
 
 # Cosmetic loadouts (Misfits Add - drip expansion)
 loadout-name-MisfitsLoadoutNeckDesertScarf = desert scarf

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Tools/instruments.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Tools/instruments.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: TrumpetInstrument 
+  parent: TrumpetInstrument
   id: N14InstrumentTrumpet
   name: trumpet
   description: A jazzy and versatile instrument.
@@ -14,8 +14,8 @@
     price: 15
 
 - type: entity
-  parent: TromboneInstrument 
-  id: N14InstrumentTrombone 
+  parent: TromboneInstrument
+  id: N14InstrumentTrombone
   name: trombone
   description: A brass instrument with an adjustable slide, has some weight to it.
   components:
@@ -29,7 +29,7 @@
     price: 15
 
 - type: entity
-  parent: BanjoInstrument 
+  parent: BanjoInstrument
   id: N14InstrumentBanjo
   name: banjo
   description: An old rustic country instrument.
@@ -44,7 +44,7 @@
     price: 15
 
 - type: entity
-  parent: ViolinInstrument 
+  parent: ViolinInstrument
   id: N14InstrumentViolin
   name: violin
   description: Played in first chairs and lawn chairs.
@@ -59,7 +59,7 @@
     price: 15
 
 - type: entity
-  parent: AcousticGuitarInstrument 
+  parent: AcousticGuitarInstrument
   id: N14InstrumentGuitar
   name: acoustic guitar
   description: Play it again... My Johnny...
@@ -79,7 +79,7 @@
     price: 15
 
 - type: entity
-  parent: SaxophoneInstrument 
+  parent: SaxophoneInstrument
   id: N14InstrumentSaxaphone
   name: saxophone
   description: Takes more than a few bombs to kill jazz.
@@ -94,7 +94,7 @@
     price: 15
 
 - type: entity
-  parent: HarmonicaInstrument 
+  parent: HarmonicaInstrument
   id: N14InstrumentHarmonica
   name: harmonica
   description: "A nifty pocket-sized instrument, for lettin' your soul sing on the trails..."
@@ -109,7 +109,7 @@
     price: 15
 
 - type: entity
-  parent: ClarinetInstrument 
+  parent: ClarinetInstrument
   id: N14InstrumentClarinet
   name: clarinet
   description: A refined reed instrument.
@@ -126,7 +126,7 @@
     price: 15
 
 - type: entity
-  parent: FluteInstrument 
+  parent: FluteInstrument
   id: N14InstrumentFlute
   name: flute
   description: An elegant woodwind instrument.
@@ -143,7 +143,7 @@
     price: 15
 
 - type: entity
-  parent: PanFluteInstrument 
+  parent: PanFluteInstrument
   id: N14InstrumentPanflute
   name: pan flute
   description: A tribal instrument of ancient design, constructed from reeds.
@@ -156,5 +156,68 @@
   - type: Item
     size: Small
     sprite: Objects/Fun/Instruments/panflute.rsi
+  - type: StaticPrice # Forge-Add
+    price: 15
+
+- type: entity
+  parent: ElectricGuitarInstrument
+  id: N14InstrumentElectricGuitar
+  name: electric guitar
+  description: Now this makes you feel like a rock star!
+  components:
+  - type: Instrument
+    program: 27
+  - type: Sprite
+    sprite: Objects/Fun/Instruments/eguitar.rsi
+    state: icon
+  - type: Item
+    size: Normal
+    sprite: Objects/Fun/Instruments/eguitar.rsi
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - back
+    sprite: Objects/Fun/Instruments/eguitar.rsi
+  - type: StaticPrice # Forge-Add
+    price: 15
+
+- type: entity
+  parent: BassGuitarInstrument
+  id: N14InstrumentBassGuitar
+  name: bass guitar
+  description: You feel really cool holding this. Shame you're the only one that thinks that.
+  components:
+  - type: Instrument
+    program: 33
+  - type: Sprite
+    sprite: Objects/Fun/Instruments/bassguitar.rsi
+    state: icon
+  - type: Item
+    size: Normal
+    sprite: Objects/Fun/Instruments/bassguitar.rsi
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - back
+    sprite: Objects/Fun/Instruments/bassguitar.rsi
+  - type: StaticPrice # Forge-Add
+    price: 15
+
+- type: entity
+  parent: RockGuitarInstrument
+  id: N14InstrumentRockGuitar
+  name: rock guitar
+  description: What an axe!
+  components:
+  - type: Instrument
+    program: 29
+  - type: Item
+    size: Normal
+    sprite: Objects/Fun/Instruments/rockguitar.rsi
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - back
+    sprite: Objects/Fun/Instruments/rockguitar.rsi
   - type: StaticPrice # Forge-Add
     price: 15

--- a/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
@@ -227,6 +227,30 @@
   items:
     - N14FoodPorkBeans
 
+- type: loadout
+  id: N14InstrumentElectricGuitar
+  category: Items
+  cost: 2
+  items:
+    - N14InstrumentElectricGuitar
+
+- type: loadout
+  id: N14InstrumentBassGuitar
+  category: Items
+  cost: 2
+  items:
+    - N14InstrumentBassGuitar
+
+- type: loadout
+  id: N14InstrumentRockGuitar
+  category: Items
+  cost: 2
+  items:
+    - N14InstrumentRockGuitar
+
+
+
+
 # Misc
 # Misfits Change: Removed bottlecap (N14CurrencyCap100) loadout entry — caps are no longer granted to players at round start via loadouts.
 #- type: loadout


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
I added the rest of the guitars from base vanilla ss14 to loadouts

## Media
<img width="722" height="565" alt="image" src="https://github.com/user-attachments/assets/31e38e91-d443-476b-a815-5317f79b38af" />



# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Oli
- add: Guitars to loadout
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
