### PR TITLE
Nerfs Supermutant Helmets

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
@@ -178,9 +178,9 @@
   - type: Armor # #Misfits Add - Haha get nerfed mutie -pierow
     modifiers:
       coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85
+        Blunt: 0.80
+        Slash: 0.80
+        Piercing: 0.95
 
 # #Misfits Add - Ranger armor for the Supermutant Ranger job.
 # Tagged SupermutantWearable so only supermutants can equip it in Outerclothing slot.
@@ -222,7 +222,6 @@
       coefficients:
         Blunt: 0.90
         Slash: 0.90
-        Piercing: 0.90
 
 - type: entity
   parent: ClothingHeadBase
@@ -240,9 +239,9 @@
   - type: Armor # #Misfits Add - Haha get nerfed mutie -pierow
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.80
+        Blunt: 0.90
+        Slash: 0.85
+        Piercing: 0.75
 
 - type: entity
   parent: ClothingMaskBase
@@ -312,9 +311,9 @@
   - type: Armor # #Misfits Add - Haha get nerfed mutie -pierow
     modifiers:
       coefficients:
-        Blunt: 0.85
+        Blunt: 0.90
         Slash: 0.85
-        Piercing: 0.80
+        Piercing: 0.85
 
 # #Misfits Add - Extra supermutant outer outfit (outfit C) — spawnable standalone wearable.
 - type: entity
@@ -412,9 +411,8 @@
   - type: Armor # #Misfits Add - Haha get nerfed mutie -pierow
     modifiers:
       coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
+        Blunt: 0.75
+        Slash: 0.75
 
 # #Misfits Add - Supermutant Tribal Gloves
 - type: entity

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
@@ -175,12 +175,12 @@
   - type: Tag
     tags:
     - SuperMutantWearable
-  - type: Armor # #Misfits Add - 50% physical damage resistance (head protection)
+  - type: Armor # #Misfits Add - Haha get nerfed mutie -pierow
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.85
 
 # #Misfits Add - Ranger armor for the Supermutant Ranger job.
 # Tagged SupermutantWearable so only supermutants can equip it in Outerclothing slot.
@@ -217,12 +217,12 @@
   - type: Tag
     tags:
     - SuperMutantWearable
-  - type: Armor # #Misfits Add - 50% physical damage resistance (head protection)
+  - type: Armor # #Misfits Add - Haha get nerfed mutie -pierow
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
+        Blunt: 0.90
+        Slash: 0.90
+        Piercing: 0.90
 
 - type: entity
   parent: ClothingHeadBase
@@ -237,12 +237,12 @@
   - type: Tag
     tags:
     - SuperMutantWearable
-  - type: Armor # #Misfits Add - 50% physical damage resistance (head protection)
+  - type: Armor # #Misfits Add - Haha get nerfed mutie -pierow
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.80
 
 - type: entity
   parent: ClothingMaskBase
@@ -309,12 +309,12 @@
   - type: Tag
     tags:
     - SuperMutantWearable
-  - type: Armor # #Misfits Add - 50% physical damage resistance (head protection)
+  - type: Armor # #Misfits Add - Haha get nerfed mutie -pierow
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.80
 
 # #Misfits Add - Extra supermutant outer outfit (outfit C) — spawnable standalone wearable.
 - type: entity
@@ -409,12 +409,12 @@
   - type: Tag
     tags:
     - SuperMutantWearable
-  - type: Armor # #Misfits Add - 50% physical damage resistance (head protection)
+  - type: Armor # #Misfits Add - Haha get nerfed mutie -pierow
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
+        Blunt: 0.90
+        Slash: 0.90
+        Piercing: 0.95
 
 # #Misfits Add - Supermutant Tribal Gloves
 - type: entity


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Reduced the Blunt, Slash, and Pierce modifiers Supermutant helmets provided.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->Seeing how the new SPECIAL system is now rolled out, this needs to be tweaked so Supermutants aren't literally godmoded. Also, the fact that other people can wear Supermutant helmets doesn't make this nerf exclusive.

## Technical details
<!-- Summary of code changes for easier review. --> "_It just works_" -Todd Howard

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- remove: Reduced Supermutant armor values on all their helmets.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
