### PR TITLE
Sentry Bot Buff

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/robots.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/robots.yml
@@ -861,14 +861,14 @@
   - type: MovementSpeedModifier
     # Misfits Tweak: reduced further — sentry bots are heavy siege walkers, not pursuit units.
     baseWalkSpeed: 0.75
-    baseSprintSpeed: 1.2
+    baseSprintSpeed: 1.0
   # Misfits Change /Add: Prevent players from dragging this robot around.
-  # At 350 HP and covered in combat plating it is far too heavy to be moved.
+  # At 1000 HP and covered in combat plating it is far too heavy to be moved.
   - type: NoPull
   - type: MobThresholds
     thresholds:
       0: Alive
-      350: Dead
+      750: Dead
     stateAlertDict:
       Alive: BorgHealth
       Dead: HumanDead
@@ -988,7 +988,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 350
+        damage: 750
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
@@ -1041,13 +1041,13 @@
   - type: MovementSpeedModifier
     # Misfits Tweak: reduced further — sentry bots are heavy siege walkers, not pursuit units.
     baseWalkSpeed: 0.75
-    baseSprintSpeed: 1.2
+    baseSprintSpeed: 1.0
   # Misfits Change /Add: Prevent players from dragging this robot around.
   - type: NoPull
   - type: MobThresholds
     thresholds:
       0: Alive
-      350: Dead
+      1000: Dead
     stateAlertDict:
       Alive: BorgHealth
       Dead: HumanDead
@@ -1167,19 +1167,19 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 350
+        damage: 1000
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
           N14ScrapElectronic1:
             min: 2
-            max: 5
+            max: 10
           N14MaterialCircuitry1:
             min: 2
-            max: 5
+            max: 20
           N14Scrap1:
             min: 2
-            max: 5
+            max: 30
           N14CurrencyPrewar: #Misfits Change /Add: Drop prewar money on death (10-40)
             min: 10
             max: 40


### PR DESCRIPTION
Made sentry bots tankier by a bit. They are admeme after all

🆑 


- tweak: Increased sentry bot HP and mats dropped

