### PR TITLE
BOS & Legion Access; Headset Box Fixes

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -77,11 +77,13 @@ public sealed partial class IdCardConsoleComponent : Component
         "CaesarLegion", // Misfit: Legion Start
         "CaesarLegionSlave",
         "CaesarLegionFrumentarii",
-        "CaesarLegionPrimeDecanus",
-        "CaesarLegionVeteranDecanus",
+        "CaesarLegionVexillarius",
+        "CaesarLegionLegionnaireRecruit",
+        "CaesarLegionLegionnaireWarrior",
+        "CaesarLegionLegionnaireVeteran",
         "CaesarLegionDean",
+        "CaesarLegionVeteranDecanus",
         "CaesarLegionOrator",
-        "CaesarLegionPriestessOfMars",
         "CaesarLegionCenturion",
         "BOS", // Misfit: BOS Start
         "BOSInitiate",

--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -52,43 +52,45 @@ public sealed partial class IdCardConsoleComponent : Component
         "TownieLaw",
         "TownieMayor",
         "TownsPerson",
-        "FotA", //Misfit Addition
-        "FotADoctor", //Misfit Addition
-        "FotAHead", //Misfit Addition
         "WastelandReporter",
         "WastelandBartender",
         "InnRoomOne",
         "InnRoomTwo",
         "InnRoomThree",
-        "VaultDweller",
+        "FotA", // Misfit: FotA Start
+        "FotADoctor",
+        "FotAHead",
+        "VaultDweller", // Misfit: Vault Start
         "VaultEngineer",
         "VaultMedical",
         "VaultSecurity",
         "VaultOverseer",
-        "TribeMember",
+        "TribeMember", // Misfit: Tribe Start
         "TribeChief",
-        // "CaravanCompanyGuard",
-        "WastelandChaplain",
+        "WastelandChaplain", // Misfit: Wastelander
         "WastelandFarmer",
-        // #Misfits Change /Comment-out/: Washington BoS access strings removed.
-        // "WashingtonInitiate",
-        // "WashingtonKnight",
-        // "WashingtonScribe",
-        // "WashingtonPaladin",
-        // "WashingtonCommander",
-        "NCR",
+        "NCR", // Misfit: NCR Start
         "NCRSGT",
         "NCRMedic",
         "NCRLT",
         "NCRRanger",
-        "BOS",
+        "CaesarLegion", // Misfit: Legion Start
+        "CaesarLegionSlave",
+        "CaesarLegionFrumentarii",
+        "CaesarLegionPrimeDecanus",
+        "CaesarLegionVeteranDecanus",
+        "CaesarLegionDean",
+        "CaesarLegionOrator",
+        "CaesarLegionPriestessOfMars",
+        "CaesarLegionCenturion",
+        "BOS", // Misfit: BOS Start
         "BOSInitiate",
         "BOSKnight",
         "BOSScribe",
         "BOSPaladin",
         "BOSPaladinCommander",
-        "80s", //Misfit Addition
-        "80sHead", //Misfit Addition
+        "80s", // Misfit: 80s Start
+        "80sHead",
     };
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -90,7 +90,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "BOSKnight",
         "BOSScribe",
         "BOSPaladin",
-        "BOSPaladinCommander",
+        "BOSHeadPaladin",
         "80s", // Misfit: 80s Start
         "80sHead",
     };

--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -81,11 +81,12 @@ public sealed partial class IdCardConsoleComponent : Component
         "NCRMedic",
         "NCRLT",
         "NCRRanger",
-        "BoSMidwest",
-        "Knight",
-        "Scribe",
-        "Paladin",
-        "PaladinCommander",
+        "BOS",
+        "BOSInitiate",
+        "BOSKnight",
+        "BOSScribe",
+        "BOSPaladin",
+        "BOSPaladinCommander",
         "80s", //Misfit Addition
         "80sHead", //Misfit Addition
     };

--- a/Resources/Prototypes/_Misfits/Access/brotherhood_of_steel.yml
+++ b/Resources/Prototypes/_Misfits/Access/brotherhood_of_steel.yml
@@ -91,8 +91,8 @@
   - BOSInitiate
   - BOSScribe
   - BOSSeniorScribe  # #Misfits Change - unified faction
-  - BOSKnight
-  - BOSSeniorKnight  # #Misfits Change - unified faction
+  #- BOSKnight
+  #- BOSSeniorKnight  # #Misfits Change - disallow regular paladin into armory
   - BOSPaladin
   - BOSSeniorPaladin  # #Misfits Change - unified faction: paladins open all paladin-wing doors
 

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_elder.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_elder.yml
@@ -30,6 +30,13 @@
         factions:
           - BrotherhoodOfSteel
       - type: PowerArmorProficiency # #Misfits Add: Elder can equip power armor.
+      - type: LanguageKnowledge # #Misfits Add: Elders speak and understand Brotherhood binary code by default.
+        speaks:
+        - English
+        - N14BrotherBeep
+        understands:
+        - English
+        - N14BrotherBeep
 
 - type: startingGear
   id: BoSWestElderCommanderGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headknight.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headknight.yml
@@ -86,6 +86,12 @@
       - type: NpcFactionMember
         factions:
           - BrotherhoodOfSteel
+      - type: LanguageKnowledge # #Misfits Add: Heads understand Brotherhood binary code by default.
+        speaks:
+        - English
+        understands:
+        - English
+        - N14BrotherBeep
 
 - type: startingGear
   id: BoSHeadKnightGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
@@ -37,6 +37,12 @@
         factions:
           - BrotherhoodOfSteel
       - type: PowerArmorProficiency
+      - type: LanguageKnowledge # #Misfits Add: Heads understand Brotherhood binary code by default.
+        speaks:
+        - English
+        understands:
+        - English
+        - N14BrotherBeep
 
 - type: startingGear
   id: BoSMidPaladinCommanderGear

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
@@ -26,6 +26,8 @@
     # equippedPrefix: alt
     slots:
     - ears
+  - type: Item
+    size: Small
 
 - type: entity
   parent: N14ClothingHeadsetAlt

--- a/Resources/Prototypes/_Nuclear14/Traits/speech.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/speech.yml
@@ -63,11 +63,10 @@
   - !type:CharacterDepartmentRequirement
     departments:
     - BrotherhoodOfSteel
-  - !type:CharacterJobRequirement # Misfit Change
+  - !type:CharacterJobRequirement
     inverted: true
     jobs:
     - BoSMidScribe
-    - BOSSeniorScribe
     - BoSWestScribe
     - BoSMidPaladinCommander
     - BoSHeadKnight

--- a/Resources/Prototypes/_Nuclear14/Traits/speech.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/speech.yml
@@ -60,16 +60,17 @@
   category: Speech
   points: -2
   requirements:
-  # Misfits Fix: CharacterTraitRequirement block removed — all referenced N14ExtremeAug* traits are commented out
-  #- !type:CharacterTraitRequirement
-  #  inverted: true
-  #  traits:
-  #  - N14ExtremeAugKnight
-  #  - N14ExtremeAugScribe
-  #  - N14ExtremeAugPaladin
   - !type:CharacterDepartmentRequirement
     departments:
     - BrotherhoodOfSteel
+  - !type:CharacterDepartmentRequirement # Misfit Change
+    inverted: true
+    jobs:
+    - BoSMidScribe
+    - BOSSeniorScribe
+    - BoSWestScribe
+    - BoSMidPaladinCommander
+    - BoSHeadKnight
   functions:
   - !type:TraitModifyLanguages
     languagesSpoken:
@@ -103,19 +104,14 @@
     - NCRStaffSergeant
     - NCRNCO
     - NCRRO
-#    - CaravanLeader
-#    - BoSWashingtonCommander
-#    - BoSWashingtonPaladin
     - BoSMidPaladinCommander
     - BoSMidPaladin
-    # Forge-Change-Start
     - NCRWS
     - NCREngineer
     - NCRMedic
     - NCRPrivateFirstClass
     - NCRSoldier
     - NCRCadet
-    #- BoSMidInquisitor # Misfits Fix: job prototype commented out
     - BoSMidScribe
     - BoSMidKnight
     - BoSMidSquire
@@ -134,8 +130,6 @@
     - CaesarLegionLegionnaireRecruit
     - CaesarLegionHoundmaster
     - CaesarLegionAuxilia
-    # #Misfits Change: CaesarLegionRecruit removed — Legionnaire covers entry-level.
-    # Forge-Change-End
     - Overseer
     - VaultSecurity
   - !type:CharacterTraitRequirement

--- a/Resources/Prototypes/_Nuclear14/Traits/speech.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/speech.yml
@@ -66,6 +66,7 @@
   - !type:CharacterJobRequirement
     inverted: true
     jobs:
+    - BoSScribe
     - BoSMidScribe
     - BoSWestScribe
     - BoSMidPaladinCommander

--- a/Resources/Prototypes/_Nuclear14/Traits/speech.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/speech.yml
@@ -63,7 +63,7 @@
   - !type:CharacterDepartmentRequirement
     departments:
     - BrotherhoodOfSteel
-  - !type:CharacterDepartmentRequirement # Misfit Change
+  - !type:CharacterJobRequirement # Misfit Change
     inverted: true
     jobs:
     - BoSMidScribe


### PR DESCRIPTION
<img width="1433" height="230" alt="image" src="https://github.com/user-attachments/assets/982e8565-5b4e-4d18-a4b8-9d8c22b95ae2" />

<img width="1159" height="483" alt="image" src="https://github.com/user-attachments/assets/a75858e3-bc22-41a8-91f5-18a12fdf1dcb" />





:cl: Lucky
- fix: BOS and Legion can now correctly change the ID accesses.
- fix: Faction headset boxes are now filled correctly.
- tweak: BOS Heads can now always understand Brotherhood Code.
- fix: BOS Code can no longer be selected as Head Member, Scribe, or Senior Scribe.

