### PR TITLE
Changes And Fixes

### DIFF
--- a/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
+++ b/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
@@ -34,7 +34,7 @@ public sealed class EntityHeaterSystem : EntitySystem
         var query = EntityQueryEnumerator<EntityHeaterComponent, ItemPlacerComponent, ApcPowerReceiverComponent>();
         while (query.MoveNext(out var uid, out var comp, out var placer, out var power))
         {
-            if (!power.Powered)
+            if (power.NeedsPower && !power.Powered)
                 continue;
 
             // don't divide by total entities since its a big grill
@@ -94,7 +94,9 @@ public sealed class EntityHeaterSystem : EntitySystem
     {
         // disable heating element glowing layer if theres no power
         // doesn't actually turn it off since that would be annoying
-        var setting = args.Powered ? comp.Setting : EntityHeaterSetting.Off;
+        var setting = args.Powered || !Comp<ApcPowerReceiverComponent>(uid).NeedsPower
+            ? comp.Setting
+            : EntityHeaterSetting.Off;
         _appearance.SetData(uid, EntityHeaterVisuals.Setting, setting);
     }
 

--- a/Content.Server/_Misfits/Sound/GrillHeaterSoundSystem.cs
+++ b/Content.Server/_Misfits/Sound/GrillHeaterSoundSystem.cs
@@ -81,7 +81,7 @@ public sealed class GrillHeaterSoundSystem : EntitySystem
     {
         if (TryComp<EntityHeaterComponent>(uid, out var heater)
             && TryComp<ApcPowerReceiverComponent>(uid, out var power)
-            && power.Powered)
+            && (!power.NeedsPower || power.Powered))
         {
             return heater.Setting != EntityHeaterSetting.Off;
         }

--- a/Content.Server/_Misfits/SpecialStats/Components/SpecialAppliedMedicalHudComponent.cs
+++ b/Content.Server/_Misfits/SpecialStats/Components/SpecialAppliedMedicalHudComponent.cs
@@ -6,6 +6,9 @@ namespace Content.Server._Misfits.SpecialStats.Components;
 [RegisterComponent]
 public sealed partial class SpecialAppliedMedicalHudComponent : Component
 {
+    public string Action = "ActionToggleSpecialMedicalHud";
+    public EntityUid? ActionEntity;
+    public bool Enabled = true;
     public bool AddedHealthBars;
     public bool AddedHealthIcons;
 }

--- a/Content.Server/_Misfits/SpecialStats/SpecialIntelligenceHudSystem.cs
+++ b/Content.Server/_Misfits/SpecialStats/SpecialIntelligenceHudSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server._Misfits.SpecialStats.Components;
+using Content.Server.Actions;
 using Content.Shared._Misfits.Special;
 using Content.Shared._Misfits.Special.Components;
 using Content.Shared._Misfits.SpecialStats;
@@ -11,6 +12,7 @@ namespace Content.Server._Misfits.SpecialStats;
 /// </summary>
 public sealed class SpecialIntelligenceHudSystem : EntitySystem
 {
+    [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     private const int MedicalHudIntelligenceThreshold = 10;
@@ -23,6 +25,8 @@ public sealed class SpecialIntelligenceHudSystem : EntitySystem
         SubscribeLocalEvent<SpecialChangedEvent>(OnSpecialChanged);
         SubscribeLocalEvent<SpecialStatsReadyEvent>(OnStatsReady);
         SubscribeLocalEvent<SpecialShutdownEvent>(OnSpecialShutdown);
+        SubscribeLocalEvent<SpecialAppliedMedicalHudComponent, ComponentShutdown>(OnMedicalHudShutdown);
+        SubscribeLocalEvent<SpecialAppliedMedicalHudComponent, SpecialMedicalHudToggleActionEvent>(OnMedicalHudToggle);
     }
 
     private void OnSpecialChanged(ref SpecialChangedEvent args)
@@ -53,6 +57,11 @@ public sealed class SpecialIntelligenceHudSystem : EntitySystem
     private void EnsureMedicalHud(EntityUid uid)
     {
         var applied = EnsureComp<SpecialAppliedMedicalHudComponent>(uid);
+        _actions.AddAction(uid, ref applied.ActionEntity, applied.Action);
+        _actions.SetToggled(applied.ActionEntity, applied.Enabled);
+
+        if (!applied.Enabled)
+            return;
 
         if (!HasComp<ShowHealthBarsComponent>(uid))
         {
@@ -76,13 +85,43 @@ public sealed class SpecialIntelligenceHudSystem : EntitySystem
         if (!TryComp<SpecialAppliedMedicalHudComponent>(uid, out var applied))
             return;
 
+        ClearMedicalHudComponents(uid, applied);
+        RemComp<SpecialAppliedMedicalHudComponent>(uid);
+    }
+
+    private void ClearMedicalHudComponents(EntityUid uid, SpecialAppliedMedicalHudComponent applied)
+    {
         if (applied.AddedHealthBars)
+        {
             RemComp<ShowHealthBarsComponent>(uid);
+            applied.AddedHealthBars = false;
+        }
 
         if (applied.AddedHealthIcons)
+        {
             RemComp<ShowHealthIconsComponent>(uid);
+            applied.AddedHealthIcons = false;
+        }
+    }
 
-        RemComp<SpecialAppliedMedicalHudComponent>(uid);
+    private void OnMedicalHudShutdown(EntityUid uid, SpecialAppliedMedicalHudComponent component, ComponentShutdown args)
+    {
+        _actions.RemoveAction(uid, component.ActionEntity);
+    }
+
+    private void OnMedicalHudToggle(EntityUid uid, SpecialAppliedMedicalHudComponent component, SpecialMedicalHudToggleActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        component.Enabled = !component.Enabled;
+
+        if (component.Enabled)
+            EnsureMedicalHud(uid);
+        else
+            ClearMedicalHudComponents(uid, component);
+
+        args.Handled = true;
     }
 
     private static void EnsureBiologicalContainer(ICollection<string> damageContainers)

--- a/Content.Shared/_Misfits/SpecialStats/SpecialMedicalHudToggleActionEvent.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialMedicalHudToggleActionEvent.cs
@@ -1,0 +1,8 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._Misfits.SpecialStats;
+
+/// <summary>
+/// Toggles the medical HUD granted by maximum Intelligence.
+/// </summary>
+public sealed partial class SpecialMedicalHudToggleActionEvent : InstantActionEvent;

--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -137,7 +137,7 @@
           WhiteLegsStormDrummer: [ 0, 0 ] # #Misfits Add - prototype-ready rank, no placed map marker yet.
           # WhiteLegsPainMaker: [ 0, 0 ] # #Misfits Change - legacy hidden rank removed from join rotation; WhiteLegs now covers the visible tribal entry slot.
           FollowerVolunteer: [ 2, 2 ] # #Misfits Change - Followers job replaced by ranked hierarchy
-          FollowerDoctor: [ 1, 1 ]   # #Misfits Add - Doctor rank slot
+          FollowerDoctor: [ 2, 2 ]   # #Misfits Add - Doctor rank slot
           FollowerHead: [ 1, 1 ]     # #Misfits Fix - allow Head to round-start as well as latejoin
           SyntheticMrHandy: [ 1, 3 ]
           SyntheticProtectron: [ 1, 3 ]

--- a/Resources/Prototypes/_Misfits/SpecialStats/actions.yml
+++ b/Resources/Prototypes/_Misfits/SpecialStats/actions.yml
@@ -1,0 +1,12 @@
+- type: entity
+  parent: ActionBase
+  id: ActionToggleSpecialMedicalHud
+  name: Toggle medical insight
+  description: Toggle the medical HUD granted by maximum Intelligence.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    icon: { sprite: Clothing/Eyes/Hud/med.rsi, state: icon }
+    iconOn: { sprite: Clothing/Eyes/Hud/med.rsi, state: icon }
+    event: !type:SpecialMedicalHudToggleActionEvent
+    useDelay: 0.25

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Machines/grill.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Machines/grill.yml
@@ -38,6 +38,9 @@
           Low: { visible: true, state: stove_on }
           Medium: { visible: true, state: stove_on }
           High: { visible: true, state: stove_on }
+  - type: ApcPowerReceiver
+    powerLoad: 0
+    needsPower: false
   # #Misfits Change /Add/ - Keep the stove audible while it is actively heating.
   - type: SpamEmitSound
     enabled: false


### PR DESCRIPTION
## About the PR
Fixes propane grills and stoves so they heat food properly, adds a hotbar toggle for the 10 Intelligence medhud effect, and raises FOTA Doctor slots on Wendover from 1 to 2.

## Why / Balance
Propane grills and stoves were not functioning correctly because fuel/non-powered heaters were still being treated like powered APC heaters in parts of the heating logic.

The 10 INT medhud effect is useful, but always-on HUD overlays can be intrusive. Giving players a hotbar toggle keeps the perk benefit while letting them turn it off when they do not want the overlay.

FOTA Doctor slots were raised by one.

## Technical details
Updated `EntityHeaterSystem` so heaters with `needsPower: false` can still heat placed entities using their configured heater power instead of relying on APC `PowerReceived`.
Updated grill/stove heater sound checks so non-powered heaters count as active when their heater setting is on.

Added `ApcPowerReceiver` with `needsPower: false` to the N14 cooking stove prototypes so they work through the same heater path as grills.

Added `SpecialMedicalHudToggleActionEvent` and `ActionToggleSpecialMedicalHud`. The 10 INT medhud grant now adds a hotbar action, tracks whether the effect is enabled, and only removes the health bar/icon components that SPECIAL added.

Updated Wendover job slots:
`FollowerDoctor: [ 1, 1 ]` -> `FollowerDoctor: [ 2, 2 ]`

# Changelog

:cl:
- fix: Fixed propane grills and stoves not heating food properly.
- add: Added a hotbar toggle for the medical HUD effect granted by 10 Intelligence.
- tweak: Increased Followers of the Apocalypse Doctor slots by one.