### PR TITLE
Even More Special Updates

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -21,6 +21,7 @@ using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Prototypes;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Content.Shared.StatusIcon;
@@ -54,6 +55,7 @@ namespace Content.Client.Lobby.UI
     public sealed partial class HumanoidProfileEditor : BoxContainer
     {
         private const string LockedSpecies = "SuperMutant";
+        private const string SpecialTuningPrototypeId = "MisfitsSpecialTuning";
 
         private readonly IConfigurationManager _cfgManager;
         private readonly IEntityManager _entManager;
@@ -2450,15 +2452,242 @@ namespace Content.Client.Lobby.UI
             topRow.AddChild(plusButton);
 
             root.AddChild(topRow);
-            root.AddChild(new Label
+            var description = new Label
             {
                 Text = Loc.GetString(GetSpecialDescriptionLoc(stat)),
                 Modulate = Color.FromHex("#AAAAAA"),
                 HorizontalExpand = true,
-            });
+            };
+
+            var currentEffect = new RichTextLabel
+            {
+                HorizontalExpand = true,
+                Modulate = Color.FromHex("#D6D6D6"),
+            };
+            currentEffect.SetMessage($"Current: {GetSpecialEffectDetails(stat, value)}");
+
+            var changePreview = new RichTextLabel
+            {
+                HorizontalExpand = true,
+            };
+            changePreview.SetMarkup(GetSpecialChangePreview(stat, value));
+
+            root.AddChild(description);
+            root.AddChild(currentEffect);
+            root.AddChild(changePreview);
 
             panel.AddChild(root);
             return panel;
+        }
+
+        private string GetSpecialChangePreview(SpecialStat stat, int value)
+        {
+            var lower = value > SpecialProfile.Minimum
+                ? $"Lower to {value - 1}: {GetSpecialEffectDetails(stat, value - 1)}"
+                : "Lower: already at minimum";
+
+            var raise = value < SpecialProfile.Maximum
+                ? $"Raise to {value + 1}: {GetSpecialEffectDetails(stat, value + 1)}"
+                : "Raise: already at maximum";
+
+            return $"[color=#E05A5A]{FormattedMessage.EscapeText(lower)}[/color]\n" +
+                   $"[color=#5A9EE0]{FormattedMessage.EscapeText(raise)}[/color]";
+        }
+
+        private string GetSpecialEffectDetails(SpecialStat stat, int value)
+        {
+            var tuning = GetSpecialTuning();
+
+            return stat switch
+            {
+                SpecialStat.Strength => GetStrengthEffectDetails(value, tuning),
+                SpecialStat.Perception => GetPerceptionEffectDetails(value, tuning),
+                SpecialStat.Endurance => GetEnduranceEffectDetails(value, tuning),
+                SpecialStat.Charisma => GetCharismaEffectDetails(value),
+                SpecialStat.Intelligence => GetIntelligenceEffectDetails(value, tuning),
+                SpecialStat.Agility => GetAgilityEffectDetails(value, tuning),
+                SpecialStat.Luck => GetLuckEffectDetails(value, tuning),
+                _ => "Neutral baseline.",
+            };
+        }
+
+        private SpecialTuningPrototype GetSpecialTuning()
+        {
+            return _prototypeManager.TryIndex<SpecialTuningPrototype>(SpecialTuningPrototypeId, out var tuning)
+                ? tuning
+                : SpecialTuningPrototype.Fallback;
+        }
+
+        private static string GetStrengthEffectDetails(int value, SpecialTuningPrototype tuning)
+        {
+            var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
+            var melee = delta * tuning.StrengthMeleeDamageMultiplierPerPoint;
+            var carry = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                -tuning.StrengthCarryPullSpeedPenaltyAtOne,
+                tuning.StrengthCarryPullSpeedBonusAtTen);
+            var heavyGun = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                tuning.StrengthHeavyGunPenaltyAtOne,
+                -tuning.StrengthHeavyGunReductionAtTen);
+
+            return $"melee damage {FormatSignedPercent(melee)}, carry/pull speed {FormatSignedPercent(carry)}, heavy gun spread/recoil {FormatSignedPercent(heavyGun)}.";
+        }
+
+        private static string GetPerceptionEffectDetails(int value, SpecialTuningPrototype tuning)
+        {
+            var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
+            var spread = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                tuning.PerceptionSpreadPenaltyAtOne,
+                -tuning.PerceptionSpreadReductionAtTen);
+            var fireDelay = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                tuning.PerceptionFireDelayPenaltyAtOne,
+                -tuning.PerceptionFireDelayReductionAtTen);
+
+            return $"gun spread/recoil {FormatSignedPercent(spread)}, gun fire delay {FormatSignedPercent(fireDelay)}.";
+        }
+
+        private static string GetEnduranceEffectDetails(int value, SpecialTuningPrototype tuning)
+        {
+            var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
+            var health = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                -tuning.EnduranceHealthPenaltyAtOne,
+                tuning.EnduranceHealthBonusAtTen);
+            var needs = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                tuning.EnduranceNeedDecayPenaltyAtOne,
+                -tuning.EnduranceNeedDecayReductionAtTen);
+            var stamina = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                -tuning.EnduranceStaminaRecoveryPenaltyAtOne,
+                tuning.EnduranceStaminaRecoveryBonusAtTen);
+            var toxin = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                tuning.EnduranceToxinDamagePenaltyAtOne,
+                -tuning.EnduranceToxinDamageReductionAtTen);
+
+            return $"health thresholds {FormatSignedNumber(health)}, hunger/thirst decay {FormatSignedPercent(needs)}, stamina recovery {FormatSignedPercent(stamina)}, poison/rad damage {FormatSignedPercent(toxin)}.";
+        }
+
+        private static string GetCharismaEffectDetails(int value)
+        {
+            var loadout = SharedSpecialSystem.GetCharismaLoadoutPointModifier(value);
+            var social = value switch
+            {
+                <= 2 => "awkward examine text and speech quirks",
+                < 5 => "awkward examine text",
+                >= 7 => "larger chat font",
+                _ => "no social penalty",
+            };
+
+            return $"loadout points {FormatSignedInt(loadout)}, {social}.";
+        }
+
+        private static string GetIntelligenceEffectDetails(int value, SpecialTuningPrototype tuning)
+        {
+            var handCraft = value <= SpecialProfile.Minimum
+                ? "hand crafting blocked"
+                : $"hand crafting delay {FormatSignedPercent(GetIntelligenceConstructionDelayModifier(value))}";
+            var lathe = value <= 3
+                ? "lathes locked"
+                : $"lathe production time {FormatSignedPercent(GetIntelligenceLatheTimeModifier(value, tuning))}";
+            var surgery = $"surgery speed {FormatSignedPercent((value - SpecialProfile.DefaultValue) * 0.1f)}";
+            var extra = value switch
+            {
+                <= 1 => ", low-intelligence accent",
+                >= 8 => ", detailed chemical scans",
+                _ => string.Empty,
+            };
+
+            return $"{handCraft}, {lathe}, {surgery}{extra}.";
+        }
+
+        private static string GetAgilityEffectDetails(int value, SpecialTuningPrototype tuning)
+        {
+            var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
+            var move = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                -tuning.AgilityMovementSpeedPenaltyAtOne,
+                tuning.AgilityMovementSpeedBonusAtTen);
+            var actionDelay = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                tuning.AgilityActionDelayPenaltyAtOne,
+                -tuning.AgilityActionDelayReductionAtTen);
+
+            return $"movement speed {FormatSignedPercent(move)}, melee attack delay {FormatSignedPercent(actionDelay)}.";
+        }
+
+        private static string GetLuckEffectDetails(int value, SpecialTuningPrototype tuning)
+        {
+            var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
+            var maxDelta = SharedSpecialSystem.GetCurvedEffectDelta(SpecialProfile.Maximum);
+            var shotCrit = Math.Clamp(tuning.LuckSingleShotCriticalChanceAtTen * delta / maxDelta, 0f, 1f);
+            var luckyLoot = Math.Clamp(delta * tuning.LuckLootChancePerPoint, 0f, 1f);
+            var clumsy = value switch
+            {
+                1 => 0.50f,
+                2 => 0.05f,
+                3 => 0.03f,
+                4 => 0.01f,
+                _ => 0f,
+            };
+
+            return $"crit chance per hit {FormatUnsignedPercent(shotCrit)}, lucky loot chance {FormatUnsignedPercent(luckyLoot)}, clumsy chance {FormatUnsignedPercent(clumsy)}.";
+        }
+
+        private static float GetIntelligenceConstructionDelayModifier(int value)
+        {
+            var multiplier = value >= SpecialProfile.DefaultValue
+                ? 1f - (value - SpecialProfile.DefaultValue) * 0.1f
+                : 1f + (SpecialProfile.DefaultValue - value) * 0.15f;
+
+            return MathF.Max(0.1f, multiplier) - 1f;
+        }
+
+        private static float GetIntelligenceLatheTimeModifier(int value, SpecialTuningPrototype tuning)
+        {
+            var minMultiplier = Math.Clamp(tuning.IntelligenceLatheMinimumTimeMultiplierAtTen, 0.1f, 1f);
+            var multiplier = value >= SpecialProfile.DefaultValue
+                ? 1f - (1f - minMultiplier) * (value - SpecialProfile.DefaultValue) /
+                    (SpecialProfile.Maximum - SpecialProfile.DefaultValue)
+                : 1f + (SpecialProfile.DefaultValue - value) * 0.15f;
+
+            return MathF.Max(0.1f, multiplier) - 1f;
+        }
+
+        private static string FormatSignedPercent(float value)
+        {
+            if (MathF.Abs(value) < 0.0005f)
+                return "0%";
+
+            return value > 0f
+                ? $"+{value * 100f:0.#}%"
+                : $"{value * 100f:0.#}%";
+        }
+
+        private static string FormatUnsignedPercent(float value)
+        {
+            return $"{MathF.Max(0f, value) * 100f:0.#}%";
+        }
+
+        private static string FormatSignedNumber(float value)
+        {
+            if (MathF.Abs(value) < 0.05f)
+                return "0";
+
+            return value > 0f
+                ? $"+{value:0.#}"
+                : $"{value:0.#}";
+        }
+
+        private static string FormatSignedInt(int value)
+        {
+            return value > 0
+                ? $"+{value}"
+                : value.ToString();
         }
 
         private void SetSpecialValue(SpecialStat stat, int value)

--- a/Content.Server/_Misfits/Special/SpecialCombatSystem.cs
+++ b/Content.Server/_Misfits/Special/SpecialCombatSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Damage;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Random;
 
@@ -34,8 +35,8 @@ public sealed class SpecialCombatSystem : EntitySystem
         var damage = args.BaseDamage;
         ApplyStrengthMeleeModifier(args.User, ref damage, special);
 
-        // Melee weapons use the same Luck crit curve as one-shot ranged weapons.
-        TryApplyLuckCritical(args.User, ref damage, special, uid);
+        // Melee weapons use the same Luck crit curve as ranged weapons.
+        TryApplyLuckCritical(args.User, ref damage, special);
 
         // Preserve the original event damage and apply only the SPECIAL delta.
         args.BonusDamage += damage - args.BaseDamage;
@@ -72,7 +73,7 @@ public sealed class SpecialCombatSystem : EntitySystem
             args.Damage = damage;
     }
 
-    private bool TryApplyLuckCritical(EntityUid user, ref DamageSpecifier damage, SpecialComponent special, EntityUid? weapon)
+    private bool TryApplyLuckCritical(EntityUid user, ref DamageSpecifier damage, SpecialComponent special, EntityUid? weapon = null)
     {
         var chance = GetLuckCriticalChance(user, special, weapon);
 
@@ -88,23 +89,14 @@ public sealed class SpecialCombatSystem : EntitySystem
     {
         var tuning = _special.GetTuning();
 
-        // Hitscan callers can omit the weapon if they want the generic Luck curve.
-        if (weapon == null)
-            return _special.GetLuckRollChance(user, 0f, tuning.LuckCriticalChancePerPoint, special);
-
-        // Single-shot weapons get the full configured chance. Magazine-fed weapons
-        // divide that chance by capacity so expected crits per reload stay similar.
+        // Every hit rolls the full configured chance; magazine-fed weapons no
+        // longer divide crit chance by ammo capacity.
         var delta = _special.GetCurvedEffectDelta(user, SpecialStat.Luck, special);
-        var ammoCapacity = GetWeaponAmmoCapacity(weapon.Value);
-        var singleShotChance = tuning.LuckSingleShotCriticalChanceAtTen * delta / SharedSpecialSystem.GetCurvedEffectDelta(SpecialProfile.Maximum);
-        return Math.Clamp(singleShotChance / ammoCapacity, 0f, 1f);
-    }
+        var shotChance = tuning.LuckSingleShotCriticalChanceAtTen * delta / SharedSpecialSystem.GetCurvedEffectDelta(SpecialProfile.Maximum);
 
-    private int GetWeaponAmmoCapacity(EntityUid weapon)
-    {
-        var ammo = new GetAmmoCountEvent();
-        RaiseLocalEvent(weapon, ref ammo, false);
+        if (weapon != null && HasComp<RevolverAmmoProviderComponent>(weapon.Value))
+            shotChance *= 2f;
 
-        return Math.Max(1, ammo.Capacity);
+        return Math.Clamp(shotChance, 0f, 1f);
     }
 }

--- a/Content.Server/_Misfits/SpecialStats/SpecialPenaltySystem.cs
+++ b/Content.Server/_Misfits/SpecialStats/SpecialPenaltySystem.cs
@@ -16,7 +16,10 @@ public sealed class SpecialPenaltySystem : EntitySystem
 
     private const int LowCharismaThreshold = 5;
     private const int LowIntelligenceThreshold = 2;
-    private const int ClumsyLuckThreshold = 3;
+    private const float ClumsyLuckOneChance = 0.50f;
+    private const float ClumsyLuckTwoChance = 0.05f;
+    private const float ClumsyLuckThreeChance = 0.03f;
+    private const float ClumsyLuckFourChance = 0.01f;
 
     public override void Initialize()
     {
@@ -59,8 +62,9 @@ public sealed class SpecialPenaltySystem : EntitySystem
         else
             ClearLowIntelligence(ent.Owner);
 
-        if (_special.GetEffective(ent.Owner, SpecialStat.Luck, ent.Comp) < ClumsyLuckThreshold)
-            ApplyLuckClumsy(ent.Owner);
+        var luck = _special.GetEffective(ent.Owner, SpecialStat.Luck, ent.Comp);
+        if (TryGetLuckClumsyChance(luck, out var clumsyChance))
+            ApplyLuckClumsy(ent.Owner, clumsyChance);
         else
             ClearLuckClumsy(ent.Owner);
     }
@@ -86,9 +90,32 @@ public sealed class SpecialPenaltySystem : EntitySystem
         RemComp<LowIntelligenceAccentComponent>(uid);
     }
 
-    private void ApplyLuckClumsy(EntityUid uid)
+    private static bool TryGetLuckClumsyChance(int luck, out float chance)
     {
-        EnsureComp<ClumsyComponent>(uid);
+        chance = luck switch
+        {
+            1 => ClumsyLuckOneChance,
+            2 => ClumsyLuckTwoChance,
+            3 => ClumsyLuckThreeChance,
+            4 => ClumsyLuckFourChance,
+            _ => 0f,
+        };
+
+        return chance > 0f;
+    }
+
+    private void ApplyLuckClumsy(EntityUid uid, float chance)
+    {
+        var hadClumsy = HasComp<ClumsyComponent>(uid);
+        var specialApplied = HasComp<SpecialAppliedClumsyComponent>(uid);
+
+        // Do not weaken or take ownership of clumsy from traits, species, or admin effects.
+        if (hadClumsy && !specialApplied)
+            return;
+
+        var clumsy = EnsureComp<ClumsyComponent>(uid);
+        clumsy.ClumsyDefaultCheck = chance;
+        Dirty(uid, clumsy);
         EnsureComp<SpecialAppliedClumsyComponent>(uid);
     }
 

--- a/Content.Shared/_Misfits/Special/README.md
+++ b/Content.Shared/_Misfits/Special/README.md
@@ -35,4 +35,4 @@ The tuning values below are multiplied by that curved delta or scaled to explici
 - Charisma changes character-creation loadout points by the curved delta times 2, rounded away from zero. Below 5 charisma, examine text gives a social tell; at 1-2 charisma, speech can gain light awkward phrasing.
 - Intelligence changes crafting delay on a fixed curve: 1 blocks hand crafting, 5 is normal speed, and 10 is 50% faster for hand crafting. Lathe production is instant at 10 intelligence. At 1 intelligence, the low-intelligence accent is enabled.
 - Agility changes movement speed from `agilityMovementSpeedPenaltyAtOne` at 1 AGI to `agilityMovementSpeedBonusAtTen` at 10 AGI.
-- Luck changes critical-hit and lucky-scavenge chance. Below 4 luck, clumsy is applied until luck recovers.
+- Luck changes critical-hit and lucky-scavenge chance. At 1 luck, clumsy uses its normal failure chance; at 2-4 luck, clumsy is still possible but much rarer.


### PR DESCRIPTION
## About the PR
Updates the SPECIAL crit and character setup UI behavior.

- Luck crits are no longer treated as a single-shot/reload-scaled effect.
- Luck crit chance now applies per hit for melee, projectile, and hitscan damage.
- Revolver weapons naturally get double the normal Luck crit chance.
- Character selection now shows the current SPECIAL effects and previews what lowering or raising each stat will do.
- Lower-stat preview text is red, and raise-stat preview text is blue.

## Why / Balance
The old crit behavior made Luck scale awkwardly for firearms, especially after moving crits away from single-shot logic. Applying crit chance per hit makes the stat easier to understand and keeps the listed value consistent with actual combat behavior.

Revolvers now get a natural crit-rate bonus to give them a stronger identity as precision/luck weapons without changing their base damage directly.

The character setup screen now gives players clearer information before they commit SPECIAL points, reducing hidden mechanics and making stat tradeoffs easier to evaluate.

## Media
<img width="2659" height="1524" alt="image" src="https://github.com/user-attachments/assets/0a2d90d0-44e0-4967-9979-0ebcba1bf8f1" />

## Technical details
- Updated `SpecialCombatSystem` so Luck crit chance is calculated per hit instead of being divided by ammo capacity.
- Removed the old ammo-capacity based crit scaling.
- Checks for `RevolverAmmoProviderComponent` on ranged weapons and doubles the computed crit chance when present.
- Updated melee, projectile, and hitscan crit paths to use the same shared crit calculation.
- Added SPECIAL effect detail helpers to `HumanoidProfileEditor`.
- Added current stat effect text and lower/raise previews to each SPECIAL row.
- Updated Luck text from single-shot crit chance to crit chance per hit.

# Changelog

:cl:
- tweak: Luck crit chance now applies per hit instead of being single-shot based.
- tweak: Revolvers now naturally have double crit chance.
- add: SPECIAL stats now show current effects and lower/raise previews in character selection.