### PR TITLE
Fix NCR Prisoner Backpack 'Hidden Storage'

### DIFF
--- a/Resources/Prototypes/Corvax/Loadouts/backpaks.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/backpaks.yml
@@ -6,6 +6,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:
@@ -25,6 +29,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:
@@ -44,6 +52,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:
@@ -63,6 +75,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:
@@ -82,6 +98,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:

--- a/Resources/Prototypes/Corvax/Loadouts/duffel.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/duffel.yml
@@ -6,6 +6,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:
@@ -25,6 +29,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:
@@ -44,6 +52,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:
@@ -63,6 +75,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:

--- a/Resources/Prototypes/Corvax/Loadouts/satchel.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/satchel.yml
@@ -13,6 +13,7 @@
       - Overseer
       - VaultDweller
       - VaultSecurity
+      - NCRPisoner
     - !type:CharacterItemGroupRequirement
       group: N14LodaoutBags
   items:
@@ -35,6 +36,7 @@
       - Overseer
       - VaultDweller
       - VaultSecurity
+      - NCRPisoner
     - !type:CharacterItemGroupRequirement
       group: N14LodaoutBags
   items:
@@ -50,6 +52,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:
@@ -69,6 +75,10 @@
   customName: false
   customDescription: false
   requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - NCRPisoner
     - !type:CharacterDepartmentRequirement
       inverted: true
       departments:

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/SuperMutant/supermutant_clothing.yml
@@ -522,7 +522,7 @@
 # FOTA armor
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: [ClothingOuterBase, AllowSuitStorageClothing]
   id: MisfitsFOTASuperMutantArmoredLabcoat
   name: Supermutant Followers Armored Labcoat
   description: A large Labcoat with a bulletproof vest inside.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Restricted NCR Prisoner from spawning with backpacks. If one is selected it should now restrict it, preventing users from using the Open Backpack keybind to exploit invisible storage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> It's a bug and I could see this a big problem down the line. (Sorry, Peter!)

## Technical details
<!-- Summary of code changes for easier review. --> .yml black magic

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- fix: NCR Prisoners no longer have hidden storage (Sorry Peter, this was tough for me as well)
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
