### PR TITLE
I'm Back

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -2503,7 +2503,7 @@ namespace Content.Client.Lobby.UI
                 SpecialStat.Strength => GetStrengthEffectDetails(value, tuning),
                 SpecialStat.Perception => GetPerceptionEffectDetails(value, tuning),
                 SpecialStat.Endurance => GetEnduranceEffectDetails(value, tuning),
-                SpecialStat.Charisma => GetCharismaEffectDetails(value),
+                SpecialStat.Charisma => GetCharismaEffectDetails(value, tuning),
                 SpecialStat.Intelligence => GetIntelligenceEffectDetails(value, tuning),
                 SpecialStat.Agility => GetAgilityEffectDetails(value, tuning),
                 SpecialStat.Luck => GetLuckEffectDetails(value, tuning),
@@ -2522,59 +2522,65 @@ namespace Content.Client.Lobby.UI
         {
             var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
             var melee = delta * tuning.StrengthMeleeDamageMultiplierPerPoint;
-            var carry = SharedSpecialSystem.GetCurvedEffectScale(
+            var unarmed = delta * tuning.StrengthUnarmedDamageMultiplierPerPoint;
+            var carry = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                -tuning.StrengthCarryPullSpeedPenaltyAtOne,
-                tuning.StrengthCarryPullSpeedBonusAtTen);
+                tuning.StrengthCarryPullSpeedMultiplierPerPoint);
+            var duffel = value >= 7
+                ? ", ignores duffel bag slowdown"
+                : string.Empty;
 
-            return $"melee damage {FormatSignedPercent(melee)}, carry/pull speed {FormatSignedPercent(carry)}.";
+            return $"melee damage {FormatSignedPercent(melee)}, unarmed damage {FormatSignedPercent(unarmed)}, carry/pull speed {FormatSignedPercent(carry)}{duffel}.";
         }
 
         private static string GetPerceptionEffectDetails(int value, SpecialTuningPrototype tuning)
         {
             var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
-            var spread = SharedSpecialSystem.GetCurvedEffectScale(
+            var spread = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                tuning.PerceptionSpreadPenaltyAtOne,
-                -tuning.PerceptionSpreadReductionAtTen);
-            var heavyGun = SharedSpecialSystem.GetCurvedEffectScale(
+                -tuning.PerceptionSpreadMultiplierPerPoint);
+            var heavyGun = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                tuning.PerceptionHeavyGunPenaltyAtOne,
-                -tuning.PerceptionHeavyGunReductionAtTen);
-            var fireDelay = SharedSpecialSystem.GetCurvedEffectScale(
+                -tuning.PerceptionHeavyGunMultiplierPerPoint);
+            var fireDelay = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                tuning.PerceptionFireDelayPenaltyAtOne,
-                -tuning.PerceptionFireDelayReductionAtTen);
+                -tuning.PerceptionFireDelayMultiplierPerPoint);
+            var mineDelay = SharedSpecialSystem.GetCurvedEffectModifier(
+                delta,
+                -tuning.PerceptionMineDelayMultiplierPerPoint);
 
-            return $"gun spread/recoil {FormatSignedPercent(spread)}, heavy gun spread/recoil {FormatSignedPercent(heavyGun)}, gun fire delay {FormatSignedPercent(fireDelay)}.";
+            return $"gun spread/recoil {FormatSignedPercent(spread)}, heavy gun spread/recoil {FormatSignedPercent(heavyGun)}, gun fire delay {FormatSignedPercent(fireDelay)}, mine arm/disarm delay {FormatSignedPercent(mineDelay)}.";
         }
 
         private static string GetEnduranceEffectDetails(int value, SpecialTuningPrototype tuning)
         {
             var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
-            var health = SharedSpecialSystem.GetCurvedEffectScale(
+            var health = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                -tuning.EnduranceHealthPenaltyAtOne,
-                tuning.EnduranceHealthBonusAtTen);
-            var needs = SharedSpecialSystem.GetCurvedEffectScale(
+                tuning.EnduranceHealthModifierPerPoint);
+            var needs = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                tuning.EnduranceNeedDecayPenaltyAtOne,
-                -tuning.EnduranceNeedDecayReductionAtTen);
-            var stamina = SharedSpecialSystem.GetCurvedEffectScale(
+                -tuning.EnduranceNeedDecayMultiplierPerPoint);
+            var stamina = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                -tuning.EnduranceStaminaRecoveryPenaltyAtOne,
-                tuning.EnduranceStaminaRecoveryBonusAtTen);
-            var toxin = SharedSpecialSystem.GetCurvedEffectScale(
+                tuning.EnduranceStaminaRecoveryMultiplierPerPoint);
+            var toxin = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                tuning.EnduranceToxinDamagePenaltyAtOne,
-                -tuning.EnduranceToxinDamageReductionAtTen);
+                -tuning.EnduranceToxinDamageMultiplierPerPoint);
 
             return $"health thresholds {FormatSignedNumber(health)}, hunger/thirst decay {FormatSignedPercent(needs)}, stamina recovery {FormatSignedPercent(stamina)}, poison/rad damage {FormatSignedPercent(toxin)}.";
         }
 
-        private static string GetCharismaEffectDetails(int value)
+        private static string GetCharismaEffectDetails(int value, SpecialTuningPrototype tuning)
         {
+            var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
             var loadout = SharedSpecialSystem.GetCharismaLoadoutPointModifier(value);
+            var buyPrices = SharedSpecialSystem.GetCurvedEffectModifier(
+                delta,
+                -tuning.CharismaTradeMultiplierPerPoint);
+            var sellPayouts = SharedSpecialSystem.GetCurvedEffectModifier(
+                delta,
+                tuning.CharismaTradeMultiplierPerPoint);
             var social = value switch
             {
                 <= 2 => "awkward examine text and speech quirks",
@@ -2583,7 +2589,7 @@ namespace Content.Client.Lobby.UI
                 _ => "no social penalty",
             };
 
-            return $"loadout points {FormatSignedInt(loadout)}, {social}.";
+            return $"loadout points {FormatSignedInt(loadout)}, buy prices {FormatSignedPercent(buyPrices)}, sell payouts {FormatSignedPercent(sellPayouts)}, {social}.";
         }
 
         private static string GetIntelligenceEffectDetails(int value, SpecialTuningPrototype tuning)
@@ -2598,6 +2604,7 @@ namespace Content.Client.Lobby.UI
             var extra = value switch
             {
                 <= 1 => ", low-intelligence accent",
+                >= 10 => ", detailed chemical scans, medical HUD",
                 >= 8 => ", detailed chemical scans",
                 _ => string.Empty,
             };
@@ -2608,14 +2615,12 @@ namespace Content.Client.Lobby.UI
         private static string GetAgilityEffectDetails(int value, SpecialTuningPrototype tuning)
         {
             var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
-            var move = SharedSpecialSystem.GetCurvedEffectScale(
+            var move = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                -tuning.AgilityMovementSpeedPenaltyAtOne,
-                tuning.AgilityMovementSpeedBonusAtTen);
-            var actionDelay = SharedSpecialSystem.GetCurvedEffectScale(
+                tuning.AgilityMovementSpeedMultiplierPerPoint);
+            var actionDelay = SharedSpecialSystem.GetCurvedEffectModifier(
                 delta,
-                tuning.AgilityActionDelayPenaltyAtOne,
-                -tuning.AgilityActionDelayReductionAtTen);
+                -tuning.AgilityActionDelayMultiplierPerPoint);
 
             return $"movement speed {FormatSignedPercent(move)}, melee attack delay {FormatSignedPercent(actionDelay)}.";
         }
@@ -2623,8 +2628,7 @@ namespace Content.Client.Lobby.UI
         private static string GetLuckEffectDetails(int value, SpecialTuningPrototype tuning)
         {
             var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
-            var maxDelta = SharedSpecialSystem.GetCurvedEffectDelta(SpecialProfile.Maximum);
-            var shotCrit = Math.Clamp(tuning.LuckSingleShotCriticalChanceAtTen * delta / maxDelta, 0f, 1f);
+            var shotCrit = Math.Clamp(delta * tuning.LuckSingleShotCriticalChancePerPoint, 0f, 1f);
             var revolverCrit = Math.Clamp(shotCrit * 2f, 0f, 1f);
             var luckyLoot = Math.Clamp(delta * tuning.LuckLootChancePerPoint, 0f, 1f);
             var clumsy = value switch
@@ -2659,11 +2663,9 @@ namespace Content.Client.Lobby.UI
 
         private static float GetIntelligenceLatheTimeModifier(int value, SpecialTuningPrototype tuning)
         {
-            var minMultiplier = Math.Clamp(tuning.IntelligenceLatheMinimumTimeMultiplierAtTen, 0.1f, 1f);
-            var multiplier = value >= SpecialProfile.DefaultValue
-                ? 1f - (1f - minMultiplier) * (value - SpecialProfile.DefaultValue) /
-                    (SpecialProfile.Maximum - SpecialProfile.DefaultValue)
-                : 1f + (SpecialProfile.DefaultValue - value) * 0.15f;
+            var delta = SharedSpecialSystem.GetCurvedEffectDelta(value);
+            var modifier = -delta * tuning.IntelligenceLatheTimeMultiplierPerPoint;
+            var multiplier = 1f + modifier;
 
             return MathF.Max(0.1f, multiplier) - 1f;
         }
@@ -2673,7 +2675,7 @@ namespace Content.Client.Lobby.UI
             return SharedSpecialSystem.GetIntelligenceLatheMaterialUseMultiplier(
                 value,
                 1f,
-                tuning.IntelligenceLatheMaterialDiscountAtTen) - 1f;
+                tuning.IntelligenceLatheMaterialUseMultiplierPerPoint) - 1f;
         }
 
         private static string FormatSignedPercent(float value)

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -2526,12 +2526,8 @@ namespace Content.Client.Lobby.UI
                 delta,
                 -tuning.StrengthCarryPullSpeedPenaltyAtOne,
                 tuning.StrengthCarryPullSpeedBonusAtTen);
-            var heavyGun = SharedSpecialSystem.GetCurvedEffectScale(
-                delta,
-                tuning.StrengthHeavyGunPenaltyAtOne,
-                -tuning.StrengthHeavyGunReductionAtTen);
 
-            return $"melee damage {FormatSignedPercent(melee)}, carry/pull speed {FormatSignedPercent(carry)}, heavy gun spread/recoil {FormatSignedPercent(heavyGun)}.";
+            return $"melee damage {FormatSignedPercent(melee)}, carry/pull speed {FormatSignedPercent(carry)}.";
         }
 
         private static string GetPerceptionEffectDetails(int value, SpecialTuningPrototype tuning)
@@ -2541,12 +2537,16 @@ namespace Content.Client.Lobby.UI
                 delta,
                 tuning.PerceptionSpreadPenaltyAtOne,
                 -tuning.PerceptionSpreadReductionAtTen);
+            var heavyGun = SharedSpecialSystem.GetCurvedEffectScale(
+                delta,
+                tuning.PerceptionHeavyGunPenaltyAtOne,
+                -tuning.PerceptionHeavyGunReductionAtTen);
             var fireDelay = SharedSpecialSystem.GetCurvedEffectScale(
                 delta,
                 tuning.PerceptionFireDelayPenaltyAtOne,
                 -tuning.PerceptionFireDelayReductionAtTen);
 
-            return $"gun spread/recoil {FormatSignedPercent(spread)}, gun fire delay {FormatSignedPercent(fireDelay)}.";
+            return $"gun spread/recoil {FormatSignedPercent(spread)}, heavy gun spread/recoil {FormatSignedPercent(heavyGun)}, gun fire delay {FormatSignedPercent(fireDelay)}.";
         }
 
         private static string GetEnduranceEffectDetails(int value, SpecialTuningPrototype tuning)
@@ -2936,6 +2936,9 @@ namespace Content.Client.Lobby.UI
             _traits.Clear();
             foreach (var trait in _prototypeManager.EnumeratePrototypes<TraitPrototype>())
             {
+                if (trait.Hidden)
+                    continue;
+
                 var usable = _characterRequirementsSystem.CheckRequirementsValid(
                     trait.Requirements,
                     highJob,

--- a/Content.Server/Carrying/CarryingSystem.cs
+++ b/Content.Server/Carrying/CarryingSystem.cs
@@ -33,6 +33,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Nyanotrasen.Item.PseudoItem;
 using Content.Shared.Storage;
 using Content.Shared.Inventory; // #Misfits Change Add: needed for IsWearingPowerArmor check
+using Content.Shared._Misfits.Carrying; // #Misfits Add: Fireman Carry trait marker
 using Content.Shared._Misfits.PowerArmor; // #Misfits Change Add: N14PowerArmorComponent for power armor carry restriction
 using Content.Server._Misfits.Grabbing.Components; // #Misfits Change Add: BeingDoubleGrabbedComponent for choke-carry throw emote
 using Robust.Shared.Map.Components;
@@ -346,6 +347,13 @@ namespace Content.Server.Carrying
 
         private void ApplyCarrySlowdown(EntityUid carrier, EntityUid carried)
         {
+            if (HasComp<CanFiremanCarryComponent>(carrier))
+            {
+                var firemanSlowdown = EnsureComp<CarryingSlowdownComponent>(carrier);
+                _slowdown.SetModifier(carrier, 1f, 1f, firemanSlowdown);
+                return;
+            }
+
             var massRatio = _contests.MassContest(carrier, carried, true);
             var massRatioSq = MathF.Pow(massRatio, 2);
             var modifier = 1 - 0.15f / massRatioSq;

--- a/Content.Server/LandMines/LandMineSystem.cs
+++ b/Content.Server/LandMines/LandMineSystem.cs
@@ -242,11 +242,10 @@ public sealed class LandMineSystem : EntitySystem
     private TimeSpan GetPerceptionMineDelay(EntityUid user, float baseSeconds)
     {
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             user,
             SpecialStat.Perception,
-            tuning.PerceptionMineDelayPenaltyAtOne,
-            -tuning.PerceptionMineDelayReductionAtTen);
+            -tuning.PerceptionMineDelayMultiplierPerPoint);
         var seconds = MathF.Max(0.5f, baseSeconds * (1f + modifier));
 
         return TimeSpan.FromSeconds(seconds);

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -605,11 +605,9 @@ namespace Content.Server.Lathe
 
             var intelligence = _special.GetEffective(user.Value, SpecialStat.Intelligence, special);
             var tuning = _special.GetTuning();
-            var minMultiplier = Math.Clamp(tuning.IntelligenceLatheMinimumTimeMultiplierAtTen, 0.1f, 1f);
-            var multiplier = intelligence >= SpecialProfile.DefaultValue
-                ? 1f - (1f - minMultiplier) * (intelligence - SpecialProfile.DefaultValue) /
-                    (SpecialProfile.Maximum - SpecialProfile.DefaultValue)
-                : 1f + (SpecialProfile.DefaultValue - intelligence) * 0.15f;
+            var delta = SharedSpecialSystem.GetCurvedEffectDelta(intelligence);
+            var modifier = -delta * tuning.IntelligenceLatheTimeMultiplierPerPoint;
+            var multiplier = 1f + modifier;
 
             return baseTime * MathF.Max(0.1f, multiplier);
         }

--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -74,6 +74,9 @@ public sealed class TraitSystem : EntitySystem
                 return;
             }
 
+            if (traitPrototype.Hidden)
+                continue;
+
             if (!_characterRequirements.CheckRequirementsValid(
                 traitPrototype.Requirements,
                 jobPrototypeToUse,

--- a/Content.Server/_Misfits/Special/SpecialCombatSystem.cs
+++ b/Content.Server/_Misfits/Special/SpecialCombatSystem.cs
@@ -62,6 +62,10 @@ public sealed class SpecialCombatSystem : EntitySystem
 
         var damage = args.BaseDamage;
 
+        // Innate mob melee is unarmed. Use gentler Strength scaling than held weapons.
+        if (uid == args.User)
+            ApplyStrengthUnarmedModifier(args.User, ref damage, special);
+
         // Melee weapons use the same Luck outcome curve as ranged weapons.
         TryApplyLuckDamageOutcome(args.User, ref damage, special);
 
@@ -78,6 +82,18 @@ public sealed class SpecialCombatSystem : EntitySystem
             return;
 
         var multiplier = 1f + delta * tuning.StrengthMeleeDamageMultiplierPerPoint;
+        damage *= MathF.Max(0.1f, multiplier);
+    }
+
+    private void ApplyStrengthUnarmedModifier(EntityUid user, ref DamageSpecifier damage, SpecialComponent special)
+    {
+        var tuning = _special.GetTuning();
+        var delta = _special.GetCurvedEffectDelta(user, SpecialStat.Strength, special);
+
+        if (delta == 0f)
+            return;
+
+        var multiplier = 1f + delta * tuning.StrengthUnarmedDamageMultiplierPerPoint;
         damage *= MathF.Max(0.1f, multiplier);
     }
 
@@ -126,7 +142,7 @@ public sealed class SpecialCombatSystem : EntitySystem
         // Every hit rolls the full configured chance; magazine-fed weapons no
         // longer divide crit chance by ammo capacity.
         var delta = _special.GetCurvedEffectDelta(user, SpecialStat.Luck, special);
-        var shotChance = tuning.LuckSingleShotCriticalChanceAtTen * delta / SharedSpecialSystem.GetCurvedEffectDelta(SpecialProfile.Maximum);
+        var shotChance = delta * tuning.LuckSingleShotCriticalChancePerPoint;
 
         if (weapon != null && HasComp<RevolverAmmoProviderComponent>(weapon.Value))
             shotChance *= 2f;

--- a/Content.Server/_Misfits/SpecialStats/Components/SpecialAppliedMedicalHudComponent.cs
+++ b/Content.Server/_Misfits/SpecialStats/Components/SpecialAppliedMedicalHudComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server._Misfits.SpecialStats.Components;
+
+/// <summary>
+/// Tracks medical HUD components that were granted by high Intelligence.
+/// </summary>
+[RegisterComponent]
+public sealed partial class SpecialAppliedMedicalHudComponent : Component
+{
+    public bool AddedHealthBars;
+    public bool AddedHealthIcons;
+}

--- a/Content.Server/_Misfits/SpecialStats/LuckJunkBonusComponent.cs
+++ b/Content.Server/_Misfits/SpecialStats/LuckJunkBonusComponent.cs
@@ -9,17 +9,120 @@ namespace Content.Server._Misfits.SpecialStats;
 public sealed partial class LuckJunkBonusComponent : Component
 {
     [DataField]
-    public List<EntProtoId> LuckyItems = new()
+    public List<LuckyLootEntry> LuckyItems = new()
     {
-        "N14Stimpak",
-        "N14CurrencyCap",
-        "N14MagazinePistol10mm",
-        "N14MagazinePistol9mm",
+        new("N14CurrencyCap", LuckyLootRarity.Common),
+        new("N14CurrencyCap10", LuckyLootRarity.Common),
+        new("N14Stimpak", LuckyLootRarity.Common),
+        new("N14MagazinePistol22lr", LuckyLootRarity.Common),
+        new("N14MagazinePistol9mm", LuckyLootRarity.Common),
+        new("N14MagazinePistol10mm", LuckyLootRarity.Common),
+        new("MagazineBox22", LuckyLootRarity.Common),
+        new("MagazineBox9mm", LuckyLootRarity.Common),
+        new("MagazineBox10mm", LuckyLootRarity.Common),
+        new("MagazineBox20gauge", LuckyLootRarity.Common),
+        new("N14MagazineShotgun20", LuckyLootRarity.Common),
+        new("SpeedLoader9", LuckyLootRarity.Common),
+        new("SpeedLoader10", LuckyLootRarity.Common),
+
+        new("N14CurrencyCap50", LuckyLootRarity.Uncommon),
+        new("N14RadXPill", LuckyLootRarity.Uncommon),
+        new("N14RadAwayBloodbag", LuckyLootRarity.Uncommon),
+        new("N14JunkToyNukaTruck", LuckyLootRarity.Uncommon),
+        new("N14HolotapeMisfitsRandom", LuckyLootRarity.Uncommon),
+        new("N14MagazineTesla", LuckyLootRarity.Uncommon),
+        new("N14MagazineTumblers", LuckyLootRarity.Uncommon),
+        new("N14MagazineGuns", LuckyLootRarity.Uncommon),
+        new("N14MagazineWasteland", LuckyLootRarity.Uncommon),
+        new("N14DrinkNukaColaQuartz", LuckyLootRarity.Uncommon),
+        new("N14DrinkNukaColaVictory", LuckyLootRarity.Uncommon),
+        new("N14MagazineAmerican180Drum", LuckyLootRarity.Uncommon),
+        new("N14MagazineSMG9mm", LuckyLootRarity.Uncommon),
+        new("N14MagazineSMG10mm", LuckyLootRarity.Uncommon),
+        new("Magazine45SubMachineGun", LuckyLootRarity.Uncommon),
+        new("N14MagazinePistol12mm", LuckyLootRarity.Uncommon),
+        new("N14MagazineSMG12mm", LuckyLootRarity.Uncommon),
+        new("N14MagazineShotgun12", LuckyLootRarity.Uncommon),
+        new("MagazineBox12gauge", LuckyLootRarity.Uncommon),
+        new("MagazineBox12", LuckyLootRarity.Uncommon),
+        new("MagazineBox44", LuckyLootRarity.Uncommon),
+        new("MagazineBox45", LuckyLootRarity.Uncommon),
+        new("N14MagazinePistol45", LuckyLootRarity.Uncommon),
+        new("N14MagazinePistol44", LuckyLootRarity.Uncommon),
+        new("MagazineBox556", LuckyLootRarity.Uncommon),
+        new("Magazine556Rifle", LuckyLootRarity.Uncommon),
+        new("LongMagazine556Rifle", LuckyLootRarity.Uncommon),
+        new("MagazineBox762", LuckyLootRarity.Uncommon),
+        new("Magazine762Rifle", LuckyLootRarity.Uncommon),
+        new("Magazine762AmmoShort", LuckyLootRarity.Uncommon),
+        new("N14PowerCellSmall", LuckyLootRarity.Uncommon),
+        new("N14MicrofusionCell", LuckyLootRarity.Uncommon),
+        new("N14ElectronChargePack", LuckyLootRarity.Uncommon),
+        new("N14PlasmaCartridge", LuckyLootRarity.Uncommon),
+        new("SpeedLoader44", LuckyLootRarity.Uncommon),
+
+        new("N14DrinkNukaColaQuantum", LuckyLootRarity.Rare),
+        new("N14HandheldHealthAnalyzer", LuckyLootRarity.Rare),
+        new("N14MagazineSMG9mmDrum", LuckyLootRarity.Rare),
+        new("LMGMagazine556Rifle", LuckyLootRarity.Rare),
+        new("Magazine762AmmoBelt", LuckyLootRarity.Rare),
+        new("MagazineBox308", LuckyLootRarity.Rare),
+        new("Magazine308Rifle", LuckyLootRarity.Rare),
+        new("Magazine308RifleLong", LuckyLootRarity.Rare),
+        new("ClipMagazine308Rifle", LuckyLootRarity.Rare),
+        new("Magazine308RifleSniper", LuckyLootRarity.Rare),
+        new("MagazineBox45-70", LuckyLootRarity.Rare),
+        new("SpeedLoader45-70", LuckyLootRarity.Rare),
+        new("SpeedLoader45-70Tube", LuckyLootRarity.Rare),
+        new("MagazineBox50", LuckyLootRarity.Rare),
+        new("N14Magazine50AMR", LuckyLootRarity.Rare),
+        new("N14MagazineMinigun5mm", LuckyLootRarity.Rare),
+        new("N14FusionCore", LuckyLootRarity.Rare),
+        new("N14PlasmaCartridgeMultiplas", LuckyLootRarity.Rare),
+        new("N14PlasmaShell", LuckyLootRarity.Rare),
+        new("40mmGrenadeFrag", LuckyLootRarity.Rare),
+        new("40mmGrenadeFire", LuckyLootRarity.Rare),
+        new("CartridgeMissile", LuckyLootRarity.Rare),
+        new("MagazineBox50HEIAP", LuckyLootRarity.Rare),
+        new("N14Magazine50AMRHEIAP", LuckyLootRarity.Rare),
+
+        new("N14SuperStimpak", LuckyLootRarity.VeryRare),
+
+        new("N14WastelanderPipboy", LuckyLootRarity.Legendary),
     };
 
     /// <summary>
     /// Additional roll-success probability per Luck point above the default of 5.
     /// </summary>
     [DataField]
-    public float ChancePerLuckPoint = 0.03f;
+    public float ChancePerLuckPoint = 0.06666667f;
+}
+
+public enum LuckyLootRarity : byte
+{
+    Common,
+    Uncommon,
+    Rare,
+    VeryRare,
+    Legendary,
+}
+
+[DataDefinition]
+public sealed partial class LuckyLootEntry
+{
+    public LuckyLootEntry()
+    {
+    }
+
+    public LuckyLootEntry(EntProtoId id, LuckyLootRarity rarity)
+    {
+        Id = id;
+        Rarity = rarity;
+    }
+
+    [DataField(required: true)]
+    public EntProtoId Id;
+
+    [DataField]
+    public LuckyLootRarity Rarity = LuckyLootRarity.Common;
 }

--- a/Content.Server/_Misfits/SpecialStats/SpecialIntelligenceHudSystem.cs
+++ b/Content.Server/_Misfits/SpecialStats/SpecialIntelligenceHudSystem.cs
@@ -1,0 +1,93 @@
+using Content.Server._Misfits.SpecialStats.Components;
+using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Components;
+using Content.Shared._Misfits.SpecialStats;
+using Content.Shared.Overlays;
+
+namespace Content.Server._Misfits.SpecialStats;
+
+/// <summary>
+/// Grants a medical HUD effect to characters with maximum Intelligence.
+/// </summary>
+public sealed class SpecialIntelligenceHudSystem : EntitySystem
+{
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
+
+    private const int MedicalHudIntelligenceThreshold = 10;
+    private const string BiologicalDamageContainer = "Biological";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SpecialChangedEvent>(OnSpecialChanged);
+        SubscribeLocalEvent<SpecialStatsReadyEvent>(OnStatsReady);
+        SubscribeLocalEvent<SpecialShutdownEvent>(OnSpecialShutdown);
+    }
+
+    private void OnSpecialChanged(ref SpecialChangedEvent args)
+    {
+        if (TryComp<SpecialComponent>(args.ChangedEntity, out var special))
+            ApplyMedicalHud((args.ChangedEntity, special));
+    }
+
+    private void OnStatsReady(ref SpecialStatsReadyEvent args)
+    {
+        if (TryComp<SpecialComponent>(args.Entity, out var special))
+            ApplyMedicalHud((args.Entity, special));
+    }
+
+    private void OnSpecialShutdown(ref SpecialShutdownEvent args)
+    {
+        ClearMedicalHud(args.Entity);
+    }
+
+    private void ApplyMedicalHud(Entity<SpecialComponent> ent)
+    {
+        if (_special.GetEffective(ent.Owner, SpecialStat.Intelligence, ent.Comp) >= MedicalHudIntelligenceThreshold)
+            EnsureMedicalHud(ent.Owner);
+        else
+            ClearMedicalHud(ent.Owner);
+    }
+
+    private void EnsureMedicalHud(EntityUid uid)
+    {
+        var applied = EnsureComp<SpecialAppliedMedicalHudComponent>(uid);
+
+        if (!HasComp<ShowHealthBarsComponent>(uid))
+        {
+            var bars = EnsureComp<ShowHealthBarsComponent>(uid);
+            EnsureBiologicalContainer(bars.DamageContainers);
+            Dirty(uid, bars);
+            applied.AddedHealthBars = true;
+        }
+
+        if (!HasComp<ShowHealthIconsComponent>(uid))
+        {
+            var icons = EnsureComp<ShowHealthIconsComponent>(uid);
+            EnsureBiologicalContainer(icons.DamageContainers);
+            Dirty(uid, icons);
+            applied.AddedHealthIcons = true;
+        }
+    }
+
+    private void ClearMedicalHud(EntityUid uid)
+    {
+        if (!TryComp<SpecialAppliedMedicalHudComponent>(uid, out var applied))
+            return;
+
+        if (applied.AddedHealthBars)
+            RemComp<ShowHealthBarsComponent>(uid);
+
+        if (applied.AddedHealthIcons)
+            RemComp<ShowHealthIconsComponent>(uid);
+
+        RemComp<SpecialAppliedMedicalHudComponent>(uid);
+    }
+
+    private static void EnsureBiologicalContainer(ICollection<string> damageContainers)
+    {
+        if (!damageContainers.Contains(BiologicalDamageContainer))
+            damageContainers.Add(BiologicalDamageContainer);
+    }
+}

--- a/Content.Server/_Misfits/SpecialStats/SpecialLuckSystem.cs
+++ b/Content.Server/_Misfits/SpecialStats/SpecialLuckSystem.cs
@@ -1,6 +1,10 @@
 using Content.Shared._Misfits.Special;
 using Content.Shared._Misfits.Special.Components;
 using Content.Shared.GameTicking;
+using Content.Shared.Random.Helpers;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server._Misfits.SpecialStats;
@@ -12,6 +16,16 @@ public sealed class SpecialLuckSystem : EntitySystem
 {
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedSpecialSystem _special = default!;
+    [Dependency] private readonly SharedStorageSystem _storage = default!;
+
+    private static readonly Dictionary<LuckyLootRarity, float> RarityWeights = new()
+    {
+        [LuckyLootRarity.Common] = 100f,
+        [LuckyLootRarity.Uncommon] = 45f,
+        [LuckyLootRarity.Rare] = 18f,
+        [LuckyLootRarity.VeryRare] = 6f,
+        [LuckyLootRarity.Legendary] = 1f,
+    };
 
     private readonly Dictionary<EntityUid, HashSet<EntityUid>> _alreadyRolled = new();
 
@@ -56,7 +70,36 @@ public sealed class SpecialLuckSystem : EntitySystem
         if (ent.Comp.LuckyItems.Count == 0)
             return;
 
-        var chosenProto = _random.Pick(ent.Comp.LuckyItems);
-        Spawn(chosenProto, Transform(ent.Owner).Coordinates);
+        if (!TryPickLuckyItem(ent.Comp, out var chosenProto))
+            return;
+
+        if (!TryComp<StorageComponent>(ent.Owner, out var storage))
+            return;
+
+        var spawned = Spawn(chosenProto, Transform(ent.Owner).Coordinates);
+        if (!_storage.Insert(ent.Owner, spawned, out _, out _, actor, storage, playSound: false))
+            Del(spawned);
+    }
+
+    private bool TryPickLuckyItem(LuckJunkBonusComponent component, out EntProtoId chosenProto)
+    {
+        var weights = new Dictionary<EntProtoId, float>();
+
+        foreach (var entry in component.LuckyItems)
+        {
+            if (!RarityWeights.TryGetValue(entry.Rarity, out var weight) || weight <= 0f)
+                continue;
+
+            weights[entry.Id] = weight;
+        }
+
+        if (weights.Count == 0)
+        {
+            chosenProto = default;
+            return false;
+        }
+
+        chosenProto = _random.Pick(weights);
+        return true;
     }
 }

--- a/Content.Server/_NC/Trade/Store/Runtime/Services/NcStoreLogicSystem.Services.cs
+++ b/Content.Server/_NC/Trade/Store/Runtime/Services/NcStoreLogicSystem.Services.cs
@@ -50,11 +50,10 @@ public sealed partial class NcStoreLogicSystem
             return amount;
 
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             user,
             SpecialStat.Charisma,
-            buying ? tuning.CharismaTradePenaltyAtOne : -tuning.CharismaTradePenaltyAtOne,
-            buying ? -tuning.CharismaTradeBonusAtTen : tuning.CharismaTradeBonusAtTen,
+            buying ? -tuning.CharismaTradeMultiplierPerPoint : tuning.CharismaTradeMultiplierPerPoint,
             special);
         var multiplier = MathF.Max(0.05f, 1f + modifier);
         var adjusted = (int) Math.Round(amount * multiplier, MidpointRounding.AwayFromZero);

--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -1,3 +1,7 @@
+using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Components;
+using Content.Shared._Misfits.SpecialStats;
+using Content.Shared._Misfits.SpecialStats.Components;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Examine;
 using Content.Shared.Inventory;
@@ -21,6 +25,7 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly ItemToggleSystem _toggle = default!;
     [Dependency] private readonly SharedPowerCellSystem _powerCell = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     public override void Initialize()
     {
@@ -60,7 +65,33 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
     private void OnRefreshMoveSpeed(EntityUid uid, ClothingSpeedModifierComponent component, InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
     {
         if (_toggle.IsActivated(uid))
-            args.Args.ModifySpeed(component.WalkModifier, component.SprintModifier);
+        {
+            var walkModifier = component.WalkModifier;
+            var sprintModifier = component.SprintModifier;
+
+            if (ShouldIgnoreStrengthSlowdown(uid))
+            {
+                walkModifier = MathF.Max(walkModifier, 1f);
+                sprintModifier = MathF.Max(sprintModifier, 1f);
+            }
+
+            args.Args.ModifySpeed(walkModifier, sprintModifier);
+        }
+    }
+
+    private bool ShouldIgnoreStrengthSlowdown(EntityUid clothing)
+    {
+        if (!TryComp<StrengthIgnoreClothingSlowdownComponent>(clothing, out var ignore) ||
+            !_container.TryGetContainingContainer((clothing, null, null), out var container))
+        {
+            return false;
+        }
+
+        var wearer = container.Owner;
+        if (!TryComp<SpecialComponent>(wearer, out var special))
+            return false;
+
+        return _special.GetEffective(wearer, SpecialStat.Strength, special) >= ignore.MinimumStrength;
     }
 
     private void OnClothingVerbExamine(EntityUid uid, ClothingSpeedModifierComponent component, GetVerbsEvent<ExamineVerb> args)

--- a/Content.Shared/Item/HeldSpeedModifierSystem.cs
+++ b/Content.Shared/Item/HeldSpeedModifierSystem.cs
@@ -1,3 +1,7 @@
+using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Components;
+using Content.Shared._Misfits.SpecialStats;
+using Content.Shared._Misfits.SpecialStats.Components;
 using Content.Shared.Clothing;
 using Content.Shared.Hands;
 using Content.Shared.Movement.Systems;
@@ -10,6 +14,7 @@ namespace Content.Shared.Item;
 public sealed class HeldSpeedModifierSystem : EntitySystem
 {
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -39,6 +44,23 @@ public sealed class HeldSpeedModifierSystem : EntitySystem
             sprintMod = clothingSpeedModifier.SprintModifier;
         }
 
+        if (ShouldIgnoreStrengthSlowdown(args.Holder, uid))
+        {
+            walkMod = MathF.Max(walkMod, 1f);
+            sprintMod = MathF.Max(sprintMod, 1f);
+        }
+
         args.Args.ModifySpeed(walkMod, sprintMod);
+    }
+
+    private bool ShouldIgnoreStrengthSlowdown(EntityUid user, EntityUid held)
+    {
+        if (!TryComp<StrengthIgnoreClothingSlowdownComponent>(held, out var ignore) ||
+            !TryComp<SpecialComponent>(user, out var special))
+        {
+            return false;
+        }
+
+        return _special.GetEffective(user, SpecialStat.Strength, special) >= ignore.MinimumStrength;
     }
 }

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using Content.Shared._Misfits.Carrying;
 using Content.Shared._Misfits.SpecialStats;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Logs;
@@ -16,6 +17,7 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Projectiles;
 using Content.Shared.Pulling.Events;
 using Content.Shared.Standing;
@@ -276,6 +278,11 @@ public sealed class PullingSystem : EntitySystem
 
     private void OnRefreshMovespeed(EntityUid uid, PullerComponent component, RefreshMovementSpeedModifiersEvent args)
     {
+        if (component.Pulling != null &&
+            HasComp<CanFiremanCarryComponent>(uid) &&
+            HasComp<MobStateComponent>(component.Pulling.Value))
+            return;
+
         args.ModifySpeed(component.WalkSpeedModifier, component.SprintSpeedModifier);
 
         if (component.Pulling == null)

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -591,6 +591,7 @@ public sealed partial class HumanoidCharacterProfile : ICharacterProfile
 
         var traits = TraitPreferences
             .Where(prototypeManager.HasIndex<TraitPrototype>)
+            .Where(t => !prototypeManager.Index<TraitPrototype>(t).Hidden)
             .Distinct()
             .ToList();
 

--- a/Content.Shared/Traits/Prototypes/TraitPrototype.cs
+++ b/Content.Shared/Traits/Prototypes/TraitPrototype.cs
@@ -28,6 +28,11 @@ public sealed partial class TraitPrototype : IPrototype
     [DataField]
     public int Points = 0;
 
+    /// <summary>
+    ///     Hidden traits can be granted by systems or jobs, but are not valid character-creation picks.
+    /// </summary>
+    [DataField]
+    public bool Hidden = false;
 
     [DataField]
     public List<CharacterRequirement> Requirements = new();

--- a/Content.Shared/_Misfits/Carrying/CanFiremanCarryComponent.cs
+++ b/Content.Shared/_Misfits/Carrying/CanFiremanCarryComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Misfits.Carrying;
+
+/// <summary>
+/// Allows carrying and dragging mobs without applying the normal carry/pull slowdown.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CanFiremanCarryComponent : Component;

--- a/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
+++ b/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
@@ -19,104 +19,65 @@ public sealed partial class SpecialTuningPrototype : IPrototype
     [DataField("strengthMeleeDamageMultiplierPerPoint")]
     public float StrengthMeleeDamageMultiplierPerPoint = 0.02f;
 
-    [DataField("strengthCarryPullSpeedPenaltyAtOne")]
-    public float StrengthCarryPullSpeedPenaltyAtOne = 0.08f;
+    [DataField("strengthUnarmedDamageMultiplierPerPoint")]
+    public float StrengthUnarmedDamageMultiplierPerPoint = 0.03333333f;
 
-    [DataField("strengthCarryPullSpeedBonusAtTen")]
-    public float StrengthCarryPullSpeedBonusAtTen = 0.10f;
+    [DataField("strengthCarryPullSpeedMultiplierPerPoint")]
+    public float StrengthCarryPullSpeedMultiplierPerPoint = 0.01333333f;
 
     // Perception: ranged accuracy, heavy gun handling, mining speed, and fire delay.
-    [DataField("perceptionSpreadReductionPerPoint")]
-    public float PerceptionSpreadReductionPerPoint = 0.004f;
+    [DataField("perceptionSpreadMultiplierPerPoint")]
+    public float PerceptionSpreadMultiplierPerPoint = 0.03333333f;
 
-    [DataField("perceptionSpreadPenaltyAtOne")]
-    public float PerceptionSpreadPenaltyAtOne = 0.15f;
+    [DataField("perceptionHeavyGunMultiplierPerPoint")]
+    public float PerceptionHeavyGunMultiplierPerPoint = 0.01333333f;
 
-    [DataField("perceptionSpreadReductionAtTen")]
-    public float PerceptionSpreadReductionAtTen = 0.25f;
+    [DataField("perceptionMineDelayMultiplierPerPoint")]
+    public float PerceptionMineDelayMultiplierPerPoint = 0.03333333f;
 
-    [DataField("perceptionHeavyGunPenaltyAtOne")]
-    public float PerceptionHeavyGunPenaltyAtOne = 0.18f;
-
-    [DataField("perceptionHeavyGunReductionAtTen")]
-    public float PerceptionHeavyGunReductionAtTen = 0.10f;
-
-    [DataField("perceptionMineDelayPenaltyAtOne")]
-    public float PerceptionMineDelayPenaltyAtOne = 0.25f;
-
-    [DataField("perceptionMineDelayReductionAtTen")]
-    public float PerceptionMineDelayReductionAtTen = 0.25f;
-
-    [DataField("perceptionFireDelayPenaltyAtOne")]
-    public float PerceptionFireDelayPenaltyAtOne = 0.08f;
-
-    [DataField("perceptionFireDelayReductionAtTen")]
-    public float PerceptionFireDelayReductionAtTen = 0.10f;
+    [DataField("perceptionFireDelayMultiplierPerPoint")]
+    public float PerceptionFireDelayMultiplierPerPoint = 0.01333333f;
 
     // Endurance: survivability, needs, stamina, and toxin resistance.
     [DataField("enduranceStaminaCritThresholdPerPoint")]
     public float EnduranceStaminaCritThresholdPerPoint = 4f;
 
-    [DataField("enduranceHealthPenaltyAtOne")]
-    public float EnduranceHealthPenaltyAtOne = 20f;
+    [DataField("enduranceHealthModifierPerPoint")]
+    public float EnduranceHealthModifierPerPoint = 2.6666667f;
 
-    [DataField("enduranceHealthBonusAtTen")]
-    public float EnduranceHealthBonusAtTen = 20f;
+    [DataField("enduranceNeedDecayMultiplierPerPoint")]
+    public float EnduranceNeedDecayMultiplierPerPoint = 0.016f;
 
-    [DataField("enduranceNeedDecayPenaltyAtOne")]
-    public float EnduranceNeedDecayPenaltyAtOne = 0.15f;
+    [DataField("enduranceStaminaRecoveryMultiplierPerPoint")]
+    public float EnduranceStaminaRecoveryMultiplierPerPoint = 0.02666667f;
 
-    [DataField("enduranceNeedDecayReductionAtTen")]
-    public float EnduranceNeedDecayReductionAtTen = 0.12f;
-
-    [DataField("enduranceStaminaRecoveryPenaltyAtOne")]
-    public float EnduranceStaminaRecoveryPenaltyAtOne = 0.15f;
-
-    [DataField("enduranceStaminaRecoveryBonusAtTen")]
-    public float EnduranceStaminaRecoveryBonusAtTen = 0.20f;
-
-    [DataField("enduranceToxinDamagePenaltyAtOne")]
-    public float EnduranceToxinDamagePenaltyAtOne = 0.12f;
-
-    [DataField("enduranceToxinDamageReductionAtTen")]
-    public float EnduranceToxinDamageReductionAtTen = 0.15f;
+    [DataField("enduranceToxinDamageMultiplierPerPoint")]
+    public float EnduranceToxinDamageMultiplierPerPoint = 0.02f;
 
     // Charisma: economy, loadout points, and presentation hooks.
-    [DataField("charismaTradePenaltyAtOne")]
-    public float CharismaTradePenaltyAtOne = 0.10f;
-
-    [DataField("charismaTradeBonusAtTen")]
-    public float CharismaTradeBonusAtTen = 0.10f;
+    [DataField("charismaTradeMultiplierPerPoint")]
+    public float CharismaTradeMultiplierPerPoint = 0.01333333f;
 
     // Intelligence: crafting/medical quality-of-life gates.
-    [DataField("intelligenceLatheMinimumTimeMultiplierAtTen")]
-    public float IntelligenceLatheMinimumTimeMultiplierAtTen = 0.50f;
+    [DataField("intelligenceLatheTimeMultiplierPerPoint")]
+    public float IntelligenceLatheTimeMultiplierPerPoint = 0.06666667f;
 
-    [DataField("intelligenceLatheMaterialDiscountAtTen")]
-    public float IntelligenceLatheMaterialDiscountAtTen = 0.25f;
+    [DataField("intelligenceLatheMaterialUseMultiplierPerPoint")]
+    public float IntelligenceLatheMaterialUseMultiplierPerPoint = 0.03333333f;
 
     // Agility: movement and general action speed.
     [DataField("agilityMovementSpeedMultiplierPerPoint")]
-    public float AgilityMovementSpeedMultiplierPerPoint = 0.004f;
+    public float AgilityMovementSpeedMultiplierPerPoint = 0.01f;
 
-    [DataField("agilityMovementSpeedPenaltyAtOne")]
-    public float AgilityMovementSpeedPenaltyAtOne = 0.075f;
-
-    [DataField("agilityMovementSpeedBonusAtTen")]
-    public float AgilityMovementSpeedBonusAtTen = 0.075f;
-
-    [DataField("agilityActionDelayPenaltyAtOne")]
-    public float AgilityActionDelayPenaltyAtOne = 0.08f;
-
-    [DataField("agilityActionDelayReductionAtTen")]
-    public float AgilityActionDelayReductionAtTen = 0.10f;
+    [DataField("agilityActionDelayMultiplierPerPoint")]
+    public float AgilityActionDelayMultiplierPerPoint = 0.01333333f;
 
     // Luck: critical hits and chance-based reward hooks.
     [DataField("luckCriticalChancePerPoint")]
     public float LuckCriticalChancePerPoint = 0.005f;
 
-    [DataField("luckSingleShotCriticalChanceAtTen")]
-    public float LuckSingleShotCriticalChanceAtTen = 0.25f;
+    [DataField("luckSingleShotCriticalChancePerPoint")]
+    public float LuckSingleShotCriticalChancePerPoint = 0.03333333f;
 
     [DataField("luckCriticalDamageMultiplier")]
     public float LuckCriticalDamageMultiplier = 1.5f;

--- a/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
+++ b/Content.Shared/_Misfits/Special/Prototypes/SpecialTuningPrototype.cs
@@ -15,7 +15,7 @@ public sealed partial class SpecialTuningPrototype : IPrototype
     [IdDataField]
     public string ID { get; private set; } = default!;
 
-    // Strength: melee output and heavy/carry handling.
+    // Strength: melee output and carry handling.
     [DataField("strengthMeleeDamageMultiplierPerPoint")]
     public float StrengthMeleeDamageMultiplierPerPoint = 0.02f;
 
@@ -25,13 +25,7 @@ public sealed partial class SpecialTuningPrototype : IPrototype
     [DataField("strengthCarryPullSpeedBonusAtTen")]
     public float StrengthCarryPullSpeedBonusAtTen = 0.10f;
 
-    [DataField("strengthHeavyGunPenaltyAtOne")]
-    public float StrengthHeavyGunPenaltyAtOne = 0.18f;
-
-    [DataField("strengthHeavyGunReductionAtTen")]
-    public float StrengthHeavyGunReductionAtTen = 0.10f;
-
-    // Perception: ranged accuracy, mining speed, and fire delay.
+    // Perception: ranged accuracy, heavy gun handling, mining speed, and fire delay.
     [DataField("perceptionSpreadReductionPerPoint")]
     public float PerceptionSpreadReductionPerPoint = 0.004f;
 
@@ -40,6 +34,12 @@ public sealed partial class SpecialTuningPrototype : IPrototype
 
     [DataField("perceptionSpreadReductionAtTen")]
     public float PerceptionSpreadReductionAtTen = 0.25f;
+
+    [DataField("perceptionHeavyGunPenaltyAtOne")]
+    public float PerceptionHeavyGunPenaltyAtOne = 0.18f;
+
+    [DataField("perceptionHeavyGunReductionAtTen")]
+    public float PerceptionHeavyGunReductionAtTen = 0.10f;
 
     [DataField("perceptionMineDelayPenaltyAtOne")]
     public float PerceptionMineDelayPenaltyAtOne = 0.25f;

--- a/Content.Shared/_Misfits/Special/README.md
+++ b/Content.Shared/_Misfits/Special/README.md
@@ -8,7 +8,7 @@ Runtime systems should query `SharedSpecialSystem` instead of reading fields dir
 - `GetModifier(entity, stat)` for temporary modifier totals.
 - `GetEffective(entity, stat)` for gameplay-safe values clamped to 1-10.
 - `GetCurvedEffectDelta(entity, stat)` for gameplay effects that should scale non-linearly around 5.
-- `GetCurvedEffectScale(entity, stat, valueAtOne, valueAtTen)` for effects that should hit exact endpoints at 1 and 10.
+- `GetCurvedEffectModifier(entity, stat, multiplierPerPoint)` for effects that multiply that curved delta by a tuning value.
 - `HasRequirement(entity, stat, minimum)` for perks, weapons, or future skill gates.
 - `TryModifyTemporary(entity, stat, modifier, duration, source)` for drugs, chems, injuries, perks, or equipment.
 
@@ -27,12 +27,12 @@ Most gameplay effects use a curved delta from the effective stat instead of a fl
 - 9: +5.5
 - 10: +7.5
 
-The tuning values below are multiplied by that curved delta or scaled to explicit 1/10 endpoints:
+The tuning values below are multiplied by that curved delta:
 
-- Strength changes melee damage by `strengthMeleeDamageMultiplierPerPoint`.
-- Perception changes ranged spread/recoil from `perceptionSpreadPenaltyAtOne` at 1 PER to `perceptionSpreadReductionAtTen` at 10 PER, and heavy gun spread/recoil from `perceptionHeavyGunPenaltyAtOne` to `perceptionHeavyGunReductionAtTen`.
-- Endurance changes health thresholds from `enduranceHealthPenaltyAtOne` at 1 END to `enduranceHealthBonusAtTen` at 10 END.
+- Strength changes held melee damage by `strengthMeleeDamageMultiplierPerPoint` and unarmed damage by the smaller `strengthUnarmedDamageMultiplierPerPoint`.
+- Perception changes ranged spread/recoil with `perceptionSpreadMultiplierPerPoint`, heavy gun spread/recoil with `perceptionHeavyGunMultiplierPerPoint`, mine trigger delay with `perceptionMineDelayMultiplierPerPoint`, and fire spread delay with `perceptionFireDelayMultiplierPerPoint`.
+- Endurance changes health thresholds with `enduranceHealthModifierPerPoint`, need decay with `enduranceNeedDecayMultiplierPerPoint`, stamina recovery with `enduranceStaminaRecoveryMultiplierPerPoint`, and poison/toxin damage with `enduranceToxinDamageMultiplierPerPoint`.
 - Charisma changes character-creation loadout points by the curved delta times 2, rounded away from zero. Below 5 charisma, examine text gives a social tell; at 1-2 charisma, speech can gain light awkward phrasing.
-- Intelligence changes crafting delay on a fixed curve: 1 blocks hand crafting, 5 is normal speed, and 10 is 50% faster for hand crafting. Lathe production is instant at 10 intelligence. At 1 intelligence, the low-intelligence accent is enabled.
-- Agility changes movement speed from `agilityMovementSpeedPenaltyAtOne` at 1 AGI to `agilityMovementSpeedBonusAtTen` at 10 AGI.
+- Intelligence changes crafting delay on a fixed curve: 1 blocks hand crafting, 5 is normal speed, and 10 is 50% faster for hand crafting. Lathe production uses `intelligenceLatheTimeMultiplierPerPoint`, material discounts use `intelligenceLatheMaterialUseMultiplierPerPoint`, and 10 intelligence grants the med HUD effect. At 1 intelligence, the low-intelligence accent is enabled.
+- Agility changes movement speed with `agilityMovementSpeedMultiplierPerPoint` and action delay with `agilityActionDelayMultiplierPerPoint`.
 - Luck changes critical-hit and lucky-scavenge chance. At 1 luck, clumsy uses its normal failure chance; at 2-4 luck, clumsy is still possible but much rarer.

--- a/Content.Shared/_Misfits/Special/README.md
+++ b/Content.Shared/_Misfits/Special/README.md
@@ -30,7 +30,7 @@ Most gameplay effects use a curved delta from the effective stat instead of a fl
 The tuning values below are multiplied by that curved delta or scaled to explicit 1/10 endpoints:
 
 - Strength changes melee damage by `strengthMeleeDamageMultiplierPerPoint`.
-- Perception changes ranged spread/recoil from `perceptionSpreadPenaltyAtOne` at 1 PER to `perceptionSpreadReductionAtTen` at 10 PER.
+- Perception changes ranged spread/recoil from `perceptionSpreadPenaltyAtOne` at 1 PER to `perceptionSpreadReductionAtTen` at 10 PER, and heavy gun spread/recoil from `perceptionHeavyGunPenaltyAtOne` to `perceptionHeavyGunReductionAtTen`.
 - Endurance changes health thresholds from `enduranceHealthPenaltyAtOne` at 1 END to `enduranceHealthBonusAtTen` at 10 END.
 - Charisma changes character-creation loadout points by the curved delta times 2, rounded away from zero. Below 5 charisma, examine text gives a social tell; at 1-2 charisma, speech can gain light awkward phrasing.
 - Intelligence changes crafting delay on a fixed curve: 1 blocks hand crafting, 5 is normal speed, and 10 is 50% faster for hand crafting. Lathe production is instant at 10 intelligence. At 1 intelligence, the low-intelligence accent is enabled.

--- a/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
+++ b/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
@@ -178,27 +178,18 @@ public sealed class SharedSpecialSystem : EntitySystem
         };
     }
 
-    public float GetCurvedEffectScale(
+    public float GetCurvedEffectModifier(
         EntityUid uid,
         SpecialStat stat,
-        float valueAtOne,
-        float valueAtTen,
+        float multiplierPerPoint,
         SpecialComponent? component = null)
     {
-        return GetCurvedEffectScale(GetCurvedEffectDelta(uid, stat, component), valueAtOne, valueAtTen);
+        return GetCurvedEffectModifier(GetCurvedEffectDelta(uid, stat, component), multiplierPerPoint);
     }
 
-    public static float GetCurvedEffectScale(float curvedDelta, float valueAtOne, float valueAtTen)
+    public static float GetCurvedEffectModifier(float curvedDelta, float multiplierPerPoint)
     {
-        // Tuning fields describe the effect at stat 1 and stat 10. The curved
-        // delta interpolates from the neutral midpoint toward the matching end.
-        if (curvedDelta > 0f)
-            return valueAtTen * curvedDelta / GetCurvedEffectDelta(SpecialProfile.Maximum);
-
-        if (curvedDelta < 0f)
-            return valueAtOne * curvedDelta / GetCurvedEffectDelta(SpecialProfile.Minimum);
-
-        return 0f;
+        return curvedDelta * multiplierPerPoint;
     }
 
     public static int GetCharismaLoadoutPointModifier(int charisma)
@@ -243,14 +234,13 @@ public sealed class SharedSpecialSystem : EntitySystem
         return GetIntelligenceLatheMaterialUseMultiplier(
             GetEffective(uid, SpecialStat.Intelligence, component),
             baseMultiplier,
-            tuning.IntelligenceLatheMaterialDiscountAtTen);
+            tuning.IntelligenceLatheMaterialUseMultiplierPerPoint);
     }
 
-    public static float GetIntelligenceLatheMaterialUseMultiplier(int intelligence, float baseMultiplier, float discountAtTen)
+    public static float GetIntelligenceLatheMaterialUseMultiplier(int intelligence, float baseMultiplier, float multiplierPerPoint)
     {
         var delta = MathF.Max(0f, GetCurvedEffectDelta(intelligence));
-        var maxDelta = GetCurvedEffectDelta(SpecialProfile.Maximum);
-        var discount = Math.Clamp(discountAtTen, 0f, 0.5f) * delta / maxDelta;
+        var discount = Math.Clamp(delta * multiplierPerPoint, 0f, 0.5f);
 
         return MathF.Max(0.1f, baseMultiplier * (1f - discount));
     }

--- a/Content.Shared/_Misfits/SpecialStats/Components/StrengthIgnoreClothingSlowdownComponent.cs
+++ b/Content.Shared/_Misfits/SpecialStats/Components/StrengthIgnoreClothingSlowdownComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Misfits.SpecialStats.Components;
+
+/// <summary>
+/// Allows sufficiently strong characters to ignore this item's clothing speed penalties.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StrengthIgnoreClothingSlowdownComponent : Component
+{
+    [DataField]
+    public int MinimumStrength = 7;
+}

--- a/Content.Shared/_Misfits/SpecialStats/SpecialAgilitySystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialAgilitySystem.cs
@@ -30,11 +30,10 @@ public sealed class SpecialAgilitySystem : EntitySystem
     private float GetActionDelayMultiplier(EntityUid uid, SpecialComponent special)
     {
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             uid,
             SpecialStat.Agility,
-            tuning.AgilityActionDelayPenaltyAtOne,
-            -tuning.AgilityActionDelayReductionAtTen,
+            -tuning.AgilityActionDelayMultiplierPerPoint,
             special);
 
         return MathF.Max(0.1f, 1f + modifier);

--- a/Content.Shared/_Misfits/SpecialStats/SpecialEnduranceSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialEnduranceSystem.cs
@@ -65,11 +65,10 @@ public sealed class SpecialEnduranceSystem : EntitySystem
             return;
 
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             ent.Owner,
             SpecialStat.Endurance,
-            tuning.EnduranceToxinDamagePenaltyAtOne,
-            -tuning.EnduranceToxinDamageReductionAtTen,
+            -tuning.EnduranceToxinDamageMultiplierPerPoint,
             ent.Comp);
         var multiplier = MathF.Max(0.1f, 1f + modifier);
 
@@ -110,11 +109,10 @@ public sealed class SpecialEnduranceSystem : EntitySystem
         var tuning = _special.GetTuning();
         var desired = reset
             ? 0f
-            : _special.GetCurvedEffectScale(
+            : _special.GetCurvedEffectModifier(
                 ent.Owner,
                 SpecialStat.Endurance,
-                -tuning.EnduranceHealthPenaltyAtOne,
-                tuning.EnduranceHealthBonusAtTen,
+                tuning.EnduranceHealthModifierPerPoint,
                 ent.Comp);
         var adjustment = desired - ent.Comp.AppliedHealthThresholdModifier;
 
@@ -202,11 +200,10 @@ public sealed class SpecialEnduranceSystem : EntitySystem
     private float GetNeedDecayMultiplier(Entity<SpecialComponent> ent)
     {
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             ent.Owner,
             SpecialStat.Endurance,
-            tuning.EnduranceNeedDecayPenaltyAtOne,
-            -tuning.EnduranceNeedDecayReductionAtTen,
+            -tuning.EnduranceNeedDecayMultiplierPerPoint,
             ent.Comp);
 
         return MathF.Max(0.1f, 1f + modifier);
@@ -215,11 +212,10 @@ public sealed class SpecialEnduranceSystem : EntitySystem
     private float GetStaminaRecoveryMultiplier(Entity<SpecialComponent> ent)
     {
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             ent.Owner,
             SpecialStat.Endurance,
-            -tuning.EnduranceStaminaRecoveryPenaltyAtOne,
-            tuning.EnduranceStaminaRecoveryBonusAtTen,
+            tuning.EnduranceStaminaRecoveryMultiplierPerPoint,
             ent.Comp);
 
         return MathF.Max(0.1f, 1f + modifier);

--- a/Content.Shared/_Misfits/SpecialStats/SpecialMovementSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialMovementSystem.cs
@@ -21,11 +21,10 @@ public sealed class SpecialMovementSystem : EntitySystem
     private void OnRefreshSpeed(Entity<SpecialComponent> ent, ref RefreshMovementSpeedModifiersEvent args)
     {
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             ent.Owner,
             SpecialStat.Agility,
-            -tuning.AgilityMovementSpeedPenaltyAtOne,
-            tuning.AgilityMovementSpeedBonusAtTen,
+            tuning.AgilityMovementSpeedMultiplierPerPoint,
             ent.Comp);
         var multiplier = MathF.Max(0.1f, 1f + modifier);
 

--- a/Content.Shared/_Misfits/SpecialStats/SpecialPerceptionSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialPerceptionSystem.cs
@@ -28,11 +28,10 @@ public sealed class SpecialPerceptionSystem : EntitySystem
             return;
 
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             holder,
             SpecialStat.Perception,
-            tuning.PerceptionSpreadPenaltyAtOne,
-            -tuning.PerceptionSpreadReductionAtTen,
+            -tuning.PerceptionSpreadMultiplierPerPoint,
             special);
         var keepFraction = Math.Clamp(1.0 + modifier, 0.5, 2.0);
 
@@ -56,11 +55,10 @@ public sealed class SpecialPerceptionSystem : EntitySystem
             return;
 
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             holder,
             SpecialStat.Perception,
-            tuning.PerceptionHeavyGunPenaltyAtOne,
-            -tuning.PerceptionHeavyGunReductionAtTen,
+            -tuning.PerceptionHeavyGunMultiplierPerPoint,
             special);
         var keepFraction = Math.Clamp(1.0 + modifier, 0.70, 1.40);
 
@@ -73,11 +71,10 @@ public sealed class SpecialPerceptionSystem : EntitySystem
     private float GetFireDelayMultiplier(EntityUid uid, SpecialComponent special)
     {
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             uid,
             SpecialStat.Perception,
-            tuning.PerceptionFireDelayPenaltyAtOne,
-            -tuning.PerceptionFireDelayReductionAtTen,
+            -tuning.PerceptionFireDelayMultiplierPerPoint,
             special);
 
         return MathF.Max(0.1f, 1f + modifier);

--- a/Content.Shared/_Misfits/SpecialStats/SpecialPerceptionSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialPerceptionSystem.cs
@@ -1,6 +1,8 @@
 using Content.Shared._Misfits.Special;
 using Content.Shared._Misfits.Special.Components;
+using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Wieldable.Components;
 
 namespace Content.Shared._Misfits.SpecialStats;
 
@@ -39,10 +41,33 @@ public sealed class SpecialPerceptionSystem : EntitySystem
         args.AngleIncrease = new Angle((double) args.AngleIncrease * keepFraction);
         args.CameraRecoilScalar *= (float) keepFraction;
 
+        ApplyHeavyGunHandling(holder, ref args, special);
+
         if (args.FireRate <= 0f)
             return;
 
         args.FireRate *= 1f / GetFireDelayMultiplier(holder, special);
+    }
+
+    private void ApplyHeavyGunHandling(EntityUid holder, ref GunRefreshModifiersEvent args, SpecialComponent special)
+    {
+        if (!HasComp<GunRequiresWieldComponent>(args.Gun.Owner) &&
+            !HasComp<WieldableComponent>(args.Gun.Owner))
+            return;
+
+        var tuning = _special.GetTuning();
+        var modifier = _special.GetCurvedEffectScale(
+            holder,
+            SpecialStat.Perception,
+            tuning.PerceptionHeavyGunPenaltyAtOne,
+            -tuning.PerceptionHeavyGunReductionAtTen,
+            special);
+        var keepFraction = Math.Clamp(1.0 + modifier, 0.70, 1.40);
+
+        args.MinAngle = new Angle((double) args.MinAngle * keepFraction);
+        args.MaxAngle = new Angle((double) args.MaxAngle * keepFraction);
+        args.AngleIncrease = new Angle((double) args.AngleIncrease * keepFraction);
+        args.CameraRecoilScalar *= (float) keepFraction;
     }
 
     private float GetFireDelayMultiplier(EntityUid uid, SpecialComponent special)

--- a/Content.Shared/_Misfits/SpecialStats/SpecialStrengthSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialStrengthSystem.cs
@@ -23,11 +23,10 @@ public sealed class SpecialStrengthSystem : EntitySystem
             return;
 
         var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
+        var modifier = _special.GetCurvedEffectModifier(
             args.User,
             SpecialStat.Strength,
-            -tuning.StrengthCarryPullSpeedPenaltyAtOne,
-            tuning.StrengthCarryPullSpeedBonusAtTen,
+            tuning.StrengthCarryPullSpeedMultiplierPerPoint,
             special);
         var multiplier = MathF.Max(0.1f, 1f + modifier);
 

--- a/Content.Shared/_Misfits/SpecialStats/SpecialStrengthSystem.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialStrengthSystem.cs
@@ -1,14 +1,10 @@
 using Content.Shared._Misfits.Special;
 using Content.Shared._Misfits.Special.Components;
-using Content.Shared.Weapons.Ranged.Components;
-using Content.Shared.Weapons.Ranged.Events;
-using Content.Shared.Wieldable.Components;
-using Robust.Shared.Maths;
 
 namespace Content.Shared._Misfits.SpecialStats;
 
 /// <summary>
-/// Applies Strength to heavy handling outside of direct melee damage.
+/// Applies Strength to carry and pull handling outside of direct melee damage.
 /// </summary>
 public sealed class SpecialStrengthSystem : EntitySystem
 {
@@ -19,7 +15,6 @@ public sealed class SpecialStrengthSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<SpecialCarryPullSpeedModifierEvent>(OnCarryPullSpeedModifier);
-        SubscribeLocalEvent<GunRefreshModifiersEvent>(OnGunRefreshModifiers);
     }
 
     private void OnCarryPullSpeedModifier(ref SpecialCarryPullSpeedModifierEvent args)
@@ -37,30 +32,5 @@ public sealed class SpecialStrengthSystem : EntitySystem
         var multiplier = MathF.Max(0.1f, 1f + modifier);
 
         args.ModifySpeed(multiplier);
-    }
-
-    private void OnGunRefreshModifiers(ref GunRefreshModifiersEvent args)
-    {
-        if (!HasComp<GunRequiresWieldComponent>(args.Gun.Owner) &&
-            !HasComp<WieldableComponent>(args.Gun.Owner))
-            return;
-
-        var holder = Transform(args.Gun.Owner).ParentUid;
-        if (!TryComp<SpecialComponent>(holder, out var special))
-            return;
-
-        var tuning = _special.GetTuning();
-        var modifier = _special.GetCurvedEffectScale(
-            holder,
-            SpecialStat.Strength,
-            tuning.StrengthHeavyGunPenaltyAtOne,
-            -tuning.StrengthHeavyGunReductionAtTen,
-            special);
-        var keepFraction = Math.Clamp(1.0 + modifier, 0.70, 1.40);
-
-        args.MinAngle = new Angle((double) args.MinAngle * keepFraction);
-        args.MaxAngle = new Angle((double) args.MaxAngle * keepFraction);
-        args.AngleIncrease = new Angle((double) args.AngleIncrease * keepFraction);
-        args.CameraRecoilScalar *= (float) keepFraction;
     }
 }

--- a/Resources/Locale/en-US/_Misfits/traits.ftl
+++ b/Resources/Locale/en-US/_Misfits/traits.ftl
@@ -1,5 +1,8 @@
 # Misfits — trait display strings for Pets perk tree
 
+trait-name-FiremanCarry = Fireman Carry
+trait-description-FiremanCarry = You can pick people up and drag them without losing speed.
+
 trait-name-N14PetDogCompanion = Dog Companion
 trait-description-N14PetDogCompanion =
     You have a loyal dog companion that follows and obeys you.

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -13,6 +13,7 @@
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 0.9
+  - type: StrengthIgnoreClothingSlowdown
   - type: HeldSpeedModifier
 
 - type: entity

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Followers/followers.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Followers/followers.yml
@@ -64,6 +64,9 @@
           - Wastelander
           - Followers # #Misfits Add - enables Followers death-alert targeting
       - type: CPRTraining
+  - !type:AddTraitSpecial
+    traits:
+    - FiremanCarry
 
 - type: startingGear
   id: FollowerHeadGear
@@ -137,6 +140,9 @@
           - Wastelander
           - Followers # #Misfits Add - enables Followers death-alert targeting
       - type: CPRTraining
+  - !type:AddTraitSpecial
+    traits:
+    - FiremanCarry
 
 - type: startingGear
   id: FollowerDoctorGear
@@ -204,6 +210,9 @@
           - Wastelander
           - Followers # #Misfits Add - enables Followers death-alert targeting
       - type: CPRTraining
+  - !type:AddTraitSpecial
+    traits:
+    - FiremanCarry
 
 - type: startingGear
   id: FollowerVolunteerGear

--- a/Resources/Prototypes/_Misfits/Special/special_tuning.yml
+++ b/Resources/Prototypes/_Misfits/Special/special_tuning.yml
@@ -1,34 +1,23 @@
 - type: specialTuning
   id: MisfitsSpecialTuning
   strengthMeleeDamageMultiplierPerPoint: 0.02
-  strengthCarryPullSpeedPenaltyAtOne: 0.08
-  strengthCarryPullSpeedBonusAtTen: 0.10
-  perceptionSpreadPenaltyAtOne: 0.15
-  perceptionSpreadReductionAtTen: 0.25
-  perceptionHeavyGunPenaltyAtOne: 0.18
-  perceptionHeavyGunReductionAtTen: 0.10
-  perceptionMineDelayPenaltyAtOne: 0.25
-  perceptionMineDelayReductionAtTen: 0.25
-  perceptionFireDelayPenaltyAtOne: 0.08
-  perceptionFireDelayReductionAtTen: 0.10
-  enduranceHealthPenaltyAtOne: 20
-  enduranceHealthBonusAtTen: 20
-  enduranceNeedDecayPenaltyAtOne: 0.15
-  enduranceNeedDecayReductionAtTen: 0.12
-  enduranceStaminaRecoveryPenaltyAtOne: 0.15
-  enduranceStaminaRecoveryBonusAtTen: 0.20
-  enduranceToxinDamagePenaltyAtOne: 0.12
-  enduranceToxinDamageReductionAtTen: 0.15
-  charismaTradePenaltyAtOne: 0.10
-  charismaTradeBonusAtTen: 0.10
-  intelligenceLatheMinimumTimeMultiplierAtTen: 0.50
-  intelligenceLatheMaterialDiscountAtTen: 0.25
-  agilityMovementSpeedPenaltyAtOne: 0.075
-  agilityMovementSpeedBonusAtTen: 0.075
-  agilityActionDelayPenaltyAtOne: 0.08
-  agilityActionDelayReductionAtTen: 0.10
+  strengthUnarmedDamageMultiplierPerPoint: 0.03333333
+  strengthCarryPullSpeedMultiplierPerPoint: 0.01333333
+  perceptionSpreadMultiplierPerPoint: 0.03333333
+  perceptionHeavyGunMultiplierPerPoint: 0.01333333
+  perceptionMineDelayMultiplierPerPoint: 0.03333333
+  perceptionFireDelayMultiplierPerPoint: 0.01333333
+  enduranceHealthModifierPerPoint: 2.6666667
+  enduranceNeedDecayMultiplierPerPoint: 0.016
+  enduranceStaminaRecoveryMultiplierPerPoint: 0.02666667
+  enduranceToxinDamageMultiplierPerPoint: 0.02
+  charismaTradeMultiplierPerPoint: 0.01333333
+  intelligenceLatheTimeMultiplierPerPoint: 0.06666667
+  intelligenceLatheMaterialUseMultiplierPerPoint: 0.03333333
+  agilityMovementSpeedMultiplierPerPoint: 0.01
+  agilityActionDelayMultiplierPerPoint: 0.01333333
   luckCriticalChancePerPoint: 0.005
-  luckSingleShotCriticalChanceAtTen: 0.25
+  luckSingleShotCriticalChancePerPoint: 0.03333333
   luckCriticalDamageMultiplier: 1.5
   luckUnluckyDamageMultiplier: 0.5
   luckLootChancePerPoint: 0.025

--- a/Resources/Prototypes/_Misfits/Special/special_tuning.yml
+++ b/Resources/Prototypes/_Misfits/Special/special_tuning.yml
@@ -3,10 +3,10 @@
   strengthMeleeDamageMultiplierPerPoint: 0.02
   strengthCarryPullSpeedPenaltyAtOne: 0.08
   strengthCarryPullSpeedBonusAtTen: 0.10
-  strengthHeavyGunPenaltyAtOne: 0.18
-  strengthHeavyGunReductionAtTen: 0.10
   perceptionSpreadPenaltyAtOne: 0.15
   perceptionSpreadReductionAtTen: 0.25
+  perceptionHeavyGunPenaltyAtOne: 0.18
+  perceptionHeavyGunReductionAtTen: 0.10
   perceptionMineDelayPenaltyAtOne: 0.25
   perceptionMineDelayReductionAtTen: 0.25
   perceptionFireDelayPenaltyAtOne: 0.08

--- a/Resources/Prototypes/_Misfits/Traits/medical.yml
+++ b/Resources/Prototypes/_Misfits/Traits/medical.yml
@@ -1,6 +1,15 @@
 # #Misfits Change - Ported from Delta-V: chronic pain trait
 
 - type: trait
+  id: FiremanCarry
+  category: Physical
+  hidden: true
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: CanFiremanCarry
+
+- type: trait
   id: ChronicPain
   category: Physical
   points: 2


### PR DESCRIPTION
## About the PR
Expanded the S.P.E.C.I.A.L. stat effects and lucky junk pile loot system.

Changes include:
- Heavy gun spread/recoil now scales from Perception instead of Strength.
- Added the hidden `Fireman Carry` trait, allowing carrying/dragging people without speed loss.
- Granted `Fireman Carry` by default to Followers of the Apocalypse roles.
- Added a 10 Intelligence medical HUD effect.
- Reworked lucky junk pile bonus loot into a rarity-weighted system.
- Added `N14WastelanderPipboy` as the rarest lucky loot reward.
- Added useful medical, magazine, drink, and ammo rewards to the lucky loot table.
- Added ammo for weapon families across appropriate rarity tiers.
- Lucky loot now spawns inside the junk pile inventory instead of on the ground.
- Lucky loot roll chance now scales up to 50% at 10 Luck.

## Why / Balance
This gives S.P.E.C.I.A.L. stats more noticeable gameplay identity:
- Perception better fits heavy gun control than Strength.
- Intelligence 10 now gives a meaningful medical utility reward.
- Luck now gives a stronger scavenging payoff without directly guaranteeing rare items.
- The lucky loot table uses rarity weights so common supplies appear often, while Pip Boys remain extremely rare.
- Super Stimpaks remain second-rarest after Pip Boys.

Followers receiving `Fireman Carry` supports their medical/support role fantasy without exposing the trait in the normal Traits menu. It's been coded this way, in case people want it in trait selection later.

## Technical details
- Added/updated S.P.E.C.I.A.L. stat systems for Perception recoil/spread, Intelligence med HUD, and Luck loot.
- Added `Fireman Carry` trait support and default role grants.
- Added hidden-trait handling so `Fireman Carry` does not appear in the Traits menu.
- Converted lucky loot entries from a flat prototype list to `LuckyLootEntry` with `LuckyLootRarity`.
- Added rarity weights:
  - Common
  - Uncommon
  - Rare
  - VeryRare
  - Legendary
- Updated lucky loot selection to pick by rarity weight.
- Updated lucky loot spawning to insert the spawned item into the junk pile `StorageComponent`.
- Increased lucky loot chance scaling so 10 Luck reaches 50%.
- Verified builds after changes.

# Changelog

:cl:
- add: Added the hidden Fireman Carry trait for Followers of the Apocalypse roles.
- add: Added a 10 Intelligence medical HUD effect.
- add: Added rarity-based lucky junk pile rewards, including Pip Boys.
- add: Added useful ammo rewards to the lucky loot table.
- tweak: Heavy gun spread and recoil now scale with Perception instead of Strength.
- fix: Lucky junk pile rewards now spawn inside the pile inventory.
- tweak: Lucky junk pile reward chance now scales up to 50% at 10 Luck.