### PR TITLE
Here We Go Again

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -6,6 +6,8 @@ using System.Text;
 using Content.Client.Materials;
 using Content.Shared.DeltaV.Salvage.Components; // DeltaV
 using Content.Shared.DeltaV.Salvage.Systems; // DeltaV
+using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Components;
 using Content.Shared.Lathe;
 using Content.Shared.Lathe.Prototypes;
 using Content.Shared.Materials;
@@ -37,6 +39,7 @@ public sealed partial class LatheMenu : DefaultWindow
     private readonly LatheSystem _lathe;
     private readonly MaterialStorageSystem _materialStorage;
     private readonly MiningPointsSystem _miningPoints; // DeltaV
+    private readonly SharedSpecialSystem _special;
 
     public event Action<BaseButton.ButtonEventArgs>? OnServerListButtonPressed;
     public event Action<string, int>? RecipeQueueAction;
@@ -66,6 +69,7 @@ public sealed partial class LatheMenu : DefaultWindow
         _lathe = _entityManager.System<LatheSystem>();
         _materialStorage = _entityManager.System<MaterialStorageSystem>();
         _miningPoints = _entityManager.System<MiningPointsSystem>(); // DeltaV
+        _special = _entityManager.System<SharedSpecialSystem>();
 
         SearchBar.OnTextChanged += _ =>
         {
@@ -186,6 +190,7 @@ public sealed partial class LatheMenu : DefaultWindow
         RecipeList.Children.Clear();
         BlueprintRecipeList.Children.Clear();
         _entityManager.TryGetComponent(Entity, out LatheComponent? lathe);
+        var materialUseMultiplier = GetEffectiveMaterialUseMultiplier(lathe);
 
         foreach (var prototype in sortedItemRecipesToShow)
         {
@@ -193,8 +198,8 @@ public sealed partial class LatheMenu : DefaultWindow
             // materials physically stored in the workbench storage container (not just
             // the material pool) are counted, enabling the button correctly.
             var canProduce = ServerAvailableMaterials != null
-                ? _lathe.CanProduce(Entity, prototype, quantity, ServerAvailableMaterials, component: lathe)
-                : _lathe.CanProduce(Entity, prototype, quantity, component: lathe);
+                ? _lathe.CanProduce(Entity, prototype, quantity, ServerAvailableMaterials, materialUseMultiplier, component: lathe)
+                : _lathe.CanProduce(Entity, prototype, quantity, materialUseMultiplier, component: lathe);
 
             var control = new RecipeControl(_lathe, prototype, () => GenerateTooltipText(prototype), canProduce, GetRecipeDisplayControl(prototype));
             control.OnButtonPressed += s =>
@@ -210,8 +215,8 @@ public sealed partial class LatheMenu : DefaultWindow
         {
             // #Misfits Fix: Same server-material-amount check for blueprint recipes.
             var canProduce = ServerAvailableMaterials != null
-                ? _lathe.CanProduce(Entity, prototype, quantity, ServerAvailableMaterials, component: lathe)
-                : _lathe.CanProduce(Entity, prototype, quantity, component: lathe);
+                ? _lathe.CanProduce(Entity, prototype, quantity, ServerAvailableMaterials, materialUseMultiplier, component: lathe)
+                : _lathe.CanProduce(Entity, prototype, quantity, materialUseMultiplier, component: lathe);
 
             var control = new RecipeControl(_lathe, prototype, () => GenerateTooltipText(prototype), canProduce, GetRecipeDisplayControl(prototype));
             control.OnButtonPressed += s =>
@@ -239,6 +244,7 @@ public sealed partial class LatheMenu : DefaultWindow
 
         BuildableRecipeList.Children.Clear();
         _entityManager.TryGetComponent(Entity, out LatheComponent? lathe);
+        var materialUseMultiplier = GetEffectiveMaterialUseMultiplier(lathe);
 
         var buildable = new List<LatheRecipePrototype>();
         var itemSearch = SearchBar.Text.Trim().ToLowerInvariant();
@@ -268,8 +274,8 @@ public sealed partial class LatheMenu : DefaultWindow
             // Only include recipes the player can currently build
             // #Misfits Fix: Use server-provided material amounts when available.
             var canBuild = ServerAvailableMaterials != null
-                ? _lathe.CanProduce(Entity, proto, quantity, ServerAvailableMaterials, component: lathe)
-                : _lathe.CanProduce(Entity, proto, quantity, component: lathe);
+                ? _lathe.CanProduce(Entity, proto, quantity, ServerAvailableMaterials, materialUseMultiplier, component: lathe)
+                : _lathe.CanProduce(Entity, proto, quantity, materialUseMultiplier, component: lathe);
             if (canBuild)
                 buildable.Add(proto);
         }
@@ -302,7 +308,8 @@ public sealed partial class LatheMenu : DefaultWindow
     private string GenerateTooltipText(LatheRecipePrototype prototype)
     {
         StringBuilder sb = new();
-        var multiplier = _entityManager.GetComponent<LatheComponent>(Entity).MaterialUseMultiplier;
+        _entityManager.TryGetComponent(Entity, out LatheComponent? lathe);
+        var multiplier = GetEffectiveMaterialUseMultiplier(lathe);
 
         foreach (var (id, amount) in prototype.Materials)
         {
@@ -354,6 +361,18 @@ public sealed partial class LatheMenu : DefaultWindow
             sb.Remove(sb.Length - 1, 1);
 
         return sb.ToString();
+    }
+
+    private float GetEffectiveMaterialUseMultiplier(LatheComponent? lathe)
+    {
+        var multiplier = lathe?.MaterialUseMultiplier ?? 1f;
+        if (_player.LocalEntity is not { } player ||
+            !_entityManager.TryGetComponent(player, out SpecialComponent? special))
+        {
+            return multiplier;
+        }
+
+        return _special.GetIntelligenceLatheMaterialUseMultiplier(player, multiplier, special);
     }
 
     public void UpdateCategories()

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -2593,7 +2593,7 @@ namespace Content.Client.Lobby.UI
                 : $"hand crafting delay {FormatSignedPercent(GetIntelligenceConstructionDelayModifier(value))}";
             var lathe = value <= 3
                 ? "lathes locked"
-                : $"lathe production time {FormatSignedPercent(GetIntelligenceLatheTimeModifier(value, tuning))}";
+                : $"lathe production time {FormatSignedPercent(GetIntelligenceLatheTimeModifier(value, tuning))}, lathe material cost {FormatSignedPercent(GetIntelligenceLatheMaterialCostModifier(value, tuning))}";
             var medical = $"medical action speed {FormatSignedPercent(SharedSpecialSystem.GetIntelligenceMedicalActionSpeed(value) - 1f)} (CPR, healing, surgery, scans)";
             var extra = value switch
             {
@@ -2666,6 +2666,14 @@ namespace Content.Client.Lobby.UI
                 : 1f + (SpecialProfile.DefaultValue - value) * 0.15f;
 
             return MathF.Max(0.1f, multiplier) - 1f;
+        }
+
+        private static float GetIntelligenceLatheMaterialCostModifier(int value, SpecialTuningPrototype tuning)
+        {
+            return SharedSpecialSystem.GetIntelligenceLatheMaterialUseMultiplier(
+                value,
+                1f,
+                tuning.IntelligenceLatheMaterialDiscountAtTen) - 1f;
         }
 
         private static string FormatSignedPercent(float value)

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -2594,7 +2594,7 @@ namespace Content.Client.Lobby.UI
             var lathe = value <= 3
                 ? "lathes locked"
                 : $"lathe production time {FormatSignedPercent(GetIntelligenceLatheTimeModifier(value, tuning))}";
-            var surgery = $"surgery speed {FormatSignedPercent((value - SpecialProfile.DefaultValue) * 0.1f)}";
+            var medical = $"medical action speed {FormatSignedPercent(SharedSpecialSystem.GetIntelligenceMedicalActionSpeed(value) - 1f)} (CPR, healing, surgery, scans)";
             var extra = value switch
             {
                 <= 1 => ", low-intelligence accent",
@@ -2602,7 +2602,7 @@ namespace Content.Client.Lobby.UI
                 _ => string.Empty,
             };
 
-            return $"{handCraft}, {lathe}, {surgery}{extra}.";
+            return $"{handCraft}, {lathe}, {medical}{extra}.";
         }
 
         private static string GetAgilityEffectDetails(int value, SpecialTuningPrototype tuning)
@@ -2625,6 +2625,7 @@ namespace Content.Client.Lobby.UI
             var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
             var maxDelta = SharedSpecialSystem.GetCurvedEffectDelta(SpecialProfile.Maximum);
             var shotCrit = Math.Clamp(tuning.LuckSingleShotCriticalChanceAtTen * delta / maxDelta, 0f, 1f);
+            var revolverCrit = Math.Clamp(shotCrit * 2f, 0f, 1f);
             var luckyLoot = Math.Clamp(delta * tuning.LuckLootChancePerPoint, 0f, 1f);
             var clumsy = value switch
             {
@@ -2634,8 +2635,17 @@ namespace Content.Client.Lobby.UI
                 4 => 0.01f,
                 _ => 0f,
             };
+            var unlucky = value switch
+            {
+                2 => 0.05f,
+                3 => 0.03f,
+                4 => 0.01f,
+                _ => 0f,
+            };
 
-            return $"crit chance per hit {FormatUnsignedPercent(shotCrit)}, lucky loot chance {FormatUnsignedPercent(luckyLoot)}, clumsy chance {FormatUnsignedPercent(clumsy)}.";
+            var unluckyDamage = 1f - Math.Clamp(tuning.LuckUnluckyDamageMultiplier, 0f, 1f);
+
+            return $"crit chance per hit {FormatUnsignedPercent(shotCrit)} (revolvers {FormatUnsignedPercent(revolverCrit)}), unlucky hit chance {FormatUnsignedPercent(unlucky)} for {FormatSignedPercent(-unluckyDamage)} damage, lucky loot chance {FormatUnsignedPercent(luckyLoot)}, clumsy chance {FormatUnsignedPercent(clumsy)}.";
         }
 
         private static float GetIntelligenceConstructionDelayModifier(int value)

--- a/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/InjectorSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Server.Chat.Systems;
 using Content.Server.Chat.Managers;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Chat;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
@@ -29,6 +30,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
     [Dependency] private readonly ReactiveSystem _reactiveSystem = default!;
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     private const ChatChannel BlockInjectionDenyChannel = ChatChannel.Emotes;
 
@@ -232,7 +234,7 @@ public sealed class InjectorSystem : SharedInjectorSystem
             }
         }
 
-        DoAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, actualDelay, new InjectorDoAfterEvent(), injector.Owner, target: target, used: injector.Owner)
+        DoAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, _special.GetIntelligenceMedicalActionDelay(user, actualDelay), new InjectorDoAfterEvent(), injector.Owner, target: target, used: injector.Owner)
         {
             BreakOnMove = true,
             BreakOnWeightlessMove = false,

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -221,13 +221,15 @@ namespace Content.Server.Lathe
             if (!Resolve(uid, ref component))
                 return false;
 
-            if (!CanProduce(uid, recipe, 1, component))
+            var materialUseMultiplier = GetIntelligenceLatheMaterialUseMultiplier(actor, component.MaterialUseMultiplier);
+
+            if (!CanProduce(uid, recipe, 1, materialUseMultiplier, component))
                 return false;
 
             foreach (var (mat, amount) in recipe.Materials)
             {
                 var adjustedAmount = recipe.ApplyMaterialDiscount
-                    ? (int) (-amount * component.MaterialUseMultiplier)
+                    ? -SharedLatheSystem.AdjustMaterial(amount, true, materialUseMultiplier)
                     : -amount;
 
                 if (!_materialStorage.TryConsumeAvailableMaterial(uid, mat, -adjustedAmount))
@@ -549,12 +551,13 @@ namespace Content.Server.Lathe
                         if (i == 0)
                         {
                             var hasRecipe = HasRecipe(uid, recipe, component);
-                            var canProduce = CanProduce(uid, recipe, 1, component);
+                            var materialUseMultiplier = GetIntelligenceLatheMaterialUseMultiplier(args.Actor, component.MaterialUseMultiplier);
+                            var canProduce = CanProduce(uid, recipe, 1, materialUseMultiplier, component);
                             var missing = string.Join(", ",
                                 recipe.Materials.Select(m =>
                                 {
                                     var needed = recipe.ApplyMaterialDiscount
-                                        ? (int) MathF.Ceiling(m.Value * component.MaterialUseMultiplier)
+                                        ? SharedLatheSystem.AdjustMaterial(m.Value, true, materialUseMultiplier)
                                         : m.Value;
                                     var available = _materialStorage.GetAvailableMaterialAmount(uid, m.Key);
                                     var shortfall = Math.Max(0, needed - available);
@@ -609,6 +612,14 @@ namespace Content.Server.Lathe
                 : 1f + (SpecialProfile.DefaultValue - intelligence) * 0.15f;
 
             return baseTime * MathF.Max(0.1f, multiplier);
+        }
+
+        private float GetIntelligenceLatheMaterialUseMultiplier(EntityUid? user, float baseMultiplier)
+        {
+            if (user == null || !TryComp<SpecialComponent>(user.Value, out var special))
+                return baseMultiplier;
+
+            return _special.GetIntelligenceLatheMaterialUseMultiplier(user.Value, baseMultiplier, special);
         }
 
         /// <summary>

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Fluids.EntitySystems;
 using Content.Server.Materials;
 using Content.Server.Power.Components;
 using Content.Shared.Administration.Logs;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Audio;
 using Content.Shared.CCVar;
 using Content.Shared.Chemistry.Components;
@@ -50,6 +51,7 @@ namespace Content.Server.Medical.BiomassReclaimer
         [Dependency] private readonly IPlayerManager _playerManager = default!;
         [Dependency] private readonly MaterialStorageSystem _material = default!;
         [Dependency] private readonly SharedMindSystem _minds = default!;
+        [Dependency] private readonly SharedSpecialSystem _special = default!;
 
         [ValidatePrototypeId<MaterialPrototype>]
         public const string BiomassPrototype = "Biomass";
@@ -156,7 +158,7 @@ namespace Content.Server.Medical.BiomassReclaimer
             var delay = reclaimer.Comp.BaseInsertionDelay * (TryComp<PhysicsComponent>(args.Used, out var physics)
                 ? physics.FixturesMass
                 : 1);
-            _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, delay, new ReclaimerDoAfterEvent(), reclaimer, target: args.Target, used: args.Used)
+            _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, _special.GetIntelligenceMedicalActionDelay(args.User, TimeSpan.FromSeconds(delay)), new ReclaimerDoAfterEvent(), reclaimer, target: args.Target, used: args.Used)
             {
                 NeedHand = true,
                 BreakOnMove = true

--- a/Content.Server/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/Medical/CPR/CPRSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.Chat.Systems;
 using Content.Server.DoAfter;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Server.Popups;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Atmos.Rotting;
 using Content.Shared.Chat;
 using Content.Shared.Damage;
@@ -37,6 +38,7 @@ public sealed class CPRSystem : EntitySystem
     [Dependency] private readonly RottingSystem _rottingSystem = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     public override void Initialize()
     {
@@ -84,7 +86,7 @@ public sealed class CPRSystem : EntitySystem
         _popupSystem.PopupEntity(Loc.GetString("cpr-start-second-person-patient", ("user", performer)), target, target);
 
         var doAfterArgs = new DoAfterArgs(
-            EntityManager, performer, performer.Comp.DoAfterDuration, new CPRDoAfterEvent(), performer, target,
+            EntityManager, performer, _special.GetIntelligenceMedicalActionDelay(performer, performer.Comp.DoAfterDuration), new CPRDoAfterEvent(), performer, target,
             performer)
         {
             BreakOnMove = true,

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -14,6 +14,7 @@ using Content.Server.NodeContainer.Nodes;
 using Content.Server.Power.Components;
 using Content.Server.Temperature.Components;
 using Content.Shared.Atmos;
+using Content.Shared._Misfits.Special;
 using Content.Shared.UserInterface;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
@@ -54,6 +55,7 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
     [Dependency] private readonly ReactiveSystem _reactiveSystem = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly NodeContainerSystem _nodeContainer = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     public override void Initialize()
     {
@@ -140,7 +142,7 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
         if (entity.Comp.BodyContainer.ContainedEntity != null)
             return;
 
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, entity.Comp.EntryDelay, new CryoPodDragFinished(), entity, target: args.Dragged, used: entity)
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, _special.GetIntelligenceMedicalActionDelay(args.User, TimeSpan.FromSeconds(entity.Comp.EntryDelay)), new CryoPodDragFinished(), entity, target: args.Dragged, used: entity)
         {
             BreakOnDamage = true,
             BreakOnMove = true,
@@ -217,7 +219,7 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
         if (args.Handled || !entity.Comp.Locked || entity.Comp.BodyContainer.ContainedEntity == null)
             return;
 
-        args.Handled = _toolSystem.UseTool(args.Used, args.User, entity.Owner, entity.Comp.PryDelay, "Prying", new CryoPodPryFinished());
+        args.Handled = _toolSystem.UseTool(args.Used, args.User, entity.Owner, (float) _special.GetIntelligenceMedicalActionDelay(args.User, TimeSpan.FromSeconds(entity.Comp.PryDelay)).TotalSeconds, "Prying", new CryoPodPryFinished());
     }
 
     private void OnExamined(Entity<CryoPodComponent> entity, ref ExaminedEvent args)

--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Ghost;
 using Content.Server.Popups;
 using Content.Server.PowerCell;
 using Content.Server._Misfits.Medical;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Chat;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
@@ -50,6 +51,7 @@ public sealed class DefibrillatorSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -139,7 +141,7 @@ public sealed class DefibrillatorSystem : EntitySystem
             return false;
 
         _audio.PlayPvs(component.ChargeSound, uid);
-        var started = _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, component.DoAfterDuration, new DefibrillatorZapDoAfterEvent(),
+        var started = _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, _special.GetIntelligenceMedicalActionDelay(user, component.DoAfterDuration), new DefibrillatorZapDoAfterEvent(),
             uid, target, uid)
             {
                 BlockDuplicate = true,

--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.Medical.Components;
 using Content.Server.Popups;
 using Content.Server.Stack;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Audio;
 using Content.Shared.Damage;
 using Content.Shared.Database;
@@ -41,6 +42,7 @@ public sealed class HealingSystem : EntitySystem
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
     [Dependency] private readonly SharedBodySystem _bodySystem = default!; // Shitmed Change
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     public override void Initialize()
     {
@@ -218,7 +220,7 @@ public sealed class HealingSystem : EntitySystem
             : component.Delay * GetScaledHealingPenalty(user, component);
 
         var doAfterEventArgs =
-            new DoAfterArgs(EntityManager, user, delay, new HealingDoAfterEvent(), target, target: target, used: uid)
+            new DoAfterArgs(EntityManager, user, _special.GetIntelligenceMedicalActionDelay(user, TimeSpan.FromSeconds(delay)), new HealingDoAfterEvent(), target, target: target, used: uid)
             {
                 //Raise the event on the target if it's not self, otherwise raise it on self.
                 BreakOnMove = true,

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Medical.Components;
 using Content.Server.PowerCell;
 using Content.Server.Temperature.Components;
 using Content.Server.Traits.Assorted;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
@@ -43,6 +44,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly ItemToggleSystem _toggle = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     public override void Initialize()
     {
@@ -115,7 +117,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
 
         _audio.PlayPvs(uid.Comp.ScanningBeginSound, uid);
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, uid.Comp.ScanDelay, new HealthAnalyzerDoAfterEvent(), uid, target: args.Target, used: uid)
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, _special.GetIntelligenceMedicalActionDelay(args.User, uid.Comp.ScanDelay), new HealthAnalyzerDoAfterEvent(), uid, target: args.Target, used: uid)
         {
             NeedHand = true,
             BreakOnMove = true

--- a/Content.Server/Medical/PenLightSystem.cs
+++ b/Content.Server/Medical/PenLightSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.DoAfter;
 using Content.Server.Popups;
 using Content.Server.PowerCell;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Drugs;
@@ -26,6 +27,7 @@ public sealed class PenLightSystem : EntitySystem
     [Dependency] private readonly PowerCellSystem _powerCell = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -87,7 +89,7 @@ public sealed class PenLightSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString("penlight-cannot-examine-self"), uid, user);
             return false;
         }
-        return _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, component.ExamSpeed, new PenLightDoAfterEvent(),
+        return _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, _special.GetIntelligenceMedicalActionDelay(user, TimeSpan.FromSeconds(component.ExamSpeed)), new PenLightDoAfterEvent(),
             uid, target, uid)
         {
             BlockDuplicate = true,

--- a/Content.Server/Medical/Stethoscope/StethoscopeSystem.cs
+++ b/Content.Server/Medical/Stethoscope/StethoscopeSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Body.Components;
 using Content.Server.Medical.Components;
 using Content.Server.Medical.Stethoscope.Components;
 using Content.Server.Popups;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Actions;
 using Content.Shared.Clothing;
 using Content.Shared.Damage;
@@ -21,6 +22,7 @@ namespace Content.Server.Medical.Stethoscope
         [Dependency] private readonly PopupSystem _popupSystem = default!;
         [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
         [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
+        [Dependency] private readonly SharedSpecialSystem _special = default!;
 
         public override void Initialize()
         {
@@ -98,7 +100,7 @@ namespace Content.Server.Medical.Stethoscope
         // construct the doafter and start it
         private void StartListening(EntityUid scope, EntityUid user, EntityUid target, StethoscopeComponent comp)
         {
-            _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, user, comp.Delay, new StethoscopeDoAfterEvent(), scope, target: target, used: scope)
+            _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, user, _special.GetIntelligenceMedicalActionDelay(user, TimeSpan.FromSeconds(comp.Delay)), new StethoscopeDoAfterEvent(), scope, target: target, used: scope)
             {
                 NeedHand = true,
                 BreakOnMove = true,

--- a/Content.Server/_Misfits/Medical/SmellingSaltsSystem.cs
+++ b/Content.Server/_Misfits/Medical/SmellingSaltsSystem.cs
@@ -1,6 +1,7 @@
 // #Misfits Change /Add/ - Smelling salts now perform a long resuscitation interaction instead of injecting a reagent.
 using Content.Server.Chat.Managers;
 using Content.Server.DoAfter;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Chat;
 using Content.Shared.DoAfter;
 using Content.Shared._Misfits.Medical;
@@ -18,6 +19,7 @@ public sealed class SmellingSaltsSystem : EntitySystem
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly ResuscitationSystem _resuscitation = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     public override void Initialize()
     {
@@ -44,7 +46,7 @@ public sealed class SmellingSaltsSystem : EntitySystem
         if (component.UseSound != null)
             _audio.PlayPvs(component.UseSound, uid);
 
-        var started = _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, component.DoAfterDuration, new SmellingSaltsDoAfterEvent(),
+        var started = _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, _special.GetIntelligenceMedicalActionDelay(user, component.DoAfterDuration), new SmellingSaltsDoAfterEvent(),
             uid, target, uid)
             {
                 BlockDuplicate = true,

--- a/Content.Server/_Misfits/Special/SpecialCombatSystem.cs
+++ b/Content.Server/_Misfits/Special/SpecialCombatSystem.cs
@@ -1,11 +1,14 @@
 using Content.Shared._Misfits.Special;
 using Content.Shared._Misfits.Special.Components;
 using Content.Shared.Damage;
+using Content.Shared.Item;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Wieldable;
+using Content.Shared.Wieldable.Components;
 using Robust.Shared.Random;
 
 namespace Content.Server._Misfits.Special;
@@ -19,9 +22,34 @@ public sealed class SpecialCombatSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<ItemComponent, GetMeleeDamageEvent>(OnGetItemMeleeDamage, after: [typeof(WieldableSystem)]);
+        SubscribeLocalEvent<WieldableComponent, GetMeleeDamageEvent>(OnWieldableMeleeDamage, after: [typeof(WieldableSystem)]);
         SubscribeLocalEvent<MeleeWeaponComponent, MeleeHitEvent>(OnMeleeHit);
         SubscribeLocalEvent<ProjectileComponent, ProjectileHitEvent>(OnProjectileHit);
         SubscribeLocalEvent<SpecialComponent, SpecialModifyHitscanDamageEvent>(OnModifyHitscanDamage);
+    }
+
+    private void OnGetItemMeleeDamage(EntityUid uid, ItemComponent component, ref GetMeleeDamageEvent args)
+    {
+        if (HasComp<WieldableComponent>(uid))
+            return;
+
+        ApplyStrengthMeleeDamage(args.User, ref args);
+    }
+
+    private void OnWieldableMeleeDamage(EntityUid uid, WieldableComponent component, ref GetMeleeDamageEvent args)
+    {
+        ApplyStrengthMeleeDamage(args.User, ref args);
+    }
+
+    private void ApplyStrengthMeleeDamage(EntityUid user, ref GetMeleeDamageEvent args)
+    {
+        if (!TryComp<SpecialComponent>(user, out var special))
+            return;
+
+        var damage = args.Damage;
+        ApplyStrengthMeleeModifier(user, ref damage, special);
+        args.Damage = damage;
     }
 
     private void OnMeleeHit(EntityUid uid, MeleeWeaponComponent component, MeleeHitEvent args)
@@ -33,7 +61,6 @@ public sealed class SpecialCombatSystem : EntitySystem
             return;
 
         var damage = args.BaseDamage;
-        ApplyStrengthMeleeModifier(args.User, ref damage, special);
 
         // Melee weapons use the same Luck outcome curve as ranged weapons.
         TryApplyLuckDamageOutcome(args.User, ref damage, special);

--- a/Content.Server/_Misfits/Special/SpecialCombatSystem.cs
+++ b/Content.Server/_Misfits/Special/SpecialCombatSystem.cs
@@ -35,8 +35,8 @@ public sealed class SpecialCombatSystem : EntitySystem
         var damage = args.BaseDamage;
         ApplyStrengthMeleeModifier(args.User, ref damage, special);
 
-        // Melee weapons use the same Luck crit curve as ranged weapons.
-        TryApplyLuckCritical(args.User, ref damage, special);
+        // Melee weapons use the same Luck outcome curve as ranged weapons.
+        TryApplyLuckDamageOutcome(args.User, ref damage, special);
 
         // Preserve the original event damage and apply only the SPECIAL delta.
         args.BonusDamage += damage - args.BaseDamage;
@@ -60,28 +60,35 @@ public sealed class SpecialCombatSystem : EntitySystem
             !TryComp<SpecialComponent>(args.Shooter.Value, out var special))
             return;
 
-        // Projectile damage is mutable on the hit event, so write back only on crit.
+        // Projectile damage is mutable on the hit event, so write back only on Luck outcomes.
         var damage = args.Damage;
-        if (TryApplyLuckCritical(args.Shooter.Value, ref damage, special, ent.Comp.Weapon))
+        if (TryApplyLuckDamageOutcome(args.Shooter.Value, ref damage, special, ent.Comp.Weapon))
             args.Damage = damage;
     }
 
     private void OnModifyHitscanDamage(Entity<SpecialComponent> ent, ref SpecialModifyHitscanDamageEvent args)
     {
         var damage = args.Damage;
-        if (TryApplyLuckCritical(ent.Owner, ref damage, ent.Comp, args.Weapon))
+        if (TryApplyLuckDamageOutcome(ent.Owner, ref damage, ent.Comp, args.Weapon))
             args.Damage = damage;
     }
 
-    private bool TryApplyLuckCritical(EntityUid user, ref DamageSpecifier damage, SpecialComponent special, EntityUid? weapon = null)
+    private bool TryApplyLuckDamageOutcome(EntityUid user, ref DamageSpecifier damage, SpecialComponent special, EntityUid? weapon = null)
     {
-        var chance = GetLuckCriticalChance(user, special, weapon);
+        var tuning = _special.GetTuning();
+        var critChance = GetLuckCriticalChance(user, special, weapon);
 
-        if (chance <= 0f || !_random.Prob(chance))
+        if (critChance > 0f && _random.Prob(critChance))
+        {
+            damage *= tuning.LuckCriticalDamageMultiplier;
+            return true;
+        }
+
+        var unluckyChance = GetLuckUnluckyChance(user, special);
+        if (unluckyChance <= 0f || !_random.Prob(unluckyChance))
             return false;
 
-        var tuning = _special.GetTuning();
-        damage *= tuning.LuckCriticalDamageMultiplier;
+        damage *= Math.Clamp(tuning.LuckUnluckyDamageMultiplier, 0f, 1f);
         return true;
     }
 
@@ -98,5 +105,16 @@ public sealed class SpecialCombatSystem : EntitySystem
             shotChance *= 2f;
 
         return Math.Clamp(shotChance, 0f, 1f);
+    }
+
+    private float GetLuckUnluckyChance(EntityUid user, SpecialComponent special)
+    {
+        return _special.GetEffective(user, SpecialStat.Luck, special) switch
+        {
+            2 => 0.05f,
+            3 => 0.03f,
+            4 => 0.01f,
+            _ => 0f,
+        };
     }
 }

--- a/Content.Shared/Lathe/SharedLatheSystem.cs
+++ b/Content.Shared/Lathe/SharedLatheSystem.cs
@@ -77,12 +77,37 @@ public abstract class SharedLatheSystem : EntitySystem
     {
         if (!Resolve(uid, ref component))
             return false;
+
+        return CanProduce(uid, recipe, amount, availableMaterials, component.MaterialUseMultiplier, component);
+    }
+
+    public bool CanProduce(EntityUid uid, LatheRecipePrototype recipe, int amount, float materialUseMultiplier, LatheComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return false;
         if (!HasRecipe(uid, recipe, component))
             return false;
 
         foreach (var (material, needed) in recipe.Materials)
         {
-            var adjustedAmount = AdjustMaterial(needed, recipe.ApplyMaterialDiscount, component.MaterialUseMultiplier);
+            var adjustedAmount = AdjustMaterial(needed, recipe.ApplyMaterialDiscount, materialUseMultiplier);
+
+            if (_materialStorage.GetAvailableMaterialAmount(uid, material) < adjustedAmount * amount)
+                return false;
+        }
+        return true;
+    }
+
+    public bool CanProduce(EntityUid uid, LatheRecipePrototype recipe, int amount, Dictionary<ProtoId<MaterialPrototype>, int> availableMaterials, float materialUseMultiplier, LatheComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return false;
+        if (!HasRecipe(uid, recipe, component))
+            return false;
+
+        foreach (var (material, needed) in recipe.Materials)
+        {
+            var adjustedAmount = AdjustMaterial(needed, recipe.ApplyMaterialDiscount, materialUseMultiplier);
             var available = availableMaterials.GetValueOrDefault(material, 0);
             if (available < adjustedAmount * amount)
                 return false;

--- a/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
+++ b/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
@@ -92,6 +92,9 @@ public sealed partial class SpecialTuningPrototype : IPrototype
     [DataField("intelligenceLatheMinimumTimeMultiplierAtTen")]
     public float IntelligenceLatheMinimumTimeMultiplierAtTen = 0.50f;
 
+    [DataField("intelligenceLatheMaterialDiscountAtTen")]
+    public float IntelligenceLatheMaterialDiscountAtTen = 0.25f;
+
     // Agility: movement and general action speed.
     [DataField("agilityMovementSpeedMultiplierPerPoint")]
     public float AgilityMovementSpeedMultiplierPerPoint = 0.004f;

--- a/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
+++ b/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
@@ -118,6 +118,9 @@ public sealed partial class SpecialTuningPrototype : IPrototype
     [DataField("luckCriticalDamageMultiplier")]
     public float LuckCriticalDamageMultiplier = 1.5f;
 
+    [DataField("luckUnluckyDamageMultiplier")]
+    public float LuckUnluckyDamageMultiplier = 0.5f;
+
     [DataField("luckLootChancePerPoint")]
     public float LuckLootChancePerPoint = 0.025f;
 }

--- a/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
+++ b/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
@@ -230,6 +230,31 @@ public sealed class SharedSpecialSystem : EntitySystem
         return baseDelay / GetIntelligenceMedicalActionSpeed(uid, component);
     }
 
+    /// <summary>
+    /// Applies the Intelligence lathe material discount to an existing material-use multiplier.
+    /// The discount only rewards above-average Intelligence; low Intelligence is already gated elsewhere.
+    /// </summary>
+    public float GetIntelligenceLatheMaterialUseMultiplier(EntityUid uid, float baseMultiplier, SpecialComponent? component = null)
+    {
+        if (!Resolve(uid, ref component, false))
+            return baseMultiplier;
+
+        var tuning = GetTuning();
+        return GetIntelligenceLatheMaterialUseMultiplier(
+            GetEffective(uid, SpecialStat.Intelligence, component),
+            baseMultiplier,
+            tuning.IntelligenceLatheMaterialDiscountAtTen);
+    }
+
+    public static float GetIntelligenceLatheMaterialUseMultiplier(int intelligence, float baseMultiplier, float discountAtTen)
+    {
+        var delta = MathF.Max(0f, GetCurvedEffectDelta(intelligence));
+        var maxDelta = GetCurvedEffectDelta(SpecialProfile.Maximum);
+        var discount = Math.Clamp(discountAtTen, 0f, 0.5f) * delta / maxDelta;
+
+        return MathF.Max(0.1f, baseMultiplier * (1f - discount));
+    }
+
     public int GetCharismaChatFontSize(EntityUid uid, int baseFontSize, SpecialComponent? component = null)
     {
         return GetEffective(uid, SpecialStat.Charisma, component) >= 7

--- a/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
+++ b/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
@@ -206,6 +206,30 @@ public sealed class SharedSpecialSystem : EntitySystem
         return (int) Math.Round(GetCurvedEffectDelta(charisma) * 2f, MidpointRounding.AwayFromZero);
     }
 
+    /// <summary>
+    /// Returns the Intelligence speed multiplier used by medical actions with do-after timers.
+    /// </summary>
+    public float GetIntelligenceMedicalActionSpeed(EntityUid uid, SpecialComponent? component = null)
+    {
+        if (!Resolve(uid, ref component, false))
+            return 1f;
+
+        return GetIntelligenceMedicalActionSpeed(GetEffective(uid, SpecialStat.Intelligence, component));
+    }
+
+    public static float GetIntelligenceMedicalActionSpeed(int intelligence)
+    {
+        return MathF.Max(0.1f, 1f + (intelligence - SpecialProfile.DefaultValue) * 0.1f);
+    }
+
+    /// <summary>
+    /// Applies the Intelligence medical speed multiplier to a timed medical action.
+    /// </summary>
+    public TimeSpan GetIntelligenceMedicalActionDelay(EntityUid uid, TimeSpan baseDelay, SpecialComponent? component = null)
+    {
+        return baseDelay / GetIntelligenceMedicalActionSpeed(uid, component);
+    }
+
     public int GetCharismaChatFontSize(EntityUid uid, int baseFontSize, SpecialComponent? component = null)
     {
         return GetEffective(uid, SpecialStat.Charisma, component) >= 7

--- a/Content.Shared/_Misfits/SpecialStats/SpecialAgilitySystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialAgilitySystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._Misfits.Special;
 using Content.Shared._Misfits.Special.Components;
+using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 
 namespace Content.Shared._Misfits.SpecialStats;
@@ -15,10 +16,10 @@ public sealed class SpecialAgilitySystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<GetMeleeAttackRateEvent>(OnMeleeAttackRate);
+        SubscribeLocalEvent<MeleeWeaponComponent, GetMeleeAttackRateEvent>(OnMeleeAttackRate);
     }
 
-    private void OnMeleeAttackRate(ref GetMeleeAttackRateEvent args)
+    private void OnMeleeAttackRate(EntityUid uid, MeleeWeaponComponent component, ref GetMeleeAttackRateEvent args)
     {
         if (!TryComp<SpecialComponent>(args.User, out var special))
             return;

--- a/Content.Shared/_Misfits/Surgery/Contamination/SurgeryCleanSystem.cs
+++ b/Content.Shared/_Misfits/Surgery/Contamination/SurgeryCleanSystem.cs
@@ -1,4 +1,5 @@
 // #Misfits Change - Ported from Delta-V surgery contamination system
+using Content.Shared._Misfits.Special;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Forensics;
@@ -19,6 +20,7 @@ public sealed class SurgeryCleanSystem : EntitySystem
 {
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     public override void Initialize()
     {
@@ -90,7 +92,7 @@ public sealed class SurgeryCleanSystem : EntitySystem
         // #Misfits TODO: Same as above — convert progress feedback to private chat message.
         _popup.PopupClient(Loc.GetString("sanitization-cleaning", ("target", target)), user, user);
 
-        var doAfterArgs = new DoAfterArgs(EntityManager, user, ent.Comp.CleanDelay, new SurgeryCleanDirtDoAfterEvent(), ent, target: target)
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, _special.GetIntelligenceMedicalActionDelay(user, TimeSpan.FromSeconds(ent.Comp.CleanDelay)), new SurgeryCleanDirtDoAfterEvent(), ent, target: target)
         {
             BreakOnMove = true,
             NeedHand = true,

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -792,18 +792,9 @@ public abstract partial class SharedSurgerySystem
         if (TryComp(user, out SurgerySpeedModifierComponent? surgerySpeedMod))
             speed *= surgerySpeedMod.SpeedModifier;
 
-        speed *= GetIntelligenceSurgerySpeed(user);
+        speed *= _special.GetIntelligenceMedicalActionSpeed(user);
 
         return stepComp.Duration / speed;
-    }
-
-    private float GetIntelligenceSurgerySpeed(EntityUid user)
-    {
-        if (!TryComp<SpecialComponent>(user, out var special))
-            return 1f;
-
-        var intelligence = _special.GetEffective(user, SpecialStat.Intelligence, special);
-        return MathF.Max(0.1f, 1f + (intelligence - SpecialProfile.DefaultValue) * 0.1f);
     }
 
     private (Entity<SurgeryComponent> Surgery, int Step)? GetNextStep(EntityUid body, EntityUid part, Entity<SurgeryComponent?> surgery, List<EntityUid> requirements)

--- a/Resources/Prototypes/_Misfits/Holotape/terminal_databases.yml
+++ b/Resources/Prototypes/_Misfits/Holotape/terminal_databases.yml
@@ -14,6 +14,25 @@
 #                                     everything Leadership can do.
 #   adminLabel     (string) Faction-themed label for the Admin checkbox in the UI.
 
+# -- Followers of the Apocalypse: Open Archive --------------------------------
+# Volunteers can read and contribute under existing roots.
+# Doctors manage root records.
+# The Head can mark protected chapter records.
+- type: misfitsTerminalDatabase
+  id: fota-openarchive
+  displayName: Open Archive
+  accentColor: "#E8A838"
+  adminLabel: DIRECTOR
+  accessRead:
+  - FotA
+  accessWrite:
+  - FotA
+  leadershipJobs:
+  - FollowerDoctor
+  - SuperMutantFollowerDoctor
+  adminJobs:
+  - FollowerHead
+
 # ── Brotherhood of Steel: 509th Archive ──────────────────────────────────────
 # Leadership = Heads (Knight / Paladin Commander / Scribe).
 # Admin      = Elder Commander.

--- a/Resources/Prototypes/_Misfits/Special/special_tuning.yml
+++ b/Resources/Prototypes/_Misfits/Special/special_tuning.yml
@@ -22,6 +22,7 @@
   charismaTradePenaltyAtOne: 0.10
   charismaTradeBonusAtTen: 0.10
   intelligenceLatheMinimumTimeMultiplierAtTen: 0.50
+  intelligenceLatheMaterialDiscountAtTen: 0.25
   agilityMovementSpeedPenaltyAtOne: 0.075
   agilityMovementSpeedBonusAtTen: 0.075
   agilityActionDelayPenaltyAtOne: 0.08

--- a/Resources/Prototypes/_Misfits/Special/special_tuning.yml
+++ b/Resources/Prototypes/_Misfits/Special/special_tuning.yml
@@ -29,4 +29,5 @@
   luckCriticalChancePerPoint: 0.005
   luckSingleShotCriticalChanceAtTen: 0.25
   luckCriticalDamageMultiplier: 1.5
+  luckUnluckyDamageMultiplier: 0.5
   luckLootChancePerPoint: 0.025


### PR DESCRIPTION
## About the PR
This PR updates several SPECIAL stat effects.

Intelligence now affects all major medical do-after actions instead of only surgery, and it also reduces lathe material costs. At 10 INT, lathe material costs are reduced by up to 25%, scaling down from there.

Strength melee damage scaling was fixed so it applies properly through melee damage calculation, including wielded/two-handed weapons, and SPECIAL combat values are now more visible in the character screen/examine info.

Agility melee attack rate handling was also fixed to use the correct melee weapon event subscription.

## Why / Balance
This makes INT more useful for medical and crafting-focused characters without making low-cost recipes free, since lathe material costs still round up after the multiplier.

INT lathe material discount scaling:
- INT 6: 3.33% discount
- INT 7: 7.50% discount
- INT 8: 12.50% discount
- INT 9: 18.33% discount
- INT 10: 25.00% discount

Medical speed uses the existing INT curve where 5 INT is neutral, higher INT is faster, and lower INT is slower.

Strength melee scaling was moved into the proper melee damage event so damage modifiers apply consistently before hits resolve, including two-handed/wieldable weapons.

Luck display text was also updated to show revolver crit chance and unlucky hit behavior more clearly.

## Technical details
Added shared INT helpers in `SharedSpecialSystem`:
- `GetIntelligenceMedicalActionSpeed`
- `GetIntelligenceMedicalActionDelay`
- `GetIntelligenceLatheMaterialUseMultiplier`

Updated medical systems to use INT-scaled action delays:
- Injector
- Biomass reclaimer
- CPR
- Cryo pod entry/prying
- Defibrillator
- Healing items
- Health analyzer
- Pen light
- Stethoscope
- Smelling salts
- Surgery cleaning
- Surgery step speed

Updated lathe logic:
- Server-side queue checks and material consumption now use the crafter's INT material multiplier.
- Client lathe UI recipe availability and tooltips now account for the local player's INT discount.
- Shared lathe `CanProduce` gained overloads for explicit material multipliers.

Updated combat/SPECIAL logic:
- Strength melee damage now applies through `GetMeleeDamageEvent`.
- Wieldable/two-handed melee weapons are now handled correctly.
- Luck crit/unlucky damage logic was cleaned up and displayed more accurately.
- Agility melee attack rate subscription now targets `MeleeWeaponComponent`.

Added tuning values:
- `intelligenceLatheMaterialDiscountAtTen: 0.25`
- `luckUnluckyDamageMultiplier: 0.5`

Also adds the Followers of the Apocalypse Open Archive terminal database entry.

# Changelog

:cl:
- tweak: Intelligence now speeds up more medical actions, including CPR, healing, scans, surgery, defibrillators, injectors, and related medical do-afters.
- tweak: Intelligence now reduces lathe material costs, scaling up to a 25% discount at 10 INT.
- fix: Fixed Strength melee damage scaling so it applies properly to wielded and two-handed melee weapons.
- fix: Fixed Agility melee attack rate handling.
- tweak: Updated SPECIAL character screen details to show more accurate INT and Luck effects.
- add: Added the Followers of the Apocalypse Open Archive terminal database.