### PR TITLE
Removed C27 Shock Debuff

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
@@ -143,7 +143,6 @@
         Brute: -0.3
       types:
         Heat: -0.3
-        Shock: -0.3
   # #Misfits Add (Phase F) - Innate melee buff: chassis fist hits noticeably harder than a
   # human punch (spec calls for melee buff to make the slow speed worth it).
   - type: MeleeWeapon


### PR DESCRIPTION
Plasma is "shock" damage right now as it wasnt harming buildings or silicons

🆑 

- tweak: Removed Shock debuff from C27's

