### PR TITLE
Mass Glowification for Town + C27 Fixes

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -123,19 +123,6 @@
       gloves: N14ClothingPAGauntlets
       shoes: N14ClothingPABoots
       back: N14ClothingPowerSystemsBack
-  - type: Storage
-    grid:
-    - 0,0,2,1
-  - type: ContainerContainer
-    containers:
-      storagebase: !type:Container
-        ents: []
-  - type: UserInterface
-    interfaces:
-      enum.StorageUiKey.Key:
-        type: StorageBoundUserInterface
-      enum.ToggleClothingUiKey.Key:
-        type: ToggleableClothingBoundUserInterface
 
 #Misfits Change /Comment-out/: Western BoS power armor removed — no Western BoS chapter in Misfits.
 #- type: entity

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/C27/c27.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/C27/c27.yml
@@ -150,6 +150,7 @@
   id: C27GearGeneric
   equipment:
     jumpsuit: ClothingC27Chassis
+    id: N14ClothingNeckDogtags
 
 # NCR: chassis jumpsuit + Light NCR kit + NCR headset + NCR soldier dogtag.
 - type: startingGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
@@ -21,6 +21,7 @@
     species:
     - Human
     - Ghoul
+    - GhoulGlowing
   - !type:CharacterDepartmentTimeRequirement
     department: Eighties
     min: 144000 # 40 hours
@@ -82,6 +83,7 @@
     species:
     - Human
     - Ghoul
+    - GhoulGlowing
   - !type:CharacterDepartmentTimeRequirement
     department: Eighties
     min: 54000 # 15 hours
@@ -139,6 +141,7 @@
     species:
     - Human
     - Ghoul
+    - GhoulGlowing
   - !type:CharacterDepartmentTimeRequirement
     department: Eighties
     min: 21600 # 6 hours
@@ -196,6 +199,7 @@
     species:
     - Human
     - Ghoul
+    - GhoulGlowing
   - !type:CharacterDepartmentTimeRequirement
     department: Eighties
     min: 7200 # 2 hours
@@ -253,6 +257,7 @@
     species:
     - Human
     - Ghoul
+    - GhoulGlowing
   - !type:CharacterPlaytimeRequirement
     tracker: Wastelander
     min: 36000 # 10 hours

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Townsfolk/townshopkeeperhelper.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Townsfolk/townshopkeeperhelper.yml
@@ -13,6 +13,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
     #- !type:CharacterDepartmentTimeRequirement # TEMP REMOVED
     #  department: Townsfolk
     #  min: 18000 # 5 hours

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Towndoctor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Towndoctor.yml
@@ -13,6 +13,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
     #- !type:CharacterDepartmentTimeRequirement # TEMP REMOVED
     #  department: Townsfolk
     #  min: 18000 # 5 hours

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townmechanic.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townmechanic.yml
@@ -12,6 +12,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
     #- !type:CharacterDepartmentTimeRequirement # TEMP REMOVED
     #  department: Townsfolk
     #  min: 0 # 2 hours

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townshopkeeper.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townshopkeeper.yml
@@ -14,6 +14,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
     #- !type:CharacterPlaytimeRequirement # TEMP REMOVED
     #  tracker: TownShopkeeperHelper
     #  min: 18000 # 5 hours

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townsperson.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/Townsperson.yml
@@ -12,6 +12,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
     #- !type:CharacterOverallTimeRequirement # TEMP REMOVED
     #  min: 0 # 1 hour
   startingGear: TownspersonGear

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/bartender.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/bartender.yml
@@ -13,6 +13,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
     #- !type:CharacterDepartmentTimeRequirement # TEMP REMOVED
     #  department: Townsfolk
     #  min: 18000 # 5 hours

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/reporter.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/reporter.yml
@@ -12,6 +12,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
   startingGear: WastelandReporterGear
   icon: "JobIconTownReporter" # Corvax-Change
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/towndeputy.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/towndeputy.yml
@@ -13,6 +13,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
     - !type:CharacterDepartmentTimeRequirement # #Misfits Tweak - re-enable timelock, 5h Townsfolk requirement
       department: Townsfolk
       min: 18000 # 5 hours

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townmayor.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townmayor.yml
@@ -15,6 +15,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
     - !type:CharacterDepartmentTimeRequirement # #Misfits Tweak - re-enable timelock, 15h Townsfolk requirement
       department: Townsfolk
       min: 54000 # 15 hours

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townsheriff.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Townsfolk/townsheriff.yml
@@ -14,6 +14,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
     - !type:CharacterDepartmentTimeRequirement # #Misfits Tweak - re-enable timelock, 10h Townsfolk requirement
       department: Townsfolk
       min: 36000 # 10 hours

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/chaplain.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/chaplain.yml
@@ -12,6 +12,7 @@
       species:
       - Human
       - Ghoul
+      - GhoulGlowing
   startingGear: WastelandChaplainGear
   icon: "JobIconWastelandChaplain" # Forge-Change
   supervisors: job-supervisors-townsfolk

--- a/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/farmer.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/Jobs/Wastelanders/farmer.yml
@@ -10,24 +10,12 @@
   startingGear: FarmerGear
   icon: "JobIconWastelandFarmer" # Corvax-Change
   supervisors: job-supervisors-wastelander
-  requirements: # #Misfits Change - robots and supermutants cannot be Farmers
+  requirements:
     - !type:CharacterSpeciesRequirement
-      inverted: true
       species:
-      - RobotMrHandy
-      - RobotProtectron
-      - RobotProtectronPolice # #Misfits Fix - missing variant species
-      - RobotProtectronBuilder # #Misfits Fix - missing variant species
-      - RobotProtectronFire # #Misfits Fix - missing variant species
-      - RobotMrGutsy
-      - RobotAssaultron
-      - RobotAssaultronTesla # #Misfits Fix - missing variant species
-      - RobotSentryBot # #Misfits Fix - missing robot chassis
-      - RobotSentryBotLaser # #Misfits Fix - missing variant species
-      - RobotRobobrain # #Misfits Fix - missing robot chassis
-      - RobotRobobrainLaser # #Misfits Fix - missing variant species
-      - SuperMutant #Misfits Change /Add: SuperMutants cannot be Town Farmers
-      - Nightkin
+      - Human
+      - Ghoul
+      - GhoulGlowing
   access:
   - WastelandFarmer
   - TownsPerson # Corvax-Change


### PR DESCRIPTION


🆑


- tweak: The Eighties can now be glowing ghouls ( Still not ready though)
- tweak: All of town can now be glowing ghouls
- fix: Fixed C27 wastelanders spawning without ID and Farmer Species lock is no longer inverted, No more extra C27's!!!
- fix: Fixed Sierra PA having storage causing topicals to be eaten and not used.

