### PR TITLE
Makes Vault Door Unlinkable

### DIFF
--- a/Content.Server/DeviceNetwork/Components/BlockNetworkConfiguratorComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/BlockNetworkConfiguratorComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server.DeviceNetwork.Components;
+
+/// <summary>
+/// Prevents network configurators from interacting with this device.
+/// </summary>
+[RegisterComponent]
+public sealed partial class BlockNetworkConfiguratorComponent : Component
+{
+}

--- a/Content.Server/DeviceNetwork/Components/BlockNetworkConfiguratorComponent.cs
+++ b/Content.Server/DeviceNetwork/Components/BlockNetworkConfiguratorComponent.cs
@@ -1,9 +1,11 @@
 namespace Content.Server.DeviceNetwork.Components;
 
 /// <summary>
-/// Prevents network configurators from interacting with this device.
+/// Prevents network configurators from interacting with this device, except from allowed source prototypes.
 /// </summary>
 [RegisterComponent]
 public sealed partial class BlockNetworkConfiguratorComponent : Component
 {
+    [DataField]
+    public HashSet<string> AllowedSourcePrototypes = new();
 }

--- a/Content.Server/DeviceNetwork/Systems/BlockNetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/BlockNetworkConfiguratorSystem.cs
@@ -1,0 +1,20 @@
+using Content.Server.DeviceNetwork.Components;
+using Content.Shared.DeviceLinking.Events;
+
+namespace Content.Server.DeviceNetwork.Systems;
+
+public sealed class BlockNetworkConfiguratorSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BlockNetworkConfiguratorComponent, LinkAttemptEvent>(OnLinkAttempt);
+    }
+
+    private void OnLinkAttempt(EntityUid uid, BlockNetworkConfiguratorComponent component, LinkAttemptEvent args)
+    {
+        if (args.User != null)
+            args.Cancel();
+    }
+}

--- a/Content.Server/DeviceNetwork/Systems/BlockNetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/BlockNetworkConfiguratorSystem.cs
@@ -14,7 +14,17 @@ public sealed class BlockNetworkConfiguratorSystem : EntitySystem
 
     private void OnLinkAttempt(EntityUid uid, BlockNetworkConfiguratorComponent component, LinkAttemptEvent args)
     {
+        if (IsAllowedSource(component, args.Source))
+            return;
+
         if (args.User != null)
             args.Cancel();
+    }
+
+    public bool IsAllowedSource(BlockNetworkConfiguratorComponent component, EntityUid source)
+    {
+        var prototype = Prototype(source);
+
+        return prototype != null && component.AllowedSourcePrototypes.Contains(prototype.ID);
     }
 }

--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -148,6 +148,9 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!targetUid.HasValue || !Resolve(targetUid.Value, ref device, false))
             return;
 
+        if (IsNetworkConfiguratorBlocked(targetUid.Value, userUid))
+            return;
+
         //This checks if the device is marked as having a savable address,
         //to avoid adding pdas and whatnot to air alarms. This flag is true
         //by default, so this will only prevent devices from being added to
@@ -198,6 +201,15 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!HasComp<DeviceLinkSourceComponent>(target) && !HasComp<DeviceLinkSinkComponent>(target))
             return;
 
+        if (target.HasValue && IsNetworkConfiguratorBlocked(target.Value, user))
+            return;
+
+        if (configurator.ActiveDeviceLink.HasValue && IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, user))
+        {
+            configurator.ActiveDeviceLink = null;
+            return;
+        }
+
         if (configurator.ActiveDeviceLink == target)
         {
             _popupSystem.PopupEntity(Loc.GetString("network-configurator-link-mode-stopped"), target.Value, user);
@@ -229,6 +241,10 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
             || !targetUid.HasValue || configurator.ActiveDeviceLink == targetUid)
             return;
 
+        if (IsNetworkConfiguratorBlocked(targetUid.Value, user)
+            || IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, user))
+            return;
+
         if (!HasComp<DeviceLinkSourceComponent>(targetUid) && !HasComp<DeviceLinkSinkComponent>(targetUid))
             return;
 
@@ -244,6 +260,9 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
 
     private bool AccessCheck(EntityUid target, EntityUid? user, NetworkConfiguratorComponent component)
     {
+        if (IsNetworkConfiguratorBlocked(target, user))
+            return false;
+
         if (!TryComp(target, out AccessReaderComponent? reader) || user == null)
             return true;
 
@@ -254,6 +273,17 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         _popupSystem.PopupEntity(Loc.GetString("network-configurator-device-access-denied"), target, user.Value);
 
         return false;
+    }
+
+    private bool IsNetworkConfiguratorBlocked(EntityUid target, EntityUid? user = null)
+    {
+        if (!HasComp<BlockNetworkConfiguratorComponent>(target))
+            return false;
+
+        if (user.HasValue)
+            _popupSystem.PopupCursor(Loc.GetString("signal-linker-component-connection-refused", ("machine", target)), user.Value);
+
+        return true;
     }
 
     private void OnComponentRemoved(EntityUid uid, DeviceListComponent component, ComponentRemove args)
@@ -339,6 +369,9 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!canReach || !target.HasValue)
             return;
 
+        if (IsNetworkConfiguratorBlocked(target.Value, user))
+            return;
+
         DetermineMode(uid, configurator, target, user);
 
         if (configurator.LinkModeActive)
@@ -385,6 +418,9 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!args.CanAccess || !args.CanInteract || !args.Using.HasValue)
             return;
 
+        if (HasComp<BlockNetworkConfiguratorComponent>(args.Target))
+            return;
+
         var verb = new UtilityVerb
         {
             Act = () => OnUsed(uid, configurator, args.Target, args.User),
@@ -419,6 +455,9 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     {
         if (!args.CanAccess || !args.CanInteract || !args.Using.HasValue
             || !TryComp<NetworkConfiguratorComponent>(args.Using.Value, out var configurator))
+            return;
+
+        if (HasComp<BlockNetworkConfiguratorComponent>(args.Target))
             return;
 
         if (!configurator.LinkModeActive && HasComp<DeviceListComponent>(args.Target))
@@ -472,7 +511,8 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (Delay(configurator))
             return;
 
-        if (!targetUid.HasValue || !configurator.ActiveDeviceLink.HasValue || !AccessCheck(targetUid.Value, userUid, configurator))
+        if (!targetUid.HasValue || !configurator.ActiveDeviceLink.HasValue || !AccessCheck(targetUid.Value, userUid, configurator)
+            || IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, userUid))
             return;
 
 
@@ -651,6 +691,10 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!configurator.ActiveDeviceLink.HasValue || !configurator.DeviceLinkTarget.HasValue)
             return;
 
+        if (IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, args.Actor)
+            || IsNetworkConfiguratorBlocked(configurator.DeviceLinkTarget.Value, args.Actor))
+            return;
+
         _adminLogger.Add(LogType.DeviceLinking, LogImpact.Low,
             $"{ToPrettyString(args.Actor):actor} cleared links between {ToPrettyString(configurator.ActiveDeviceLink.Value):subject} and {ToPrettyString(configurator.DeviceLinkTarget.Value):subject2} with {ToPrettyString(uid):tool}");
 
@@ -685,6 +729,10 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     private void OnToggleLinks(EntityUid uid, NetworkConfiguratorComponent configurator, NetworkConfiguratorToggleLinkMessage args)
     {
         if (!configurator.ActiveDeviceLink.HasValue || !configurator.DeviceLinkTarget.HasValue)
+            return;
+
+        if (IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, args.Actor)
+            || IsNetworkConfiguratorBlocked(configurator.DeviceLinkTarget.Value, args.Actor))
             return;
 
         if (TryComp(configurator.ActiveDeviceLink, out DeviceLinkSourceComponent? activeSource) && TryComp(configurator.DeviceLinkTarget, out DeviceLinkSinkComponent? targetSink))
@@ -723,6 +771,10 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     private void OnSaveLinks(EntityUid uid, NetworkConfiguratorComponent configurator, NetworkConfiguratorLinksSaveMessage args)
     {
         if (!configurator.ActiveDeviceLink.HasValue || !configurator.DeviceLinkTarget.HasValue)
+            return;
+
+        if (IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, args.Actor)
+            || IsNetworkConfiguratorBlocked(configurator.DeviceLinkTarget.Value, args.Actor))
             return;
 
         if (TryComp(configurator.ActiveDeviceLink, out DeviceLinkSourceComponent? activeSource) && TryComp(configurator.DeviceLinkTarget, out DeviceLinkSinkComponent? targetSink))

--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -37,6 +37,7 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly BlockNetworkConfiguratorSystem _blockNetworkConfigurator = default!;
 
     public override void Initialize()
     {
@@ -201,10 +202,10 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!HasComp<DeviceLinkSourceComponent>(target) && !HasComp<DeviceLinkSinkComponent>(target))
             return;
 
-        if (target.HasValue && IsNetworkConfiguratorBlocked(target.Value, user))
+        if (target.HasValue && IsNetworkConfiguratorBlocked(target.Value, user, configurator.ActiveDeviceLink))
             return;
 
-        if (configurator.ActiveDeviceLink.HasValue && IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, user))
+        if (configurator.ActiveDeviceLink.HasValue && IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, user, target))
         {
             configurator.ActiveDeviceLink = null;
             return;
@@ -241,8 +242,8 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
             || !targetUid.HasValue || configurator.ActiveDeviceLink == targetUid)
             return;
 
-        if (IsNetworkConfiguratorBlocked(targetUid.Value, user)
-            || IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, user))
+        if (IsNetworkConfiguratorBlocked(targetUid.Value, user, configurator.ActiveDeviceLink)
+            || IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, user, targetUid))
             return;
 
         if (!HasComp<DeviceLinkSourceComponent>(targetUid) && !HasComp<DeviceLinkSinkComponent>(targetUid))
@@ -258,9 +259,9 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         }
     }
 
-    private bool AccessCheck(EntityUid target, EntityUid? user, NetworkConfiguratorComponent component)
+    private bool AccessCheck(EntityUid target, EntityUid? user, NetworkConfiguratorComponent component, EntityUid? source = null)
     {
-        if (IsNetworkConfiguratorBlocked(target, user))
+        if (IsNetworkConfiguratorBlocked(target, user, source))
             return false;
 
         if (!TryComp(target, out AccessReaderComponent? reader) || user == null)
@@ -275,9 +276,12 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         return false;
     }
 
-    private bool IsNetworkConfiguratorBlocked(EntityUid target, EntityUid? user = null)
+    private bool IsNetworkConfiguratorBlocked(EntityUid target, EntityUid? user = null, EntityUid? source = null)
     {
-        if (!HasComp<BlockNetworkConfiguratorComponent>(target))
+        if (!TryComp<BlockNetworkConfiguratorComponent>(target, out var component))
+            return false;
+
+        if (source.HasValue && _blockNetworkConfigurator.IsAllowedSource(component, source.Value))
             return false;
 
         if (user.HasValue)
@@ -369,7 +373,7 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!canReach || !target.HasValue)
             return;
 
-        if (IsNetworkConfiguratorBlocked(target.Value, user))
+        if (IsNetworkConfiguratorBlocked(target.Value, user, configurator.ActiveDeviceLink))
             return;
 
         DetermineMode(uid, configurator, target, user);
@@ -418,7 +422,7 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!args.CanAccess || !args.CanInteract || !args.Using.HasValue)
             return;
 
-        if (HasComp<BlockNetworkConfiguratorComponent>(args.Target))
+        if (IsNetworkConfiguratorBlocked(args.Target, null, configurator.ActiveDeviceLink))
             return;
 
         var verb = new UtilityVerb
@@ -457,7 +461,7 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
             || !TryComp<NetworkConfiguratorComponent>(args.Using.Value, out var configurator))
             return;
 
-        if (HasComp<BlockNetworkConfiguratorComponent>(args.Target))
+        if (IsNetworkConfiguratorBlocked(args.Target, null, configurator.ActiveDeviceLink))
             return;
 
         if (!configurator.LinkModeActive && HasComp<DeviceListComponent>(args.Target))
@@ -511,8 +515,8 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (Delay(configurator))
             return;
 
-        if (!targetUid.HasValue || !configurator.ActiveDeviceLink.HasValue || !AccessCheck(targetUid.Value, userUid, configurator)
-            || IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, userUid))
+        if (!targetUid.HasValue || !configurator.ActiveDeviceLink.HasValue || !AccessCheck(targetUid.Value, userUid, configurator, configurator.ActiveDeviceLink)
+            || IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, userUid, targetUid))
             return;
 
 
@@ -691,8 +695,8 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!configurator.ActiveDeviceLink.HasValue || !configurator.DeviceLinkTarget.HasValue)
             return;
 
-        if (IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, args.Actor)
-            || IsNetworkConfiguratorBlocked(configurator.DeviceLinkTarget.Value, args.Actor))
+        if (IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, args.Actor, configurator.DeviceLinkTarget)
+            || IsNetworkConfiguratorBlocked(configurator.DeviceLinkTarget.Value, args.Actor, configurator.ActiveDeviceLink))
             return;
 
         _adminLogger.Add(LogType.DeviceLinking, LogImpact.Low,
@@ -731,8 +735,8 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!configurator.ActiveDeviceLink.HasValue || !configurator.DeviceLinkTarget.HasValue)
             return;
 
-        if (IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, args.Actor)
-            || IsNetworkConfiguratorBlocked(configurator.DeviceLinkTarget.Value, args.Actor))
+        if (IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, args.Actor, configurator.DeviceLinkTarget)
+            || IsNetworkConfiguratorBlocked(configurator.DeviceLinkTarget.Value, args.Actor, configurator.ActiveDeviceLink))
             return;
 
         if (TryComp(configurator.ActiveDeviceLink, out DeviceLinkSourceComponent? activeSource) && TryComp(configurator.DeviceLinkTarget, out DeviceLinkSinkComponent? targetSink))
@@ -773,8 +777,8 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!configurator.ActiveDeviceLink.HasValue || !configurator.DeviceLinkTarget.HasValue)
             return;
 
-        if (IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, args.Actor)
-            || IsNetworkConfiguratorBlocked(configurator.DeviceLinkTarget.Value, args.Actor))
+        if (IsNetworkConfiguratorBlocked(configurator.ActiveDeviceLink.Value, args.Actor, configurator.DeviceLinkTarget)
+            || IsNetworkConfiguratorBlocked(configurator.DeviceLinkTarget.Value, args.Actor, configurator.ActiveDeviceLink))
             return;
 
         if (TryComp(configurator.ActiveDeviceLink, out DeviceLinkSourceComponent? activeSource) && TryComp(configurator.DeviceLinkTarget, out DeviceLinkSinkComponent? targetSink))

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/talldoors.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/talldoors.yml
@@ -470,6 +470,7 @@
     resistance: 10
   - type: SpriteFade
   - type: DoorSignalControl
+  - type: BlockNetworkConfigurator
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: BasicDevice

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/talldoors.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/talldoors.yml
@@ -471,6 +471,9 @@
   - type: SpriteFade
   - type: DoorSignalControl
   - type: BlockNetworkConfigurator
+    allowedSourcePrototypes:
+    - N14DoorVaultControls
+    - N14DoorVaultControlsLocked
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: BasicDevice


### PR DESCRIPTION
## About the PR
Multitools everywhere sobbing violently

## Why / Balance
No more vault door hacking

## Technical details
Adds a `BlockNetworkConfiguratorComponent` that blocks network configurator interactions and cancels device-linking attempts against entities using it.

The component supports `allowedSourcePrototypes`, letting specific source devices bypass the block. `N14DoorVault` uses this component and only allows links sourced from `N14DoorVaultControls` or `N14DoorVaultControlsLocked`.

`NetworkConfiguratorSystem` now checks this component before adding devices, opening link UIs, saving links, clearing links, toggling links, adding verbs, or linking devices. This prevents normal multitool configuration of vault doors while still allowing Vault Door Controls to link to them.

## Media
When trying to use it on the door.
<img width="341" height="339" alt="image" src="https://github.com/user-attachments/assets/3a5b5003-d7c2-482b-b4aa-f59e446916ab" />

When linking door controls with it.
<img width="1077" height="775" alt="image" src="https://github.com/user-attachments/assets/470c7afb-f985-4d80-8f13-0182c1e957f4" />

# Changelog

:cl:
- fix: Prevented vault doors from being configured with multitools, while still allowing Vault Door Controls to link to them.