### PR TITLE
BOS: Require Heads To Spend Minimal Time In Other Castes

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headknight.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headknight.yml
@@ -73,6 +73,12 @@
     - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 8h as Senior Knight before Head Knight
       tracker: BoSMidKnight
       min: 28800 # 8 hours as Senior Knight
+    - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 3h
+      tracker: BoSScribe
+      min: 10800 # 3 hours as Scribe
+    - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 3h
+      tracker: BoSPaladin
+      min: 10800 # 3 hours as Paladin
   startingGear: BoSHeadKnightGear
   alwaysUseSpawner: true
   icon: "JobIconBosMKnight"

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headpaladin.yml
@@ -24,6 +24,12 @@
     - !type:CharacterPlaytimeRequirement
       tracker: BoSMidSquire
       min: 36000 # 10 hours
+    - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 3h
+      tracker: BoSScribe
+      min: 10800 # 3 hours as Scribe
+    - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 3h
+      tracker: BoSKnight
+      min: 10800 # 3 hours as Knight
   startingGear: BoSMidPaladinCommanderGear
   alwaysUseSpawner: true
   icon: "JobIconBosMCommander" # Corvax-Change

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/BrotherhoodOfSteel/bos_headscribe.yml
@@ -18,6 +18,12 @@
     - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 8h as Senior Scribe before Head Scribe
       tracker: BoSMidScribe
       min: 28800 # 8 hours as Senior Scribe
+    - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 3h
+      tracker: BoSPaladin
+      min: 10800 # 3 hours as Paladin
+    - !type:CharacterPlaytimeRequirement # #Misfits Tweak - Require 3h
+      tracker: BoSKnight
+      min: 10800 # 3 hours as Knight
   startingGear: BoSWestScribeGear
   alwaysUseSpawner: true
   icon: "JobIconBosMScriptor"


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Each Head role now requires 3 hours (less than one round) in the other two castes, so they get a feeling for what other castes need.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://discord.com/channels/1471565853534322715/1510656450811400272/1510656450811400272

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Lucky
- tweak: BOS: Each Head role now requires 3 hours in the other two castes,
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
