### PR TITLE
Bugfixes Medical Insight Toggle

### DIFF
--- a/Content.Client/Overlays/ShowHealthBarsSystem.cs
+++ b/Content.Client/Overlays/ShowHealthBarsSystem.cs
@@ -21,12 +21,21 @@ public sealed class ShowHealthBarsSystem : EquipmentHudSystem<ShowHealthBarsComp
     {
         base.Initialize();
 
+        SubscribeLocalEvent<ShowHealthBarsComponent, AfterAutoHandleStateEvent>(OnAfterHandleState);
+
         _overlay = new(EntityManager, _prototype);
+    }
+
+    private void OnAfterHandleState(EntityUid uid, ShowHealthBarsComponent component, ref AfterAutoHandleStateEvent args)
+    {
+        RefreshOverlay(uid);
     }
 
     protected override void UpdateInternal(RefreshEquipmentHudEvent<ShowHealthBarsComponent> component)
     {
         base.UpdateInternal(component);
+
+        _overlay.DamageContainers.Clear();
 
         foreach (var comp in component.Components)
         {

--- a/Content.Client/Overlays/ShowHealthIconsSystem.cs
+++ b/Content.Client/Overlays/ShowHealthIconsSystem.cs
@@ -23,12 +23,20 @@ public sealed class ShowHealthIconsSystem : EquipmentHudSystem<ShowHealthIconsCo
     {
         base.Initialize();
 
+        SubscribeLocalEvent<ShowHealthIconsComponent, AfterAutoHandleStateEvent>(OnAfterHandleState);
         SubscribeLocalEvent<DamageableComponent, GetStatusIconsEvent>(OnGetStatusIconsEvent);
+    }
+
+    private void OnAfterHandleState(EntityUid uid, ShowHealthIconsComponent component, ref AfterAutoHandleStateEvent args)
+    {
+        RefreshOverlay(uid);
     }
 
     protected override void UpdateInternal(RefreshEquipmentHudEvent<ShowHealthIconsComponent> component)
     {
         base.UpdateInternal(component);
+
+        DamageContainers.Clear();
 
         foreach (var damageContainerId in component.Components.SelectMany(x => x.DamageContainers))
         {

--- a/Content.Server/_Misfits/SpecialStats/SpecialIntelligenceHudSystem.cs
+++ b/Content.Server/_Misfits/SpecialStats/SpecialIntelligenceHudSystem.cs
@@ -58,26 +58,37 @@ public sealed class SpecialIntelligenceHudSystem : EntitySystem
     {
         var applied = EnsureComp<SpecialAppliedMedicalHudComponent>(uid);
         _actions.AddAction(uid, ref applied.ActionEntity, applied.Action);
-        _actions.SetToggled(applied.ActionEntity, applied.Enabled);
+        SetMedicalHudEnabled(uid, applied, applied.Enabled);
+    }
 
-        if (!applied.Enabled)
-            return;
+    private void SetMedicalHudEnabled(EntityUid uid, SpecialAppliedMedicalHudComponent applied, bool enabled)
+    {
+        applied.Enabled = enabled;
+        _actions.SetToggled(applied.ActionEntity, enabled);
 
-        if (!HasComp<ShowHealthBarsComponent>(uid))
+        if (!enabled)
         {
-            var bars = EnsureComp<ShowHealthBarsComponent>(uid);
-            EnsureBiologicalContainer(bars.DamageContainers);
-            Dirty(uid, bars);
+            ClearMedicalHudComponents(uid, applied);
+            return;
+        }
+
+        if (!TryComp<ShowHealthBarsComponent>(uid, out var bars))
+        {
+            bars = EnsureComp<ShowHealthBarsComponent>(uid);
             applied.AddedHealthBars = true;
         }
 
-        if (!HasComp<ShowHealthIconsComponent>(uid))
+        EnsureBiologicalContainer(bars.DamageContainers);
+        Dirty(uid, bars);
+
+        if (!TryComp<ShowHealthIconsComponent>(uid, out var icons))
         {
-            var icons = EnsureComp<ShowHealthIconsComponent>(uid);
-            EnsureBiologicalContainer(icons.DamageContainers);
-            Dirty(uid, icons);
+            icons = EnsureComp<ShowHealthIconsComponent>(uid);
             applied.AddedHealthIcons = true;
         }
+
+        EnsureBiologicalContainer(icons.DamageContainers);
+        Dirty(uid, icons);
     }
 
     private void ClearMedicalHud(EntityUid uid)
@@ -114,12 +125,7 @@ public sealed class SpecialIntelligenceHudSystem : EntitySystem
         if (args.Handled)
             return;
 
-        component.Enabled = !component.Enabled;
-
-        if (component.Enabled)
-            EnsureMedicalHud(uid);
-        else
-            ClearMedicalHudComponents(uid, component);
+        SetMedicalHudEnabled(uid, component, !component.Enabled);
 
         args.Handled = true;
     }

--- a/Content.Shared/Overlays/ShowHealthBarsComponent.cs
+++ b/Content.Shared/Overlays/ShowHealthBarsComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Overlays;
 /// <summary>
 /// This component allows you to see health bars above damageable mobs.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(raiseAfterAutoHandleState: true)]
 public sealed partial class ShowHealthBarsComponent : Component
 {
     /// <summary>

--- a/Content.Shared/Overlays/ShowHealthIconsComponent.cs
+++ b/Content.Shared/Overlays/ShowHealthIconsComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Overlays;
 /// <summary>
 /// This component allows you to see health status icons above damageable mobs.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(raiseAfterAutoHandleState: true)]
 public sealed partial class ShowHealthIconsComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
## About the PR
Fixed the 10 Intelligence medical insight toggle not restoring visible health bars after being turned back on.

## Why / Balance
Medical insight already granted health bars/icons at 10 Intelligence, but after disabling and re-enabling the action, the client overlay could remain inactive until the player ghosted out and re-entered their body. This restores the intended behavior.

## Technical details
Updated the medical insight toggle path to keep the action toggle state and granted HUD components synchronized.

Also updated health bar/icon overlay refresh behavior so the client rebuilds the overlay after networked component state is applied. This prevents the overlay from refreshing with empty damage container data during re-enable.

# Changelog

:cl:
- fix: Fixed 10 Intelligence medical insight not restoring visible health bars after being toggled back on.