### PR TITLE
Fixes SM FotA Loadout

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
@@ -522,7 +522,7 @@
 # FOTA armor
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: [ClothingOuterBase, AllowSuitStorageClothing]
   id: MisfitsFOTASuperMutantArmoredLabcoat
   name: Supermutant Followers Armored Labcoat
   description: A large Labcoat with a bulletproof vest inside.

--- a/Resources/Prototypes/_Misfits/Roles/loadouts_supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/loadouts_supermutant.yml
@@ -17,6 +17,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantGladiatorLoincloth
 
@@ -36,6 +37,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantSkullHelmetTribal
 
@@ -55,6 +57,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantTribalGloves
 
@@ -74,6 +77,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantZootSuit
 
@@ -93,6 +97,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantZootHat
 
@@ -112,6 +117,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantZootBoot
 
@@ -131,6 +137,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantVaultSuit
 
@@ -150,6 +157,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantTribalLoincloth
 
@@ -170,6 +178,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantGladiatorArmor
 
@@ -215,6 +224,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantOutfitC
 
@@ -234,6 +244,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantGladiatorBoots
 
@@ -253,6 +264,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantGladiatorHelmet
 
@@ -272,6 +284,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantNeck
 
@@ -291,6 +304,7 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantNeckTrinket
 
@@ -310,5 +324,6 @@
         - SuperMutantNCRRanger
         - SuperMutantNCRTrooper
         - SuperMutantTribal
+        - SuperMutantFollowerDoctor
   items:
     - ClothingSuperMutantNeckCapeTribal


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> SM FotA can now access SM loadouts they were missing

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> They forgot :godmode: 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="2130" height="537" alt="image" src="https://github.com/user-attachments/assets/1cd9a564-9b84-48a7-8b7d-29ad92f2cc65" />


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- fix: Fixes SM FotA Loadout; They can bring SM items now.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
