### PR TITLE
Minor Legion Buff and Townie Love.

### DIFF
--- a/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
@@ -169,10 +169,9 @@ undecided-loadout-category-recruit-base-name = Regular Legionary Recruit Kit
 undecided-loadout-category-recruit-base-description =
     A box with everything needed for a novice warrior.
     Contains: 1 light legion armor, 1 spear quiver belt,
-    1 9mm SMG, 2 SMG magazines (9mm),
-    1 box of ammunition (9mm), 1 legion buckler,
-    1 tribal machete, 1 healing powder,
-    2 K-rations, and 1 ceramic flask.
+    1 M3A1 grease gun, 2 .45 SMG magazines,
+    1 legion buckler, 1 tribal machete,
+    1 healing powder, 2 K-rations, and 1 ceramic flask.
 
 undecided-loadout-category-recruit-spear-name = Legionary Recruit Spearman Kit
 undecided-loadout-category-recruit-spear-description =

--- a/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
@@ -1030,10 +1030,9 @@
     items:
       - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: ClothingBeltQuiverSpear
-      - id: N14WeaponSMG9mm
-      - id: N14MagazineSMG9mm
+      - id: N14WeaponSMGGreaseGun
+      - id: Magazine45SubMachineGun
         amount: 2
-      - id: MagazineBox9mm
       - id: N14TribalMachete
       - id: N14LegionnaireBuckler
       - id: N14HealingPowder #Misfits Change /Tweak/: replaces dirty stimpak, Legion uses tribal medicine

--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -51,7 +51,7 @@
           TribalShaman: [ 3, 3 ] # #Misfits Change - renamed from TribalHealer
           TownMayor: [ 1, 1 ]
           TownSheriff: [ 1, 1 ]
-          TownDeputy: [ 1, 2 ]
+          TownDeputy: [ 4, 4 ]
           # TownDoctor: [ 1, 1 ] # #Misfits Tweak - disabled; FoTA FollowerDoctor slots replace town medical coverage.
           TownMechanic: [ 2, 2 ]
           TownShopkeeper: [ 1, 1 ]

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/LMGs/LMGs.yml
@@ -290,8 +290,8 @@
     minAngle: -20 # Corvax-Change
     maxAngle: -45 # Corvax-Change
   - type: Gun
-    minAngle: 24
-    maxAngle: 60
+    minAngle: 22
+    maxAngle: 50
     angleIncrease: 4
     angleDecay: 16
     fireRate: 3.5 # Corvax-Change
@@ -353,8 +353,8 @@
     minAngle: -21 
     maxAngle: -40 
   - type: Gun
-    minAngle: 24
-    maxAngle: 60
+    minAngle: 22
+    maxAngle: 50
     angleIncrease: 4
     angleDecay: 16
     fireRate: 4


### PR DESCRIPTION
## About the PR
Buffed M60 to be a little more accurate, made bren much more accurate
Gave recruits the M3A1 grease gun instead of the dogass 9mm SMG from hell.
Added 2 slots to townie guard. praise be. millions must town.

## Why / Balance
NCR has .50 specialists and service rifles en mass back. legion is getting some love in return.
Town guard is such a limited role, why? their kit lost the HMG over a month ago. they can have some slots.

## Technical details
yml and ftl

## Media

https://github.com/user-attachments/assets/d7518092-1f84-4f12-80e9-4448d94f2182

# Changelog

:cl: Billy
- tweak: small legion buffs 
- tweak: more town guard slots billions must town
- tweak: buffed bren to be a little more accurate.