### PR TITLE
Adds Ghostrole/NPC Robots Languages

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
@@ -522,7 +522,7 @@
 # FOTA armor
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: [ClothingOuterBase, AllowSuitStorageClothing]
   id: MisfitsFOTASuperMutantArmoredLabcoat
   name: Supermutant Followers Armored Labcoat
   description: A large Labcoat with a bulletproof vest inside.

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/robots.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/robots.yml
@@ -483,6 +483,20 @@
       params:
         volume: -3
         maxDistance: 10
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
 
 - type: entity
   parent: N14MobRobotMrHandyClaw
@@ -593,6 +607,20 @@
       params:
         volume: -3
         maxDistance: 10
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
 
 - type: entity
   parent: N14MobRobotHostile
@@ -664,6 +692,20 @@
       params:
         volume: -3
         maxDistance: 10
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
 
 - type: entity
   parent: N14MobRobotHostile
@@ -726,6 +768,20 @@
       params:
         volume: -3
         maxDistance: 12
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
 
 - type: entity
   parent: N14MobRobotHostile
@@ -819,6 +875,20 @@
       params:
         volume: -3
         maxDistance: 12
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
 
 - type: entity
   id: N14SentryBotOverloadLightEmitter

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/robots.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/robots.yml
@@ -240,6 +240,20 @@
       params:
         volume: -3
         maxDistance: 12
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
 
 - type: entity
   parent: N14MobRobotHostileMelee
@@ -306,6 +320,21 @@
       params:
         volume: -3
         maxDistance: 12
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+
 
 - type: entity
   parent: N14MobRobotProtectronHostile
@@ -326,6 +355,21 @@
       shader: unshaded
       map: ["light"]
       visible: false
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+
 
 - type: entity
   parent: N14MobRobotProtectronHostile
@@ -346,6 +390,21 @@
       shader: unshaded
       map: ["light"]
       visible: false
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+
 
 - type: entity
   parent: N14MobRobotProtectronHostile
@@ -392,6 +451,21 @@
     blackboard:
       NavSmash: !type:Bool
         true
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+
 
 - type: entity
   parent: N14MobRobotHostileMelee
@@ -533,6 +607,21 @@
       params:
         volume: -3
         maxDistance: 10
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+
 
 - type: entity
   parent: N14MobRobotHostile
@@ -1082,6 +1171,21 @@
           path: /Audio/Machines/warning_buzzer.ogg
           params:
             volume: 2
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+
 
 # Misfits Change /Add: Ballistic Sentry Bot - same chassis as the laser variant but armed with a
 # 5mm minigun instead of a gatling laser. Once the drum empties the HTN falls back to a heavy stomp.
@@ -1261,3 +1365,18 @@
           path: /Audio/Machines/warning_buzzer.ogg
           params:
             volume: 2
+  # Misfits Add - robot/broadcast languages when player-controlled.
+  - type: LanguageKnowledge
+    speaks:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+    understands:
+    - N14BrotherBeep
+    - N14Robot
+    - English
+    - Latin
+    - Chinese
+


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->Adds Ghostrole/NPC Robots Languages speak/understands:     
    - N14BrotherBeep
    - N14Robot
    - English
    - Latin
    - Chinese

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->They should be able to. They're robots and they smart.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- add: Ghostrole and NPC Robots Languages for Eyebots/Gutsys/Mr.Handy's/Assaultrons/etc...They can now speak Brotherhood Code, Binary, English, Latin, and Chinese! Wow!
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
