### PR TITLE
Add C-27 Combat Armor Set and Its Craft

### DIFF
--- a/Resources/Locale/en-US/_Misfits/lathe-blueprints.ftl
+++ b/Resources/Locale/en-US/_Misfits/lathe-blueprints.ftl
@@ -91,4 +91,5 @@ lathe-category-blueprint-mmi = MMI Schematic
 lathe-category-blueprint-c27-armor-generic = C-27 Armor (Generic)
 lathe-category-blueprint-c27-armor-ncr = C-27 Armor (NCR)
 lathe-category-blueprint-c27-armor-bos = C-27 Armor (Brotherhood)
+lathe-category-blueprint-c27-combat = C-27 Combat Armor
 

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_armor.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_armor.yml
@@ -93,6 +93,29 @@
   - type: ExplosionResistance
     damageCoefficient: 0.15 # #Misfits Tweak - 85% explosion reduction
 
+- type: entity
+  abstract: true
+  parent: BaseC27Armor
+  id: BaseC27ArmorCombat
+  components:
+  - type: Armor
+    modifiers:
+      coefficients: # #Misfits these vaules Should render this amor effective for ballistics , while being very weak to Energy, an side-grade for medium
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.50
+        Heat: 0.85
+  - type: Reflect
+    reflects:
+    - SmallCaliber
+    - MediumCaliber
+    reflectProb: 0.20
+    innate: true
+    spread: 90
+  - type: ClothingSpeedModifier
+    walkModifier: 0.85
+    sprintModifier: 0.85
+
 # === Concrete: Light tier ===
 
 - type: entity
@@ -197,3 +220,15 @@
     sprite: _Misfits/Clothing/OuterClothing/Armor/c27_heavy_bos.rsi
   - type: Clothing
     sprite: _Misfits/Clothing/OuterClothing/Armor/c27_heavy_bos.rsi
+
+# === Concrete: Combat Set ===
+- type: entity
+  parent: BaseC27ArmorCombat
+  id: ClothingC27ArmorCombatGeneric
+  name: c-27 combat armor plating
+  description: Following the development of modern combat armor, this adapted composite plating package was produced for C-27 units, improving ballistic protection while retaining some battlefield mobility.
+  components:
+  - type: Sprite
+    sprite: _Misfits/Clothing/OuterClothing/Armor/c27_combat_generic.rsi
+  - type: Clothing
+    sprite: _Misfits/Clothing/OuterClothing/Armor/c27_combat_generic.rsi

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_helmets.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/C27/c27_helmets.yml
@@ -60,6 +60,23 @@
   - type: ExplosionResistance
     damageCoefficient: 0.7
 
+- type: entity
+  abstract: true
+  parent: BaseC27Helmet
+  id: BaseC27HelmetCombat
+  components:
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.70
+        Heat: 0.85
+  - type: EyeProtection
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
+
+
 # === Concrete: Light tier ===
 
 - type: entity
@@ -164,3 +181,16 @@
     sprite: _Misfits/Clothing/Head/Helmets/c27_heavy_bos.rsi
   - type: Clothing
     sprite: _Misfits/Clothing/Head/Helmets/c27_heavy_bos.rsi
+
+# === Concrete: Combat Set ===
+
+- type: entity
+  parent: BaseC27HelmetCombat
+  id: ClothingC27HelmetCombatGeneric
+  name: c-27 combat helmet
+  description: Reinforced composite helmet for C-27 units with full-face visor and integrated optics, designed to pair with combat plating.
+  components:
+  - type: Sprite
+    sprite: _Misfits/Clothing/Head/Helmets/c27_combat_generic.rsi
+  - type: Clothing
+    sprite: _Misfits/Clothing/Head/Helmets/c27_combat_generic.rsi

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/c27_blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/c27_blueprints.yml
@@ -29,6 +29,8 @@
     - N14BPC27HelmetMediumGeneric
     - N14BPC27ArmorHeavyGeneric
     - N14BPC27HelmetHeavyGeneric
+    - N14BPC27ArmorCombatGeneric
+    - N14BPC27HelmetCombatGeneric
 
 - type: entity
   parent: N14BlueprintBase

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_c27.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_c27.yml
@@ -186,3 +186,31 @@
     Cloth: 100
     Thread: 65
     Plastic: 60
+
+# =====================================================================
+# C-27 Combat armor set
+# =====================================================================
+
+- type: latheRecipe
+  id: N14BPC27ArmorCombatGeneric
+  result: ClothingC27ArmorCombatGeneric
+  category: N14BlueprintC27CombatGeneric
+  completetime: 10
+  requiresBlueprint: true
+  materials:
+    Steel: 15000
+    Cloth: 200
+    Thread: 150
+    Plastic: 1050
+
+- type: latheRecipe
+  id: N14BPC27HelmetCombatGeneric
+  result: ClothingC27HelmetCombatGeneric
+  category: N14BlueprintC27CombatGeneric
+  completetime: 6
+  requiresBlueprint: true
+  materials:
+    Steel: 2000
+    Cloth: 500
+    Thread: 45
+    Plastic: 30

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/categories_blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/categories_blueprints.yml
@@ -335,3 +335,7 @@
   id: N14BlueprintC27ArmorBoS
   name: lathe-category-blueprint-c27-armor-bos
 
+- type: latheCategory
+  id: N14BlueprintC27CombatGeneric
+  name: lathe-category-blueprint-c27-combat
+


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Added a balistic focused sidegrade for medium/heavy armor for C-27 , whit the looks of combat armor
Sprites by Taro_varne 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This armor is as good as heavy for ballistics and whit a 15% slowdown instead of the 25% heavy , heavily hindered by its weakness to heat.
## Technical details
<!-- Summary of code changes for easier review. -->
Added armor/helmet into the c-27_armor.yml
Added a craft paired whit the generic blueprint
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="196" height="115" alt="image" src="https://github.com/user-attachments/assets/1109fe10-c481-490b-9d55-2dea5deb1d21" />
the middle one (duh)
<img width="572" height="570" alt="image" src="https://github.com/user-attachments/assets/2bf08cbe-874e-4119-925c-0a2dae7ebcda" />
Craft price of the armor
# Changelog
<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Taro_varne , EnderCastle 
- add: Added C-27 Combat armor Set
- add: Added C-27 Combat armor Craft onto the Generic Blueprint
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
