### PR TITLE
Adds 3 Tile Attack Range to Whip

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Melee/specific.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Melee/specific.yml
@@ -8,6 +8,8 @@
     sprite: Corvax/Objects/Weapons/Melee/whip.rsi
     state: icon
   - type: MeleeWeapon
+    range: 3
+    angle: 10
     soundHit:
       collection: WhipSound
     damage:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->Makes it so the Whip has a 3 tile Melee range

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> It actually makes sense for a whip to have a ranged attack, plus it's kind of weak anyways so I think it's a good buff.

## Technical details
<!-- Summary of code changes for easier review. --> Yeah it works

source: trust me bro

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/6f692f4c-8417-400c-a278-025af6dfadcb



# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- add: Whip now has 3 tile attack range
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
