### PR TITLE
Adds FOTA Guards

### DIFF
--- a/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
+++ b/Content.Server/Temperature/Systems/EntityHeaterSystem.cs
@@ -34,7 +34,7 @@ public sealed class EntityHeaterSystem : EntitySystem
         var query = EntityQueryEnumerator<EntityHeaterComponent, ItemPlacerComponent, ApcPowerReceiverComponent>();
         while (query.MoveNext(out var uid, out var comp, out var placer, out var power))
         {
-            if (!power.Powered)
+            if (power.NeedsPower && !power.Powered)
                 continue;
 
             // don't divide by total entities since its a big grill
@@ -94,7 +94,9 @@ public sealed class EntityHeaterSystem : EntitySystem
     {
         // disable heating element glowing layer if theres no power
         // doesn't actually turn it off since that would be annoying
-        var setting = args.Powered ? comp.Setting : EntityHeaterSetting.Off;
+        var setting = args.Powered || !Comp<ApcPowerReceiverComponent>(uid).NeedsPower
+            ? comp.Setting
+            : EntityHeaterSetting.Off;
         _appearance.SetData(uid, EntityHeaterVisuals.Setting, setting);
     }
 

--- a/Content.Server/_Misfits/Sound/GrillHeaterSoundSystem.cs
+++ b/Content.Server/_Misfits/Sound/GrillHeaterSoundSystem.cs
@@ -81,7 +81,7 @@ public sealed class GrillHeaterSoundSystem : EntitySystem
     {
         if (TryComp<EntityHeaterComponent>(uid, out var heater)
             && TryComp<ApcPowerReceiverComponent>(uid, out var power)
-            && power.Powered)
+            && (!power.NeedsPower || power.Powered))
         {
             return heater.Setting != EntityHeaterSetting.Off;
         }

--- a/Content.Server/_Misfits/SpecialStats/Components/SpecialAppliedMedicalHudComponent.cs
+++ b/Content.Server/_Misfits/SpecialStats/Components/SpecialAppliedMedicalHudComponent.cs
@@ -6,6 +6,9 @@ namespace Content.Server._Misfits.SpecialStats.Components;
 [RegisterComponent]
 public sealed partial class SpecialAppliedMedicalHudComponent : Component
 {
+    public string Action = "ActionToggleSpecialMedicalHud";
+    public EntityUid? ActionEntity;
+    public bool Enabled = true;
     public bool AddedHealthBars;
     public bool AddedHealthIcons;
 }

--- a/Content.Server/_Misfits/SpecialStats/LuckJunkBonusComponent.cs
+++ b/Content.Server/_Misfits/SpecialStats/LuckJunkBonusComponent.cs
@@ -82,9 +82,6 @@ public sealed partial class LuckJunkBonusComponent : Component
         new("N14PlasmaShell", LuckyLootRarity.Rare),
         new("40mmGrenadeFrag", LuckyLootRarity.Rare),
         new("40mmGrenadeFire", LuckyLootRarity.Rare),
-        new("CartridgeMissile", LuckyLootRarity.Rare),
-        new("MagazineBox50HEIAP", LuckyLootRarity.Rare),
-        new("N14Magazine50AMRHEIAP", LuckyLootRarity.Rare),
 
         new("N14SuperStimpak", LuckyLootRarity.VeryRare),
 

--- a/Content.Server/_Misfits/SpecialStats/SpecialIntelligenceHudSystem.cs
+++ b/Content.Server/_Misfits/SpecialStats/SpecialIntelligenceHudSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server._Misfits.SpecialStats.Components;
+using Content.Server.Actions;
 using Content.Shared._Misfits.Special;
 using Content.Shared._Misfits.Special.Components;
 using Content.Shared._Misfits.SpecialStats;
@@ -11,6 +12,7 @@ namespace Content.Server._Misfits.SpecialStats;
 /// </summary>
 public sealed class SpecialIntelligenceHudSystem : EntitySystem
 {
+    [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     private const int MedicalHudIntelligenceThreshold = 10;
@@ -23,6 +25,8 @@ public sealed class SpecialIntelligenceHudSystem : EntitySystem
         SubscribeLocalEvent<SpecialChangedEvent>(OnSpecialChanged);
         SubscribeLocalEvent<SpecialStatsReadyEvent>(OnStatsReady);
         SubscribeLocalEvent<SpecialShutdownEvent>(OnSpecialShutdown);
+        SubscribeLocalEvent<SpecialAppliedMedicalHudComponent, ComponentShutdown>(OnMedicalHudShutdown);
+        SubscribeLocalEvent<SpecialAppliedMedicalHudComponent, SpecialMedicalHudToggleActionEvent>(OnMedicalHudToggle);
     }
 
     private void OnSpecialChanged(ref SpecialChangedEvent args)
@@ -53,6 +57,11 @@ public sealed class SpecialIntelligenceHudSystem : EntitySystem
     private void EnsureMedicalHud(EntityUid uid)
     {
         var applied = EnsureComp<SpecialAppliedMedicalHudComponent>(uid);
+        _actions.AddAction(uid, ref applied.ActionEntity, applied.Action);
+        _actions.SetToggled(applied.ActionEntity, applied.Enabled);
+
+        if (!applied.Enabled)
+            return;
 
         if (!HasComp<ShowHealthBarsComponent>(uid))
         {
@@ -76,13 +85,43 @@ public sealed class SpecialIntelligenceHudSystem : EntitySystem
         if (!TryComp<SpecialAppliedMedicalHudComponent>(uid, out var applied))
             return;
 
+        ClearMedicalHudComponents(uid, applied);
+        RemComp<SpecialAppliedMedicalHudComponent>(uid);
+    }
+
+    private void ClearMedicalHudComponents(EntityUid uid, SpecialAppliedMedicalHudComponent applied)
+    {
         if (applied.AddedHealthBars)
+        {
             RemComp<ShowHealthBarsComponent>(uid);
+            applied.AddedHealthBars = false;
+        }
 
         if (applied.AddedHealthIcons)
+        {
             RemComp<ShowHealthIconsComponent>(uid);
+            applied.AddedHealthIcons = false;
+        }
+    }
 
-        RemComp<SpecialAppliedMedicalHudComponent>(uid);
+    private void OnMedicalHudShutdown(EntityUid uid, SpecialAppliedMedicalHudComponent component, ComponentShutdown args)
+    {
+        _actions.RemoveAction(uid, component.ActionEntity);
+    }
+
+    private void OnMedicalHudToggle(EntityUid uid, SpecialAppliedMedicalHudComponent component, SpecialMedicalHudToggleActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        component.Enabled = !component.Enabled;
+
+        if (component.Enabled)
+            EnsureMedicalHud(uid);
+        else
+            ClearMedicalHudComponents(uid, component);
+
+        args.Handled = true;
     }
 
     private static void EnsureBiologicalContainer(ICollection<string> damageContainers)

--- a/Content.Shared/_Misfits/SpecialStats/SpecialMedicalHudToggleActionEvent.cs
+++ b/Content.Shared/_Misfits/SpecialStats/SpecialMedicalHudToggleActionEvent.cs
@@ -1,0 +1,8 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._Misfits.SpecialStats;
+
+/// <summary>
+/// Toggles the medical HUD granted by maximum Intelligence.
+/// </summary>
+public sealed partial class SpecialMedicalHudToggleActionEvent : InstantActionEvent;

--- a/Resources/Locale/en-US/_Misfits/job-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/job-names.ftl
@@ -101,6 +101,8 @@ job-name-follower-head = Followers Head
 job-description-follower-head = You lead this chapter of the Followers. The sick, the curious, and the desperate look to you for direction. Set the example, protect your people, and keep the mission alive.
 job-name-follower-doctor = Followers Doctor
 job-description-follower-doctor = You are a trained Follower physician. Stitch the wounded, study the wastes, and push medicine into places NCR and Brotherhood dare not go.
+job-name-follower-guard = Followers Guard
+job-description-follower-guard = You protect the Followers' clinic, escort doctors into dangerous ground, and keep desperate people from turning the humanitarian mission into another battlefield.
 job-name-follower-volunteer = Followers Volunteer
 job-description-follower-volunteer = You are new to the Followers. You believe knowledge and compassion can outlast bullets and bombs. Prove it — learn from those above you and help anyone who needs it.
 

--- a/Resources/Locale/en-US/_Misfits/job-supervisors.ftl
+++ b/Resources/Locale/en-US/_Misfits/job-supervisors.ftl
@@ -35,4 +35,5 @@ job-supervisors-bos-initiate = the Brotherhood chain of command
 # #Misfits Add - Followers of the Apocalypse supervisor strings.
 job-supervisors-follower-head = yourself and the Followers' founding charter
 job-supervisors-follower-doctor = the Follower Head and the Followers' medical mission
+job-supervisors-follower-guard = the Follower Head and the doctors you are protecting
 job-supervisors-follower-volunteer = the Follower Doctors and Follower Head above you

--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -137,6 +137,7 @@
           WhiteLegsStormDrummer: [ 0, 0 ] # #Misfits Add - prototype-ready rank, no placed map marker yet.
           # WhiteLegsPainMaker: [ 0, 0 ] # #Misfits Change - legacy hidden rank removed from join rotation; WhiteLegs now covers the visible tribal entry slot.
           FollowerVolunteer: [ 2, 2 ] # #Misfits Change - Followers job replaced by ranked hierarchy
+          FollowerGuard: [ 2, 2 ]      # #Misfits Add - FOTA compound guards
           FollowerDoctor: [ 1, 1 ]   # #Misfits Add - Doctor rank slot
           FollowerHead: [ 1, 1 ]     # #Misfits Fix - allow Head to round-start as well as latejoin
           SyntheticMrHandy: [ 1, 3 ]

--- a/Resources/Prototypes/Maps/Misfits/Wendover.yml
+++ b/Resources/Prototypes/Maps/Misfits/Wendover.yml
@@ -137,7 +137,7 @@
           WhiteLegsStormDrummer: [ 0, 0 ] # #Misfits Add - prototype-ready rank, no placed map marker yet.
           # WhiteLegsPainMaker: [ 0, 0 ] # #Misfits Change - legacy hidden rank removed from join rotation; WhiteLegs now covers the visible tribal entry slot.
           FollowerVolunteer: [ 2, 2 ] # #Misfits Change - Followers job replaced by ranked hierarchy
-          FollowerDoctor: [ 1, 1 ]   # #Misfits Add - Doctor rank slot
+          FollowerDoctor: [ 2, 2 ]   # #Misfits Add - Doctor rank slot
           FollowerHead: [ 1, 1 ]     # #Misfits Fix - allow Head to round-start as well as latejoin
           SyntheticMrHandy: [ 1, 3 ]
           SyntheticProtectron: [ 1, 3 ]

--- a/Resources/Prototypes/_Misfits/Catalog/Fills/Factions/idcards.yml
+++ b/Resources/Prototypes/_Misfits/Catalog/Fills/Factions/idcards.yml
@@ -71,6 +71,8 @@
     contents:
     - id: N14IDFollowerVolunteer
       amount: 4
+    - id: N14IDFollowerGuard
+      amount: 2
     - id: N14IDFollowerDoctor
       amount: 4
   - type: Sprite

--- a/Resources/Prototypes/_Misfits/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Markers/Spawners/jobs.yml
@@ -809,6 +809,14 @@
 
 - type: entity
   parent: N14SpawnPointFollowers
+  id: MisfitsSpawnPointFollowerGuard
+  name: follower guard
+  components:
+  - type: SpawnPoint
+    job_id: FollowerGuard
+
+- type: entity
+  parent: N14SpawnPointFollowers
   id: MisfitsSpawnPointFollowerHead
   name: follower head
   components:

--- a/Resources/Prototypes/_Misfits/Entities/Structures/Doors/doors_80s.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Structures/Doors/doors_80s.yml
@@ -40,7 +40,7 @@
 
 - type: entity
   parent: N14DoorCell
-  id: N14DoorCellSlantedLocked80s
+  id: N14DoorCellLocked80s
   suffix: 80s, Locked
   components:
   - type: AccessReader

--- a/Resources/Prototypes/_Misfits/Entities/Structures/Doors/doors_80s.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Structures/Doors/doors_80s.yml
@@ -39,6 +39,27 @@
     layoutId: AirlockCargo
 
 - type: entity
+  parent: N14DoorCell
+  id: N14DoorCellSlantedLocked80s
+  suffix: 80s, Locked
+  components:
+  - type: AccessReader
+    access: [["80s"]]
+  - type: Wires
+    layoutId: AirlockCargo
+
+- type: entity
+  parent: N14DoorCellRust
+  id: MisfitsDoorCellRustLocked80s
+  suffix: 80s, Locked
+  components:
+  - type: AccessReader
+    access: [["80s"]]
+  - type: Wires
+    layoutId: AirlockCargo
+
+
+- type: entity
   parent: N14DoorWoodWhiteSlanted
   id: N14DoorWoodSlantedWhiteLocked80s
   suffix: 80s, Locked

--- a/Resources/Prototypes/_Misfits/Entities/Structures/Doors/doors_bos.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Structures/Doors/doors_bos.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
-  parent: N14DoorMetalBarSlanted
-  id: MisfitsDoorMetalBarSlantedBoSMidwestKnight
+  parent: N14DoorCell
+  id: MisfitsDoorCellBoSMidwestKnight
   suffix: BoSMidwest, Locked, Knight
   components:
   - type: ContainerFill
@@ -10,8 +10,8 @@
     layoutId: HighSec
 
 - type: entity
-  parent: HighSecDoor
-  id: MisfitsHighSecDoorLockedBoSMidwestKnight
+  parent: N14DoorCellRust
+  id: MisfitsDoorCellRustBoSMidwestKnight
   suffix: BoSMidwest, Locked, Knight
   components:
   - type: ContainerFill

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Followers/followers.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Followers/followers.yml
@@ -1,6 +1,6 @@
 # #Misfits Add - Followers of the Apocalypse department and ranked jobs.
 # Replaces the single upstream Followers job (now commented out in _Nuclear14/Roles/Jobs/Fun/followers.yml).
-# Hierarchy: Follower Head > Follower Doctor > Follower Volunteer
+# Hierarchy: Follower Head > Follower Doctor > Follower Guard > Follower Volunteer
 
 - type: department
   id: FollowersOfTheApocalypse
@@ -10,6 +10,7 @@
   roles:
   - FollowerHead
   - FollowerDoctor
+  - FollowerGuard
   - FollowerVolunteer
   - SuperMutantFollowerDoctor
 
@@ -165,7 +166,88 @@
 - type: playTimeTracker
   id: FollowerDoctor
 
-# ─── Follower Volunteer ───────────────────────────────────────────────────────
+# --- Follower Guard ----------------------------------------------------------
+- type: job
+  id: FollowerGuard
+  setPreference: true
+  jobWhitelistBypassesRoleTimers: true
+  weight: 103
+  displayWeight: 108
+  showBorder: true
+  canBeAntag: false
+  name: job-name-follower-guard
+  description: job-description-follower-guard
+  playTimeTracker: FollowerGuard
+  startingGear: FollowerGuardGear
+  icon: "JobIconPassenger"
+  supervisors: job-supervisors-follower-guard
+  alwaysUseSpawner: true
+  accessGroups:
+  - FollowersApocalypse
+  - FotA
+  requirements:
+  - !type:CharacterPlaytimeRequirement
+    tracker: FollowerVolunteer
+    min: 7200 # 2 hours as Follower Volunteer
+  - !type:CharacterDepartmentTimeRequirement
+    department: FollowersOfTheApocalypse
+    min: 10800 # 3 hours in faction
+  - !type:CharacterSpeciesRequirement
+    inverted: true
+    species:
+    - RobotMrHandy
+    - RobotMrGutsy
+    - RobotProtectron
+    - RobotProtectronPolice
+    - RobotProtectronBuilder
+    - RobotProtectronFire
+    - RobotAssaultron
+    - RobotAssaultronTesla
+    - RobotSentryBot
+    - RobotSentryBotLaser
+    - RobotRobobrain
+    - RobotRobobrainLaser
+    - SuperMutant
+    - Nightkin
+  special:
+  - !type:AddComponentSpecial
+    components:
+      - type: NpcFactionMember
+        factions:
+          - Wastelander
+          - Followers # #Misfits Add - enables Followers death-alert targeting
+      - type: CPRTraining
+  - !type:AddTraitSpecial
+    traits:
+    - FiremanCarry
+
+- type: startingGear
+  id: FollowerGuardGear
+  equipment:
+    jumpsuit: N14ClothingUniformJumpsuitFollowers
+    back: N14ClothingBackpackSatchelMilitary
+    shoes: N14ClothingBootsLeatherFilled
+    id: N14IDFollowerGuard
+    ears: N14ClothingHeadsetFollowers
+    outerClothing: N14ClothingOuterCoatFollowersArmored
+    belt: ClothingBelt10mmfilled
+    pocket1: Handcuffs
+    pocket2: N14HandheldHealthAnalyzer
+  innerClothingSkirt: N14ClothingUniformJumpskirtFalloutBlack
+  satchel: N14ClothingBackpackSatchelWastelanderFilled
+  duffelbag: N14ClothingBackpackDuffelFilled
+  storage:
+    back:
+    - N14BoxPlasticFilledWastelander
+    - N14PoliceBaton
+    - N14CombatKnife
+    - MagazineBox10mm
+    - Brutepack
+
+- type: playTimeTracker
+  id: FollowerGuard
+
+# --- Follower Volunteer ------------------------------------------------------
 - type: job
   id: FollowerVolunteer
   setPreference: true

--- a/Resources/Prototypes/_Misfits/SpecialStats/actions.yml
+++ b/Resources/Prototypes/_Misfits/SpecialStats/actions.yml
@@ -1,0 +1,12 @@
+- type: entity
+  parent: ActionBase
+  id: ActionToggleSpecialMedicalHud
+  name: Toggle medical insight
+  description: Toggle the medical HUD granted by maximum Intelligence.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    icon: { sprite: Clothing/Eyes/Hud/med.rsi, state: icon }
+    iconOn: { sprite: Clothing/Eyes/Hud/med.rsi, state: icon }
+    event: !type:SpecialMedicalHudToggleActionEvent
+    useDelay: 0.25

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
@@ -736,6 +736,19 @@
 
 - type: entity
   parent: N14IDDoctor
+  id: N14IDFollowerGuard
+  name: followers (guard) ID
+  description: An ID card worn by the Followers of the Apocalypse.
+  components:
+  - type: Tag
+    tags:
+    - IdCardFollowers
+  - type: Access
+    tags:
+    - FotA
+
+- type: entity
+  parent: N14IDDoctor
   id: N14IDFollowerHead
   name: followers (head) ID
   description: An ID card worn by the Followers of the Apocalypse.

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Machines/grill.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Machines/grill.yml
@@ -38,6 +38,9 @@
           Low: { visible: true, state: stove_on }
           Medium: { visible: true, state: stove_on }
           High: { visible: true, state: stove_on }
+  - type: ApcPowerReceiver
+    powerLoad: 0
+    needsPower: false
   # #Misfits Change /Add/ - Keep the stove audible while it is actively heating.
   - type: SpamEmitSound
     enabled: false

--- a/Resources/Prototypes/_Nuclear14/Traits/mental.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/mental.yml
@@ -114,6 +114,7 @@
         - VaultDoctor
         - FollowerHead    # #Misfits Change - Followers job replaced by ranked hierarchy
         - FollowerDoctor
+        - FollowerGuard
         - FollowerVolunteer
   functions:
     - !type:TraitAddComponent

--- a/Resources/Prototypes/_Nuclear14/Traits/physical.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/physical.yml
@@ -26,6 +26,7 @@
       jobs:
         - FollowerHead    # #Misfits Change - Followers job replaced by ranked hierarchy
         - FollowerDoctor
+        - FollowerGuard
         - FollowerVolunteer
     # Forge-Change-End
     - !type:CharacterTraitRequirement
@@ -115,6 +116,7 @@
       jobs:
         - FollowerHead    # #Misfits Change - Followers job replaced by ranked hierarchy
         - FollowerDoctor
+        - FollowerGuard
         - FollowerVolunteer
     # Forge-Change-End
     - !type:CharacterTraitRequirement
@@ -210,6 +212,7 @@
       jobs:
         - FollowerHead    # #Misfits Change - Followers job replaced by ranked hierarchy
         - FollowerDoctor
+        - FollowerGuard
         - FollowerVolunteer
     # Forge-Change-End
     - !type:CharacterTraitRequirement
@@ -295,6 +298,7 @@
       jobs:
         - FollowerHead    # #Misfits Change - Followers job replaced by ranked hierarchy
         - FollowerDoctor
+        - FollowerGuard
         - FollowerVolunteer
   # Forge-Change-End
   functions:
@@ -384,6 +388,7 @@
       jobs:
         - FollowerHead    # #Misfits Change - Followers job replaced by ranked hierarchy
         - FollowerDoctor
+        - FollowerGuard
         - FollowerVolunteer
     # Forge-Change-End
     # Misfits Fix: CharacterTraitRequirement block removed — all referenced N14ExtremeAug* traits are commented out
@@ -456,6 +461,7 @@
         - BoSWestElderCommander
         - FollowerHead    # #Misfits Change - Followers job replaced by ranked hierarchy
         - FollowerDoctor
+        - FollowerGuard
         - FollowerVolunteer
         # Forge-Change-End
     - !type:CharacterTraitRequirement


### PR DESCRIPTION
## About the PR
Adds a new Followers of the Apocalypse Guard role.

## Why / Balance
Followers now have dedicated defensive personnel for protecting the clinic and escorting doctors into dangerous areas. The role is capped at 2 slots, has FotA access only, and uses a defensive loadout rather than full military gear, keeping it below organized faction combat roles while giving Followers some protection.

Propane grills and stoves were not functioning correctly because fuel/non-powered heaters were still being treated like powered APC heaters in parts of the heating logic.

The 10 INT medhud effect is useful, but always-on HUD overlays can be intrusive. Giving players a hotbar toggle keeps the perk benefit while letting them turn it off when they do not want the overlay.

FOTA Doctor slots were raised by one.

## Technical details
Added `FollowerGuard`, `FollowerGuardGear`, and its playtime tracker to the Followers job prototype. Added the role to the Followers department, Wendover job slots, map spawn markers, ID card prototypes, spare ID box, localization, and trait exclusions. The loadout includes Followers clothing, armored Followers coat, FotA headset, guard ID, 10mm revolver belt, baton, cuffs, knife, basic medical supplies, and a health analyzer.

Updated `EntityHeaterSystem` so heaters with `needsPower: false` can still heat placed entities using their configured heater power instead of relying on APC `PowerReceived`.
Updated grill/stove heater sound checks so non-powered heaters count as active when their heater setting is on.

Added `ApcPowerReceiver` with `needsPower: false` to the N14 cooking stove prototypes so they work through the same heater path as grills.

Added `SpecialMedicalHudToggleActionEvent` and `ActionToggleSpecialMedicalHud`. The 10 INT medhud grant now adds a hotbar action, tracks whether the effect is enabled, and only removes the health bar/icon components that SPECIAL added.

Updated Wendover job slots:
`FollowerDoctor: [ 1, 1 ]` -> `FollowerDoctor: [ 2, 2 ]`

# Changelog

:cl:
- add: Added Followers of the Apocalypse Guard.
- add: More doors for mappers
- tweak: Removes the funny one shot bullets from Lucky Drops.
- fix: Fixed propane grills and stoves not heating food properly.
- add: Added a hotbar toggle for the medical HUD effect granted by 10 Intelligence.
- tweak: Increased Followers of the Apocalypse Doctor slots by one.