### PR TITLE
Adds Weather System

### DIFF
--- a/Content.Client/Overlays/StencilOverlay.Weather.cs
+++ b/Content.Client/Overlays/StencilOverlay.Weather.cs
@@ -20,6 +20,12 @@ public sealed partial class StencilOverlay
         var worldAABB = args.WorldAABB;
         var worldBounds = args.WorldBounds;
         var position = args.Viewport.Eye?.Position.Position ?? Vector2.Zero;
+        var viewport = args.Viewport;
+        var renderScale = viewport.RenderScale.X;
+        var viewportSize = viewport.Size;
+        var hasEye = viewport.Eye != null;
+        var eyePosition = viewport.Eye?.Position.Position ?? Vector2.Zero;
+        var eyeZoom = viewport.Eye?.Zoom ?? Vector2.One;
 
         // Cut out the irrelevant bits via stencil
         // This is why we don't just use parallax; we might want specific tiles to get drawn over
@@ -53,7 +59,6 @@ public sealed partial class StencilOverlay
                     worldHandle.DrawRect(gridTile, Color.White);
                 }
             }
-
         }, Color.Transparent);
 
         worldHandle.SetTransform(Matrix3x2.Identity);
@@ -63,7 +68,27 @@ public sealed partial class StencilOverlay
         var sprite = _sprite.GetFrame(weatherProto.Sprite, curTime);
 
         // Draw the rain
-        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilDraw").Instance());
+        if (weatherProto.VisibilityClearRadius > 0f && hasEye)
+        {
+            var length = eyeZoom.X;
+            var pixelCenter = Vector2.Transform(eyePosition, invMatrix);
+            var pixelMaxRange = weatherProto.VisibilityClearRadius * renderScale / length * EyeManager.PixelsPerMeter;
+            var pixelBufferRange = MathF.Max(1f, weatherProto.VisibilityClearBuffer * renderScale / length * EyeManager.PixelsPerMeter);
+            var pixelMinRange = MathF.Max(0f, pixelMaxRange - pixelBufferRange);
+
+            _weatherVisibilityShader.SetParameter("position", new Vector2(pixelCenter.X, viewportSize.Y - pixelCenter.Y));
+            _weatherVisibilityShader.SetParameter("maxRange", pixelMaxRange);
+            _weatherVisibilityShader.SetParameter("minRange", pixelMinRange);
+            _weatherVisibilityShader.SetParameter("bufferRange", pixelBufferRange);
+            _weatherVisibilityShader.SetParameter("gradient", 0.80f);
+
+            worldHandle.UseShader(_weatherVisibilityShader);
+        }
+        else
+        {
+            worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilDraw").Instance());
+        }
+
         _parallax.DrawParallax(worldHandle, worldAABB, sprite, curTime, position, Vector2.Zero, modulate: (weatherProto.Color ?? Color.White).WithAlpha(alpha));
 
         worldHandle.SetTransform(Matrix3x2.Identity);

--- a/Content.Client/Overlays/StencilOverlay.cs
+++ b/Content.Client/Overlays/StencilOverlay.cs
@@ -33,6 +33,7 @@ public sealed partial class StencilOverlay : Overlay
     private IRenderTexture? _blep;
 
     private readonly ShaderInstance _shader;
+    private readonly ShaderInstance _weatherVisibilityShader;
 
     public StencilOverlay(ParallaxSystem parallax, SharedTransformSystem transform, SpriteSystem sprite, WeatherSystem weather)
     {
@@ -43,6 +44,7 @@ public sealed partial class StencilOverlay : Overlay
         _weather = weather;
         IoCManager.InjectDependencies(this);
         _shader = _protoManager.Index<ShaderPrototype>("WorldGradientCircle").InstanceUnique();
+        _weatherVisibilityShader = _protoManager.Index<ShaderPrototype>("WeatherVisibilityDraw").InstanceUnique();
     }
 
     protected override void Draw(in OverlayDrawArgs args)

--- a/Content.Server/NPC/HTN/Preconditions/TargetInLOSPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/TargetInLOSPrecondition.cs
@@ -1,4 +1,5 @@
 using Content.Server.Interaction;
+using Content.Server.Weather;
 
 namespace Content.Server.NPC.HTN.Preconditions;
 
@@ -6,6 +7,7 @@ public sealed partial class TargetInLOSPrecondition : HTNPrecondition
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
     private InteractionSystem _interaction = default!;
+    private WeatherSystem _weather = default!;
 
     [DataField("targetKey")]
     public string TargetKey = "Target";
@@ -17,6 +19,7 @@ public sealed partial class TargetInLOSPrecondition : HTNPrecondition
     {
         base.Initialize(sysManager);
         _interaction = sysManager.GetEntitySystem<InteractionSystem>();
+        _weather = sysManager.GetEntitySystem<WeatherSystem>();
     }
 
     public override bool IsMet(NPCBlackboard blackboard)
@@ -28,6 +31,7 @@ public sealed partial class TargetInLOSPrecondition : HTNPrecondition
 
         var range = blackboard.GetValueOrDefault<float>(RangeKey, _entManager);
 
-        return _interaction.InRangeUnobstructed(owner, target, range);
+        return _weather.CanSeeThroughWeather(owner, target) &&
+            _interaction.InRangeUnobstructed(owner, target, range);
     }
 }

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/PickDrainTargetOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/PickDrainTargetOperator.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Content.Server.LifeDrainer;
 using Content.Server.NPC.Pathfinding;
 using Content.Server.NPC.Systems;
+using Content.Server.Weather;
 using NpcFactionSystem = Content.Shared.NPC.Systems.NpcFactionSystem;
 
 
@@ -15,6 +16,7 @@ public sealed partial class PickDrainTargetOperator : HTNOperator
     private LifeDrainerSystem _drainer = default!;
     private NpcFactionSystem _faction = default!;
     private PathfindingSystem _pathfinding = default!;
+    private WeatherSystem _weather = default!;
 
     private EntityQuery<LifeDrainerComponent> _drainerQuery;
     private EntityQuery<TransformComponent> _xformQuery;
@@ -37,6 +39,7 @@ public sealed partial class PickDrainTargetOperator : HTNOperator
         _drainer = sysMan.GetEntitySystem<LifeDrainerSystem>();
         _faction = sysMan.GetEntitySystem<NpcFactionSystem>();
         _pathfinding = sysMan.GetEntitySystem<PathfindingSystem>();
+        _weather = sysMan.GetEntitySystem<WeatherSystem>();
 
         _drainerQuery = _entMan.GetEntityQuery<LifeDrainerComponent>();
         _xformQuery = _entMan.GetEntityQuery<TransformComponent>();
@@ -54,8 +57,12 @@ public sealed partial class PickDrainTargetOperator : HTNOperator
         // find crit psionics nearby
         foreach (var target in _faction.GetNearbyHostiles(owner, range))
         {
-            if (!_drainer.CanDrain(ent, target) || !_xformQuery.TryComp(target, out var xform))
+            if (!_weather.CanSeeThroughWeather(owner, target) ||
+                !_drainer.CanDrain(ent, target) ||
+                !_xformQuery.TryComp(target, out var xform))
+            {
                 continue;
+            }
 
             // pathfind to the first crit psionic in range to start draining
             var targetCoords = xform.Coordinates;

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -1,4 +1,5 @@
 using Content.Server.NPC.Components;
+using Content.Server.Weather;
 using Content.Shared.CombatMode;
 using Content.Shared.Interaction;
 using Content.Shared.Weapons.Ranged.Components;
@@ -14,6 +15,7 @@ public sealed partial class NPCCombatSystem
     [Dependency] private readonly SharedCombatModeSystem _combat = default!;
     [Dependency] private readonly RotateToFaceSystem _rotate = default!;
     [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] private readonly WeatherSystem _weather = default!;
 
     private EntityQuery<CombatModeComponent> _combatQuery;
     private EntityQuery<NPCSteeringComponent> _steeringQuery;
@@ -135,7 +137,8 @@ public sealed partial class NPCCombatSystem
             {
                 comp.LOSAccumulator += UnoccludedCooldown;
                 // For consistency with NPC steering.
-                comp.TargetInLOS = _interaction.InRangeUnobstructed(uid, comp.Target, distance + 0.1f);
+                comp.TargetInLOS = _weather.CanSeeThroughWeather(uid, comp.Target) &&
+                    _interaction.InRangeUnobstructed(uid, comp.Target, distance + 0.1f);
             }
 
             if (!comp.TargetInLOS)

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -7,6 +7,7 @@ using Content.Server.NPC.Queries.Queries;
 using Content.Server.Nutrition.Components;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Server.Storage.Components;
+using Content.Server.Weather;
 using Content.Shared.Examine;
 using Content.Shared.Fluids.Components;
 using Content.Shared.Hands.Components;
@@ -48,6 +49,7 @@ public sealed class NPCUtilitySystem : EntitySystem
     [Dependency] private readonly WeldableSystem _weldable = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly WeatherSystem _weather = default!;
 
     private EntityQuery<PuddleComponent> _puddleQuery;
     private EntityQuery<TransformComponent> _xformQuery;
@@ -301,12 +303,18 @@ public sealed class NPCUtilitySystem : EntitySystem
             {
                 var radius = blackboard.GetValueOrDefault<float>(blackboard.GetVisionRadiusKey(EntityManager), EntityManager);
 
-                return _examine.InRangeUnOccluded(owner, targetUid, radius + 0.5f, null) ? 1f : 0f;
+                return _weather.CanSeeThroughWeather(owner, targetUid) &&
+                    _examine.InRangeUnOccluded(owner, targetUid, radius + 0.5f, null)
+                        ? 1f
+                        : 0f;
             }
             case TargetInLOSOrCurrentCon:
             {
                 var radius = blackboard.GetValueOrDefault<float>(blackboard.GetVisionRadiusKey(EntityManager), EntityManager);
                 const float bufferRange = 0.5f;
+
+                if (!_weather.CanSeeThroughWeather(owner, targetUid))
+                    return 0f;
 
                 if (blackboard.TryGetValue<EntityUid>("Target", out var currentTarget, EntityManager) &&
                     currentTarget == targetUid &&
@@ -440,6 +448,9 @@ public sealed class NPCUtilitySystem : EntitySystem
             {
                 foreach (var ent in _npcFaction.GetNearbyHostiles(owner, vision))
                 {
+                    if (!_weather.CanSeeThroughWeather(owner, ent))
+                        continue;
+
                     entities.Add(ent);
                 }
                 break;

--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.Radiation.Components;
+using Content.Server.Radiation.Events;
 using Content.Shared.Radiation.Components;
 using Content.Shared.Radiation.Events;
 using Robust.Shared.Configuration;
@@ -38,6 +39,17 @@ public sealed partial class RadiationSystem : EntitySystem
     {
         var msg = new OnIrradiatedEvent(time, radsPerSecond);
         RaiseLocalEvent(uid, msg);
+    }
+
+    public void IrradiateReceiver(Entity<RadiationReceiverComponent> entity, float radsPerSecond, float time)
+    {
+        entity.Comp.CurrentRadiation = MathF.Max(entity.Comp.CurrentRadiation, radsPerSecond);
+        IrradiateEntity(entity.Owner, radsPerSecond, time);
+    }
+
+    public void RaiseRadiationUpdated()
+    {
+        RaiseLocalEvent(new RadiationSystemUpdatedEvent());
     }
 
     public void SetSourceEnabled(Entity<RadiationSourceComponent?> entity, bool val)

--- a/Content.Server/Weather/WeatherSystem.cs
+++ b/Content.Server/Weather/WeatherSystem.cs
@@ -1,13 +1,20 @@
 using Content.Server.Administration;
+using Content.Server.Chat.Systems;
 using Content.Server.GameTicking;
 using Content.Server.Maps;
+using Content.Server.Radiation.Components;
+using Content.Server.Radiation.Systems;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
+using Content.Shared.Ghost;
+using Content.Shared.Light.Components;
 using Content.Shared.Weather;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Linq;
@@ -19,10 +26,24 @@ public sealed class WeatherSystem : SharedWeatherSystem
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IConsoleHost _console = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly IMapManager _map = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly RadiationSystem _radiation = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private const float WeatherEffectInterval = 1f;
+    private static readonly TimeSpan RandomWeatherMinDelay = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan RandomWeatherMaxDelay = TimeSpan.FromMinutes(60);
+    private static readonly TimeSpan RandomWeatherMinDuration = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan RandomWeatherMaxDuration = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan RandomRadioactiveWeatherMinDuration = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan RandomRadioactiveWeatherMaxDuration = TimeSpan.FromMinutes(3);
+
+    private readonly Dictionary<(EntityUid MapUid, string ProtoId), float> _effectAccumulators = new();
+    private TimeSpan? _nextRandomWeatherTime;
 
     public override void Initialize()
     {
@@ -43,14 +64,164 @@ public sealed class WeatherSystem : SharedWeatherSystem
     {
         base.Update(frameTime);
 
-        if (_config.GetCVar(CCVars.AutoWeather) && _gameTicker.RunLevel == GameRunLevel.InRound && !WeatherRunning())
+        if (!_config.GetCVar(CCVars.AutoWeather) || _gameTicker.RunLevel != GameRunLevel.InRound)
         {
+            _nextRandomWeatherTime = null;
+            return;
+        }
+
+        if (WeatherRunning())
+        {
+            _nextRandomWeatherTime = null;
+            return;
+        }
+
+        if (_nextRandomWeatherTime == null)
+        {
+            ScheduleNextRandomWeather();
+            return;
+        }
+
+        if (Timing.CurTime >= _nextRandomWeatherTime.Value)
+        {
+            _nextRandomWeatherTime = null;
             var (weather, map) = SetRandomWeather();
+
             if (weather != null)
             {
                 Logger.InfoS("weather", $"Randomizing weather to {weather.ID} on map {map}");
             }
+            else
+            {
+                ScheduleNextRandomWeather();
+            }
         }
+    }
+
+    protected override void Run(EntityUid uid, WeatherData weather, WeatherPrototype weatherProto, float frameTime)
+    {
+        base.Run(uid, weather, weatherProto, frameTime);
+
+        if (weather.State != WeatherState.Running)
+            return;
+
+        if (weatherProto.Radioactive)
+            RunRadioactiveWeather(uid, weatherProto, frameTime);
+    }
+
+    protected override bool SetState(EntityUid uid, WeatherState state, WeatherComponent component, WeatherData weather, WeatherPrototype weatherProto)
+    {
+        if (!base.SetState(uid, state, component, weather, weatherProto))
+            return false;
+
+        if (state == WeatherState.Starting && weatherProto.ShowMessage && weatherProto.Message != string.Empty)
+        {
+            var sender = weatherProto.Sender != null
+                ? Loc.GetString(weatherProto.Sender.Value)
+                : Loc.GetString("weather-announcement");
+            var color = weatherProto.Radioactive ? Color.Red : Color.LightSkyBlue;
+
+            _chat.DispatchGlobalAnnouncement(Loc.GetString(weatherProto.Message), sender, colorOverride: color);
+        }
+
+        return true;
+    }
+
+    protected override void EndWeather(EntityUid uid, WeatherComponent component, string proto)
+    {
+        _effectAccumulators.Remove((uid, proto));
+        base.EndWeather(uid, component, proto);
+    }
+
+    public bool CanSeeThroughWeather(EntityUid viewer, EntityUid target)
+    {
+        if (!TryComp<TransformComponent>(viewer, out var viewerXform) ||
+            !TryComp<TransformComponent>(target, out var targetXform))
+        {
+            return true;
+        }
+
+        if (viewerXform.MapUid == null ||
+            viewerXform.MapUid != targetXform.MapUid ||
+            !TryComp<WeatherComponent>(viewerXform.MapUid.Value, out var weather))
+        {
+            return true;
+        }
+
+        var visibilityRadius = 0f;
+        foreach (var (protoId, data) in weather.Weather)
+        {
+            if (data.State != WeatherState.Starting && data.State != WeatherState.Running)
+                continue;
+
+            if (!_prototype.TryIndex<WeatherPrototype>(protoId, out var weatherProto) ||
+                weatherProto.VisibilityClearRadius <= 0f)
+            {
+                continue;
+            }
+
+            visibilityRadius = MathF.Max(visibilityRadius, weatherProto.VisibilityClearRadius);
+        }
+
+        if (visibilityRadius <= 0f)
+            return true;
+
+        if (!IsWeatherExposed(viewerXform.MapUid.Value, viewerXform) &&
+            !IsWeatherExposed(viewerXform.MapUid.Value, targetXform))
+        {
+            return true;
+        }
+
+        if (!viewerXform.Coordinates.TryDistance(EntityManager, _transform, targetXform.Coordinates, out var distance))
+            return true;
+
+        return distance <= visibilityRadius;
+    }
+
+    private void RunRadioactiveWeather(EntityUid mapUid, WeatherPrototype weatherProto, float frameTime)
+    {
+        var key = (mapUid, weatherProto.ID);
+        _effectAccumulators.TryGetValue(key, out var accumulator);
+        accumulator += frameTime;
+
+        if (accumulator < WeatherEffectInterval)
+        {
+            _effectAccumulators[key] = accumulator;
+            return;
+        }
+
+        _effectAccumulators[key] = 0f;
+
+        var irradiated = false;
+        var query = EntityQueryEnumerator<RadiationReceiverComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var receiver, out var xform))
+        {
+            if (HasComp<GhostComponent>(uid))
+                continue;
+
+            if (!IsWeatherExposed(mapUid, xform))
+                continue;
+
+            _radiation.IrradiateReceiver((uid, receiver), weatherProto.RadsPerSecond, accumulator);
+            irradiated = true;
+        }
+
+        if (irradiated)
+            _radiation.RaiseRadiationUpdated();
+    }
+
+    private bool IsWeatherExposed(EntityUid mapUid, TransformComponent xform)
+    {
+        if (xform.MapUid != mapUid || xform.GridUid == null)
+            return false;
+
+        var gridUid = xform.GridUid.Value;
+        if (!TryComp<MapGridComponent>(gridUid, out var grid))
+            return false;
+
+        TryComp<RoofComponent>(gridUid, out var roof);
+        var tile = _mapSystem.GetTileRef(gridUid, grid, xform.Coordinates);
+        return CanWeatherAffect(gridUid, grid, tile, roof);
     }
 
     private bool WeatherRunning()
@@ -137,10 +308,36 @@ public sealed class WeatherSystem : SharedWeatherSystem
         var weather = RandomWeather();
         if (weather != null) {
             MapId map = GetMainMap();
-            SetWeather(map, weather, null);
+            SetWeather(map, weather, GetRandomWeatherEndTime(weather));
             return (weather, map);
         }
         return (weather, MapId.Nullspace);
+    }
+
+    private void ScheduleNextRandomWeather()
+    {
+        var delay = _random.NextFloat(
+            (float) RandomWeatherMinDelay.TotalSeconds,
+            (float) RandomWeatherMaxDelay.TotalSeconds);
+
+        _nextRandomWeatherTime = Timing.CurTime + TimeSpan.FromSeconds(delay);
+    }
+
+    private TimeSpan GetRandomWeatherEndTime(WeatherPrototype weather)
+    {
+        var maxDuration = weather.Radioactive
+            ? RandomRadioactiveWeatherMaxDuration
+            : RandomWeatherMaxDuration;
+
+        var minDuration = weather.Radioactive
+            ? RandomRadioactiveWeatherMinDuration
+            : RandomWeatherMinDuration;
+
+        var duration = _random.NextFloat(
+            (float) minDuration.TotalSeconds,
+            (float) maxDuration.TotalSeconds);
+
+        return Timing.CurTime + TimeSpan.FromSeconds(duration);
     }
 
     /**
@@ -160,13 +357,22 @@ public sealed class WeatherSystem : SharedWeatherSystem
         int totalChance = 0;
         foreach (var proto in _prototype.EnumeratePrototypes<WeatherPrototype>())
         {
+            if (proto.Chance <= 0)
+                continue;
+
             totalChance += proto.Chance;
         }
+
+        if (totalChance <= 0)
+            return null;
 
         int tgtChance = _random.Next(totalChance);
         int curr = 0;
         foreach (var proto in _prototype.EnumeratePrototypes<WeatherPrototype>())
         {
+            if (proto.Chance <= 0)
+                continue;
+
             if (curr <= tgtChance && tgtChance < curr + proto.Chance)
                 return proto;
             curr += proto.Chance;

--- a/Content.Shared/Weather/WeatherPrototype.cs
+++ b/Content.Shared/Weather/WeatherPrototype.cs
@@ -71,4 +71,18 @@ public sealed partial class WeatherPrototype : IPrototype
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public int Chance = 1;
 
+    /// <summary>
+    /// Radius around the viewer where the weather overlay should be masked out.
+    /// Used for dense weather that limits long-range sight without obscuring
+    /// the immediate area.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("visibilityClearRadius")]
+    public float VisibilityClearRadius;
+
+    /// <summary>
+    /// Width of the visual transition at the edge of <see cref="VisibilityClearRadius"/>.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("visibilityClearBuffer")]
+    public float VisibilityClearBuffer = 1f;
+
 }

--- a/Resources/Locale/en-US/_Nuclear14/weather.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/weather.ftl
@@ -1,4 +1,4 @@
-weather-announcement = The weather is changing.
+weather-announcement = Weather Alert
 weather-ashfall = Ashfall is approaching.
 weather-ashfall-light = Ashfall is approaching.
 weather-ashfall-heavy = Heavy ashfall is approaching.
@@ -16,6 +16,6 @@ weather-storm = Storm is approaching.
 
 weather-sandstorm-extreme = Extreme sandstorm is approaching.
 weather-snowfall-extreme = Extreme snowfall is approaching.
-weather-radioactive-particles = Radioactive fallout is approaching. [color=red]Warning: seek shelter![/color]
-weather-radioactive-rain = Radioactive rain is approaching. [color=red]Warning: seek shelter![/color]
+weather-radioactive-particles = Radioactive fallout is approaching. Seek shelter immediately.
+weather-radioactive-rain = Radioactive rain is approaching. Seek shelter immediately.
 

--- a/Resources/Prototypes/Corvax/weather.yml
+++ b/Resources/Prototypes/Corvax/weather.yml
@@ -8,9 +8,9 @@
     params:
       loop: true
       volume: -6
-  duration: 150
+  duration: 180
   radioactive: true
-  rads: 1.25
+  rads: 2
   showMessage: true
   chance: 1 # Misfits: reduced from 2
   sender: weather-announcement
@@ -46,6 +46,7 @@
       volume: -6
   duration: 180
   radioactive: true
+  rads: 1
   showMessage: true
   chance: 1
   sender: weather-announcement

--- a/Resources/Prototypes/Shaders/Stencils.yml
+++ b/Resources/Prototypes/Shaders/Stencils.yml
@@ -23,3 +23,12 @@
     ref: 1
     op: Keep
     func: NotEqual
+
+- type: shader
+  id: WeatherVisibilityDraw
+  kind: source
+  path: "/Textures/Shaders/weather_visibility_draw.swsl"
+  stencil:
+    ref: 1
+    op: Keep
+    func: NotEqual

--- a/Resources/Prototypes/_Misfits/Species/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Species/supermutant.yml
@@ -44,6 +44,7 @@
   - SuperMutantNCRTrooper
   - SuperMutantTribal
   - SuperMutantFollowerDoctor
+  - SuperMutantEnclave
   prototype: N14MobSuperMutant
   sprites: MobSuperMutantSprites
   markingLimits: MobSuperMutantMarkingLimits

--- a/Resources/Prototypes/_Nuclear14/weather.yml
+++ b/Resources/Prototypes/_Nuclear14/weather.yml
@@ -12,7 +12,9 @@
       loop: true
       volume: -6
   temperature: 400
-  duration: 60
+  duration: 600
+  visibilityClearRadius: 5
+  visibilityClearBuffer: 2
   showMessage: true
   sender: weather-announcement
   message: weather-sandstorm-extreme
@@ -28,8 +30,10 @@
       loop: true
       volume: -6
   temperature: 2 # -
-  duration: 60
+  duration: 600
+  visibilityClearRadius: 5
+  visibilityClearBuffer: 2
   showMessage: true
-  chance: 1 # Misfits: explicit, reduced impact on overall weather pool
+  chance: 0 # Misfits: admin-only, excluded from random weather pool
   sender: weather-announcement
   message: weather-snowfall-extreme

--- a/Resources/Prototypes/weather.yml
+++ b/Resources/Prototypes/weather.yml
@@ -48,7 +48,7 @@
 - type: weather
   id: Default
   duration: 3600 # Misfits: increased from 1200 to keep calm periods much longer
-  chance: 50 # Misfits: increased from 15 to heavily favour no-weather
+  chance: 0 # Misfits: calm periods are handled by WeatherSystem's random delay
   message: weather-default
 
 # - type: weather
@@ -95,7 +95,7 @@
       loop: true
       volume: -6
   temperature: 300
-  duration: 250
+  duration: 600
   chance: 1 # Misfits: reduced from 2
   message: weather-rain
   # Misfits Change Add: Rain puddle spawning. Puddles grow silently on open outdoor tiles
@@ -210,7 +210,7 @@
       loop: true
       volume: -6
   temperature: 310
-  duration: 250
+  duration: 600
   showMessage: true
   chance: 1
   sender: weather-announcement

--- a/Resources/Textures/Shaders/weather_visibility_draw.swsl
+++ b/Resources/Textures/Shaders/weather_visibility_draw.swsl
@@ -1,0 +1,21 @@
+uniform highp vec2 position;
+uniform highp float maxRange;
+uniform highp float minRange;
+uniform highp float bufferRange;
+uniform highp float gradient;
+
+void fragment() {
+    highp vec4 color = zTexture(UV);
+    highp float distance = length(FRAGCOORD.xy - position);
+
+    if (distance < minRange) {
+        discard;
+    }
+
+    if (distance < maxRange) {
+        highp float ratio = pow((distance - minRange) / bufferRange, gradient);
+        color.a *= ratio;
+    }
+
+    COLOR = color;
+}


### PR DESCRIPTION
## About the PR

Adds a more complete wasteland weather system with announcements, timed random weather, radioactive weather effects, and heavy-weather visibility limits.

## Why / Balance

Weather now happens less constantly and more predictably as a round event: automatic weather waits 30-60 real minutes between events. Normal random weather lasts 5-10 minutes, while radioactive weather is capped at 3 minutes to reduce how punishing radiation exposure can be.

Sandstorms and snowstorms now limit long-range visibility while still letting players see nearby surroundings. NPCs also respect this visibility limit, so they cannot target or shoot players through dense weather if the player would not be able to see them.

Snowfall is admin-only and no longer appears in the random weather pool.

## Technical details

- Added weather start announcements with color handling for radioactive weather.
- Added radioactive weather processing that applies rads to exposed entities.
- Added `rads` support to radioactive weather prototypes.
- Added randomized automatic weather scheduling:
  - 30-60 minute delay between random weather events.
  - 5-10 minute duration for normal random weather.
  - 1-3 minute duration for radioactive random weather.
- Removed `Default` weather from random selection by setting its chance to `0`.
- Added visibility masking fields to weather prototypes:
  - `visibilityClearRadius`
  - `visibilityClearBuffer`
- Added a client shader for soft fading around the local visibility radius.
- Applied limited visibility to sandstorm and snowfall weather.
- Made NPC targeting, LOS checks, ranged combat, and drain targeting respect dense-weather visibility.
- Made snowfall admin-only by setting its random chance to `0`.
- Updated rain/storm and radioactive weather prototype durations.

# Changelog

:cl:
- add: Added automatic wasteland weather events with announcements and randomized timing.
- add: Added radioactive weather radiation exposure for players caught outside.
- add: Added dense-weather visibility limits for sandstorms and snowstorms.
- fix: NPCs can no longer see, target, or shoot players through sandstorms/snowstorms past the visibility limit.
- tweak: Weather now occurs every 30-60 minutes and lasts 5-10 minutes.
- tweak: Radioactive weather now lasts at most 3 minutes.
- tweak: Snowfall is now admin-only and excluded from random weather.