### PR TITLE
Update CCVars.NPC.cs

### DIFF
--- a/Content.Shared/CCVar/CCVars.NPC.cs
+++ b/Content.Shared/CCVar/CCVars.NPC.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.CCVar;
 public sealed partial class CCVars
 {
     public static readonly CVarDef<int> NPCMaxUpdates =
-        CVarDef.Create("npc.max_updates", 512); // #Misfits Tweak: Reduced from 2048 to 512 for performance
+        CVarDef.Create("npc.max_updates", 2048);
 
     public static readonly CVarDef<bool> NPCEnabled = CVarDef.Create("npc.enabled", true);
 


### PR DESCRIPTION
restores npcupdates to original value since we have juicy server. should cause less braindead ais

## About the PR
restores the ai update ccvar to 2048 from 512 since we dont need to nerf it for performance

## Why / Balance
make ais less ai

## Technical details

:cl:

- fix: restores npcupdates to original value since we have juicy server.
