### PR TITLE
Bloody Mess Perk

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/SharpSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Kitchen.Components;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Body.Components;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Body.Part;
 using Content.Shared.Database;
 using Content.Shared.Interaction;
 using Content.Shared.Nutrition.Components;
@@ -129,6 +130,12 @@ public sealed class SharpSystem : EntitySystem
 
         if (hasBody)
             _bodySystem.GibBody(args.Args.Target.Value, body: body);
+
+        // Misfits Change for butchering severed body parts
+        if (TryComp<BodyPartComponent>(args.Args.Target.Value, out var bodyPart))
+        {
+            _bodySystem.GibPart(args.Args.Target.Value, bodyPart);
+        }
 
         _destructibleSystem.DestroyEntity(args.Args.Target.Value);
 

--- a/Content.Server/_Misfits/GhoulReversal/GhoulifyOnRadiationDeathSystem.cs
+++ b/Content.Server/_Misfits/GhoulReversal/GhoulifyOnRadiationDeathSystem.cs
@@ -77,9 +77,10 @@ public sealed class GhoulifyOnRadiationDeathSystem : EntitySystem
             if (!_mobThreshold.TryGetThresholdForState(uid, MobState.Critical, out var critThreshold, thresholds))
                 critThreshold = FixedPoint2.New(100);
 
-            // Apply blunt damage equal to crit threshold so the player wakes in soft crit
+            // Apply airloss damage equal to crit threshold so the player wakes in soft crit
+            // Changed from blunt to prevent Bloody Mess characters from getting all their limbs gibbed
             var critDamage = new DamageSpecifier();
-            critDamage.DamageDict["Blunt"] = critThreshold.Value;
+            critDamage.DamageDict["Asphyxiation"] = critThreshold.Value;
             _damageable.TryChangeDamage(uid, critDamage, ignoreResistances: true);
 
             _mobThreshold.SetAllowRevives(uid, false, thresholds);

--- a/Content.Server/_Misfits/Traits/GibModifierSystem.cs
+++ b/Content.Server/_Misfits/Traits/GibModifierSystem.cs
@@ -1,0 +1,49 @@
+using Content.Server.Destructible;
+using Content.Server.Destructible.Thresholds.Triggers;
+using Content.Shared._Misfits.Traits;
+using Content.Shared.Body.Systems;
+
+
+namespace Content.Server._Misfits.Traits;
+
+
+public sealed class GibModifierSystem : EntitySystem
+{
+    [Dependency] private SharedBodySystem _body = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GibModifierComponent, ComponentInit>(OnComponentInit);
+    }
+
+    private void OnComponentInit(Entity<GibModifierComponent> ent, ref ComponentInit args)
+    {
+        // set overall gib threshold for the entity
+        if (TryComp(ent, out DestructibleComponent? entityDestructible))
+        {
+            foreach (var threshold in entityDestructible.Thresholds)
+            {
+                if (threshold.Trigger is DamageTypeTrigger trigger)
+                {
+                    trigger.Damage = (int)  (trigger.Damage * ent.Comp.GibThresholdMultiplier); // rounds down
+                }
+            }
+        }
+        // set gib and sever thresholds for each bodypart
+        foreach (var part in _body.GetBodyChildren(ent))
+        {
+            if (!TryComp(part.Id, out DestructibleComponent? partDestructible))
+                continue;
+            foreach (var threshold in partDestructible.Thresholds)
+            {
+                if (threshold.Trigger is DamageTypeTrigger trigger)
+                {
+                    trigger.Damage = (int)  (trigger.Damage * ent.Comp.GibThresholdMultiplier); // rounds down
+                }
+            }
+            part.Component.CanSever = true; // beheading is back on the menu
+            part.Component.SeverIntegrity = (part.Component.SeverIntegrity * ent.Comp.SeverThresholdMultiplier);
+        }
+    }
+
+}

--- a/Content.Shared/_Misfits/Traits/GibModifierComponent.cs
+++ b/Content.Shared/_Misfits/Traits/GibModifierComponent.cs
@@ -1,0 +1,15 @@
+namespace Content.Shared._Misfits.Traits;
+
+[RegisterComponent]
+public sealed partial class GibModifierComponent : Component
+{
+
+    [DataField]
+    [ViewVariables]
+    public float GibThresholdMultiplier = 1f;
+
+    [DataField]
+    [ViewVariables]
+    public float SeverThresholdMultiplier = 1f;
+
+}

--- a/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
+++ b/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
@@ -238,7 +238,7 @@ public partial class SharedBodySystem
             && partIdSlot is not null
             && delta != null
             && !HasComp<BodyPartReattachedComponent>(partEnt)
-            && !partEnt.Comp.Enabled
+            // && !partEnt.Comp.Enabled    // Misfits change for Bloody Mess perk. Functional limbs can be severed.
             && damageable.TotalDamage >= partEnt.Comp.SeverIntegrity
             && _severingDamageTypes.Any(damageType => delta.DamageDict.TryGetValue(damageType, out var value) && value > 0))
             severed = true;

--- a/Resources/Locale/en-US/_Misfits/traits/physical.ftl
+++ b/Resources/Locale/en-US/_Misfits/traits/physical.ftl
@@ -1,0 +1,4 @@
+trait-name-MisfitsBloodyMess = Bloody Mess
+trait-description-MisfitsBloodyMess =
+    You're [color=yellow]doubly prone[/color] to [color=red]dismemberment[/color] and [color=red]exploding into gore[/color].
+    Hope you know a good doctor...

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -7,6 +7,7 @@
   - type: Damageable
     damageContainer: OrganicPart # Shitmed Change
   - type: BodyPart
+    severIntegrity: 150  # Misfits Change
   - type: Gibbable
   - type: ContainerContainer
     containers:
@@ -28,19 +29,25 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
-        damage: 110
+        damage: 200
       behaviors:
       - !type:GibPartBehavior { }
     - trigger:
         !type:DamageTypeTrigger
         damageType: Slash
-        damage: 150
+        damage: 250
+      behaviors:
+      - !type:GibPartBehavior { }
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Piercing
+        damage: 250
       behaviors:
       - !type:GibPartBehavior { }
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat
-        damage: 200
+        damage: 250
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawnInContainer: true
@@ -84,6 +91,12 @@
       - !type:GibPartBehavior { }
     - trigger:
         !type:DamageTypeTrigger
+        damageType: Piercing
+        damage: 500
+      behaviors:
+      - !type:GibPartBehavior { }
+    - trigger:
+        !type:DamageTypeTrigger
         damageType: Heat
         damage: 400
       behaviors:
@@ -115,6 +128,7 @@
     toolName: "a head" # Shitmed Change
     vital: true
     canSever: false # #Misfits Tweak - Disable head severing for all playable mobs
+    severIntegrity: 200 # Misfits Change
   - type: Input
     context: "ghost"
   - type: Tag
@@ -141,6 +155,10 @@
       types:
         Blunt: 7
     staminaCost: 7
+  - type: Butcherable # Misfits Addition
+    spawned:
+    - id: FoodMeatHuman
+      amount: 1
 
 - type: entity
   id: BaseRightArm
@@ -157,6 +175,10 @@
       types:
         Blunt: 7
     staminaCost: 7
+  - type: Butcherable # Misfits Addition
+    spawned:
+    - id: FoodMeatHuman
+      amount: 1
 
 - type: entity
   id: BaseLeftHand
@@ -204,6 +226,10 @@
       types:
         Blunt: 8
     staminaCost: 9
+  - type: Butcherable # Misfits Addition
+    spawned:
+    - id: FoodMeatHuman
+      amount: 2
 
 - type: entity
   id: BaseRightLeg
@@ -221,6 +247,10 @@
       types:
         Blunt: 8
     staminaCost: 9
+  - type: Butcherable # Misfits Addition
+    spawned:
+    - id: FoodMeatHuman
+      amount: 2
 
 - type: entity
   id: BaseLeftFoot

--- a/Resources/Prototypes/_Misfits/Body/Parts/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Body/Parts/supermutant.yml
@@ -14,7 +14,7 @@
     # Integrity thresholds scaled ×2.22 vs default human (90→200 CriticallyWounded).
     # At default 90, legs disable at ~306 raw Slash while mob crits at ~571 raw.
     # At 200, legs disable at ~680 raw, safely after mob crit at ~571 raw.
-    severIntegrity: 200
+    severIntegrity: 300  # Updated at human part integrity has been increased
     integrityThresholds:
       CriticallyWounded: 200
       HeavilyWounded: 165
@@ -51,6 +51,12 @@
         !type:DamageTypeTrigger
         damageType: Slash
         damage: 400
+      behaviors:
+      - !type:GibPartBehavior { }
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Piercing
+        damage: 500
       behaviors:
       - !type:GibPartBehavior { }
     - trigger:
@@ -101,6 +107,12 @@
         !type:DamageTypeTrigger
         damageType: Slash
         damage: 800
+      behaviors:
+      - !type:GibPartBehavior { }
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Piercing
+        damage: 1000
       behaviors:
       - !type:GibPartBehavior { }
     - trigger:

--- a/Resources/Prototypes/_Misfits/Traits/physical.yml
+++ b/Resources/Prototypes/_Misfits/Traits/physical.yml
@@ -1,0 +1,10 @@
+- type: trait
+  id: MisfitsBloodyMess
+  category: Physical
+  points: 6
+  functions:
+  - !type:TraitReplaceComponent
+    components:
+    - type: GibModifier
+      gibThresholdMultiplier: 0.5
+      severThresholdMultiplier: 0.5


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Adds the Bloody Mess perk, allowing players to opt in for horrifying dismemberment and potential RR. Also makes human arms and legs butcherable for meat, because the concept of a Fallout cannibal eating someone's arm but otherwise leaving them alive to seek revenge is very funny to me.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
While it is understandable that many people don't like when their characters are maimed or gibbed, it is also at times hilarious. Some people want that red shirt experience (and I'm one of them).

## Technical details
<!-- Summary of code changes for easier review. -->
- New System and Component for multiplying gib and sever thresholds. These could be used to make an opposite perk (Adamantium Skeleton?) but I didn't bother taking it that far for this iteration.
- Increased sever and gib thresholds on body parts across the board to avoid punishing people who don't love getting their arms lopped off
- Very minor changes to a couple of upstream files, commented for clarity
- Ghoulification now inflicts Asphyxiation damage to put the newly made ghoul into crit, rather than blunt.
  - Bloody Mess-havers would otherwise have every body part gib on ghoulification... including their heads.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added a new perk, Bloody Mess. It lets others turn you into a bloody mess. Don't take this if you care about keeping your limbs.
- tweak: Made arms and legs butcherable for human meat. Now a hungry cannibal can eat their own leg.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
