### PR TITLE
The Laser Rebuffening with Light Rework, and Various Smaller Changes.

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
@@ -264,7 +264,7 @@ undecided-loadout-category-mbos-init-bal-description =
 undecided-loadout-category-mbos-kni-las-name = Laser Kit
 undecided-loadout-category-mbos-kni-las-description =
     A cache containing belongings of a Brotherhood chapter member.
-    Includes 1 crude laser rifle, 3 microfusion cells, 1 12.7mm pistol,
+    Includes 1 crude laser rifle, 1 microfusion cell, 1 12.7mm pistol,
     2 12.7mm pistol magazines, 1 roll of gauze, 1 stimpak,
     and 1 K ration MRE.
 
@@ -319,7 +319,7 @@ undecided-loadout-category-mbos-pal-bal-description =
 undecided-loadout-category-mbos-pal-sni-name = Advanced Laser Kit
 undecided-loadout-category-mbos-pal-sni-description =
     A cache containing belongings of a Brotherhood chapter member.
-    Includes 1 AER-9, 3 microfusion cells,
+    Includes 1 AER-9, 1 microfusion cell,
     1 12.7mm pistol, 2 12.7mm pistol magazines, 1 roll of gauze,
     1 stimpak, and 1 K ration MRE.
 
@@ -327,7 +327,7 @@ undecided-loadout-category-mbos-pal-sni-description =
 undecided-loadout-category-mbos-pal-pla-name = Automatic Laser Kit
 undecided-loadout-category-mbos-pal-pla-description =
     A cache containing belongings of a Brotherhood chapter member.
-    Includes 1 Automatic AER-9, 3 microfusion cells, 1 12.7mm pistol,
+    Includes 1 Automatic AER-9, 1 microfusion cell1, 1 12.7mm pistol,
     2 12.7mm pistol magazines, 1 roll of gauze, 1 stimpak,
     and 1 K ration MRE.
 

--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/armor.yml
@@ -211,8 +211,8 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/reconnaissancearmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.10
-    sprintModifier: 1.10
+    walkModifier: 1.05
+    sprintModifier: 1.05
   - type: Armor
     modifiers:
       coefficients:
@@ -234,14 +234,14 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/lightreconnaissancearmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.15
-    sprintModifier: 1.15
+    walkModifier: 1.10
+    sprintModifier: 1.10
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.85
         Slash: 0.85
-        Piercing: 0.85
+        Piercing: 0.80
         Heat: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.85
@@ -277,8 +277,8 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/lightarmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.1
-    sprintModifier: 1.1 # the little ones can enjoy the game too.
+    walkModifier: 1.05
+    sprintModifier: 1.05 # the little ones can enjoy the game too.
   - type: Armor
     modifiers:
       coefficients:
@@ -302,10 +302,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.75
-        Heat: 0.75
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.70
+        Heat: 0.70
   - type: ExplosionResistance
     damageCoefficient: 0.80
 
@@ -320,8 +320,8 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/explorerarmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.15
-    sprintModifier: 1.15
+    walkModifier: 1.10
+    sprintModifier: 1.10
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Corvax/Trade/trade.yml
+++ b/Resources/Prototypes/Corvax/Trade/trade.yml
@@ -539,15 +539,15 @@
   name: "Ammunition"
   entries:
   - proto: N14MicrofusionCellRed
-    price: 75
+    price: 375
   - proto: N14MicrofusionCellRed
-    price: 125
+    price: 250
     count: 15
   - proto: N14PlasmaCartridge
-    price: 150
+    price: 450
     count: 12
   - proto: 40mmGrenadeFrag
-    price: 150
+    price: 250
     count: 10
 
 - type: storeCategoryStructured
@@ -567,21 +567,21 @@
   - proto: N14BrassKnife
     price: 20
   - proto: N14WastelandSpear
-    price: 20
+    price: 75
   - proto: N14PilumSpear
-    price: 20
+    price: 60
   - proto: N14WastelandPolearm
-    price: 20
+    price: 235
   - proto: N14GolfClub
-    price: 20
-  - proto: N14WastelandTribalJavelin
-    price: 20
-  - proto: N14BaseAxe
     price: 50
+  - proto: N14WastelandTribalJavelin
+    price: 55
+  - proto: N14BaseAxe
+    price: 120
 #  - proto: N14ChineseSword
 #    price: 200
   - proto: N14CeremonialSword
-    price: 250
+    price: 550
   - proto: N14SledgeHammer
     price: 200
 
@@ -711,7 +711,7 @@
     amount: 10
     price: 150
   - proto: N14SuperStimpak
-    price: 250
+    price: 550
     count: 5
   - proto: N14HandheldHealthAnalyzer
     price: 350

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/assasin.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/assasin.yml
@@ -9,8 +9,8 @@
   - type: Clothing
     sprite: _Misfits/Clothing/CaesarLegion/assasin.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1.10
+    walkModifier: 1.05
+    sprintModifier: 1.05
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
@@ -431,6 +431,7 @@
     - N14BPLegionAmmo40mmGrenade
     - N14BPLegionAmmoBox762       # #Misfits Add - 7.62mm box (for SKS)
     - N14BPLegionWeaponDynamite   # #Misfits Add - craftable dynamite
+    - N14BPLegionAmmoSKSEnbloc308
 
 - type: entity
   parent: N14BlueprintBase

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Weapons/Guns/Ammunition/hitscan.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Weapons/Guns/Ammunition/hitscan.yml
@@ -1,7 +1,7 @@
 # Misfits — Hitscan beam definitions for energy weapons.
 # Each weapon specifies its own beam via GunDamageBonusComponent.hitscanProtoOverride.
 # The cell just provides charge; the weapon controls beam color and base damage.
-# Damage hierarchy: Red (17) < Amber (19) < Yellow (17 base, Wattz +bonus) < Green (25) < Blue (30) < Violet (30)
+# Damage hierarchy: Red (25) < Amber (30) < Yellow (17 base, Wattz +bonus) < Green (35) < Blue (40) < Violet (43)
 
 #MARK: Microfusion Cell Lasers — per-weapon beam assignment
 # AER-9/Auto/RCW/Gatling/crude/makeshift -> Red
@@ -15,7 +15,8 @@
   id: N14MFLaserRed
   damage:
     types:
-      Heat: 17
+      Heat: 20
+      Pierce: 5
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -32,7 +33,8 @@
   id: N14MFLaserAmber
   damage:
     types:
-      Heat: 19
+      Heat: 23
+      Pierce: 7
   tintColor: "#FF8C00"
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
@@ -49,6 +51,7 @@
   damage:
     types:
       Heat: 25
+      Pierce: 10
   muzzleFlash:
     sprite: _Misfits/Objects/Weapons/Guns/Projectiles/green_laser.rsi
     state: muzzle_green_laser
@@ -64,6 +67,7 @@
   damage:
     types:
       Heat: 30
+      Pierce: 10
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_blue
@@ -80,7 +84,8 @@
   id: N14MFLaserViolet
   damage:
     types:
-      Heat: 30
+      Heat: 40
+      Radiation: 3
   tintColor: "#8B00FF"
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_bos_town.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_bos_town.yml
@@ -671,13 +671,17 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Glass: 100
+    Glass: 300
 
     Circuitry: 100
 
-    ScrapElectronic: 100
+    ScrapElectronic: 300
 
-    Lead: 100
+    N14Gold: 200
+
+    N14Silver: 300
+
+    Lead: 500
 
 
 - type: latheRecipe
@@ -802,15 +806,15 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Glass: 850
+    Glass: 1000
 
-    Circuitry: 100
+    Circuitry: 300
 
-    ScrapElectronic: 100
+    ScrapElectronic: 500
 
-    N14Gold: 50
+    N14Gold: 500
 
-    Lead: 850
+    Lead: 1000
 
 # #Misfits Removed - duplicate FC recipe commented out; consolidated to single generic fusion core above
 # - type: latheRecipe

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -2351,6 +2351,20 @@
 
     N14Gunpowder: 15
 
+- type: latheRecipe
+  id: N14BPLegionAmmoSKSEnbloc308 # #Misfits Change - new SKSEnbloc308 rep
+  result: SKSEnbloc308
+  category: N14BlueprintLegionAmmoT3
+  completetime: 5
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 200
+
+    Lead: 50
+
+    N14Gunpowder: 50
 
 - type: latheRecipe
   id: N14BPLegionAmmoSpeedLoader45-70

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
@@ -339,8 +339,7 @@
     Glass: 500
     Circuitry: 100
     ScrapElectronic: 200
-    N14Gold: 300
-    N14Gold: 500
+    N14Gold: 800
 
 - type: latheRecipe
   id: N14BPVaultAmmoMag10mmSMG

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
@@ -336,10 +336,11 @@
   availableFaction:
   - Vault
   materials:
-    Glass: 100
+    Glass: 500
     Circuitry: 100
-    ScrapElectronic: 100
-    N14Gold: 100
+    ScrapElectronic: 200
+    N14Gold: 300
+    N14Gold: 500
 
 - type: latheRecipe
   id: N14BPVaultAmmoMag10mmSMG

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -1059,7 +1059,7 @@
     items:
       - id: N14WeaponLaserRifleCrude
       - id: N14MicrofusionCellRed
-        amount: 3
+        amount: 1
       - id: N14WeaponPistol12mm
       - id: N14MagazinePistol12mm
         amount: 2
@@ -1220,7 +1220,7 @@
     items:
       - id: N14WeaponLaserRifle
       - id: N14MicrofusionCell
-        amount: 3
+        amount: 1
       - id: N14WeaponPistol12mm
       - id: N14MagazinePistol12mm
         amount: 2
@@ -1242,7 +1242,7 @@
     items:
       - id: N14WeaponLaserRifleAuto # misfits change by bill; makes it easier to balance paladin kits, AER14 too much roundstart.
       - id: N14MicrofusionCellBlue
-        amount: 3
+        amount: 1
       - id: N14WeaponPistol12mm
       - id: N14MagazinePistol12mm
         amount: 2

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Battery/Battery.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Battery/Battery.yml
@@ -60,8 +60,8 @@
         state: o2
         shader: unshaded
   - type: Battery
-    maxCharge: 1200
-    startingCharge: 1200
+    maxCharge: 2300
+    startingCharge: 2300
   - type: HitscanBatteryAmmoProvider
     proto: N14MFLaserRed
     fireCost: 50

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/308.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/308.yml
@@ -164,7 +164,7 @@
       - N14Magazine308RifleSnipers
   - type: BallisticAmmoProvider
     proto: N14Cartridge308Rifle
-    capacity: 10
+    capacity: 5
   - type: Sprite
     netsync: false
     sprite: _Nuclear14/Objects/Weapons/Guns/Ammunition/Magazines/308/mag5.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 21
   # Misfits Add - 5.56mm intermediate rifle round; good range retention
   - type: BallisticDamageFalloff
     falloffStartTiles: 9.0

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -346,8 +346,8 @@
   components:
   - type: Wieldable
   - type: GunWieldBonus
-    minAngle: -23 # #Misfits Tweak - wielded spread 2°/13°; fast fire. fast spread.
-    maxAngle: -47
+    minAngle: -23 # #Misfits Tweak - wielded spread 2°/20°; fast fire. fast spread.
+    maxAngle: -40
   - type: Sprite
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/laser_autorifle.rsi
     layers:
@@ -377,7 +377,7 @@
           tags:
             - N14MicrofusionCell
   - type: Gun
-    fireRate: 8
+    fireRate: 6
     soundGunshot:
       collection: N14LaserAutoRifleGunshot
     selectedMode: FullAuto
@@ -483,13 +483,13 @@
           tags:
             - N14MicrofusionCell
   - type: Gun
-    fireRate: 4
+    fireRate: 3.5
     soundGunshot:
       collection: N14LaserAutoRifleGunshot
     selectedMode: FullAuto
     availableModes:
     - FullAuto
-  # #Misfits Add - Green beam override (25 Heat); AER-14 prototype with unique green optics
+  # #Misfits Add - Green beam override ; AER-14 prototype with unique green optics
   - type: GunDamageBonus
     hitscanProtoOverride: N14MFLaserGreen
   - type: FollowDistance
@@ -537,13 +537,13 @@
           tags:
             - N14MicrofusionCell
   - type: Gun
-    fireRate: 6 # Higher ROF than AER-9 (5); reflects advanced pre-war engineering
+    fireRate: 3 # Higher ROF than AER-9 (2.5); reflects advanced pre-war engineering
     soundGunshot:
       collection: N14LaserAutoRifleGunshot
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
-  # Amber beam override (19 Heat) — weapon controls its own beam color
+  # Amber beam override — weapon controls its own beam color
   - type: GunDamageBonus
     hitscanProtoOverride: N14MFLaserAmber
   - type: FollowDistance
@@ -591,7 +591,7 @@
           tags:
             - N14MicrofusionCell
   - type: Gun
-    fireRate: 3 # Low ROF compensates for highest damage output
+    fireRate: 2.5 # Low ROF compensates for highest damage output
     soundGunshot:
       collection: N14LaserAutoRifleGunshot
     selectedMode: SemiAuto
@@ -615,8 +615,8 @@
   components:
   - type: Wieldable
   - type: GunWieldBonus
-    minAngle: -25 # #Misfits Tweak - wielded spread 0°/2°; 0° min for rifles
-    maxAngle: -58
+    minAngle: -24 # #Misfits Tweak - wielded spread 1°/10°; 0° min for rifles
+    maxAngle: -50
   - type: Sprite
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/laser_rifle.rsi
     layers:
@@ -646,7 +646,7 @@
           tags:
             - N14MicrofusionCell
   - type: Gun
-    fireRate: 3
+    fireRate: 2.5
     soundGunshot:
       collection: N14LaserAutoRifleGunshot
     selectedMode: SemiAuto
@@ -669,7 +669,7 @@
   - type: Wieldable
   - type: GunWieldBonus
     minAngle: -23
-    maxAngle: -56
+    maxAngle: -45
   - type: Sprite
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/laser_rifle_crude.rsi
     layers:
@@ -695,7 +695,7 @@
           tags:
             - N14MicrofusionCell
   - type: Gun
-    fireRate: 2.5
+    fireRate: 2
     soundGunshot:
       collection: N14LaserAutoRifleGunshot
     selectedMode: SemiAuto
@@ -1014,12 +1014,12 @@
     backStrength: 4
   - type: StaticPrice
     price: 300
-  # #Misfits Change - Yellow beam override + focusing optics: +23 heat damage (total 40), double fireCost (12 shots)
+  # #Misfits Change - Yellow beam override + focusing optics: +23 heat damage (total 45), double fireCost (12 shots)
   - type: GunDamageBonus
     hitscanProtoOverride: N14MFLaserYellow
     bonusDamage:
       types:
-        Heat: 23
+        Heat: 28
     fireCostMultiplier: 2.0
 
 - type: entity
@@ -1071,12 +1071,12 @@
     backStrength: 4
   - type: StaticPrice
     price: 400
-  # #Misfits Change - Yellow beam override + focusing optics: +13 heat damage (total 30), double fireCost (12 shots)
+  # #Misfits Change - Yellow beam override + focusing optics: +13 heat damage (total 35), double fireCost (12 shots)
   - type: GunDamageBonus
     hitscanProtoOverride: N14MFLaserYellow
     bonusDamage:
       types:
-        Heat: 13
+        Heat: 18
     fireCostMultiplier: 2.0
 
 #MARK: Heavy

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -537,7 +537,7 @@
     angleDecay: 16
     soundGunshot:
       collection: N14MarksmanGunshot
-    fireRate: 2
+    fireRate: 0.5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -563,6 +563,11 @@
     backStrength: 3
   - type: StaticPrice
     price: 175
+  - type: GunDamageBonus
+    bonusDamage:
+      types:
+        Pierce: 20 # High bullet velocity sniper rifle. makes the .308 more lethal without requiring a massive rebalance of calibers.
+        Structural: 30 # Lighter anti-PA weapon. Bring down the metal monsters.
 # Forge-add-end
 
 # #Misfits Add — Cowboy Repeater, Paciencia, Ratslayer, M1 Carbine, Rangemaster


### PR DESCRIPTION
## About the PR
Lasers reworked to have upped damages, greater capacities, but lower ROFs and some are much more inaccurate than before. BOS roles lost 50% of their roundstart MF cells because they now contain double the previous charge of shots. Vault and brotherhood MF cell BPs adjusted accordingly.
.308 sniper given the damage bonus component. it now does 58 pierce and 30 struct on its own, with no new bullet prototype. If this actually works I will cry out for joy. Decreased its mag size to 5 shots and its ROF to 0.5, by request of the cat.
Nerfed legion armor speedboosts. Im sorry my chuds.
Gave legion the .308 SKS clip BP. You're welcome my chuds.
Buffed 5.56 by 2 whole points of damage WOW!
Tweaked some trade catatong prices.

Yes I finished this PR on my fucking birthday my party is in an hour and fifteen minutes from me writing this.

## Why / Balance
Lasers felt like shit. nothing like the actual games. this makes them closer while keeping it fair.
.308 sniper felt like shit. nothing like the actual games. this makes it closer while keeping it fair.
Legion speed meta felt like shit. nothing like the actual games. this makes them closer while keeping it fair and adjusted for SPECIAL.
Legion sks clip is just a ammo mag man.
5.56 felt like shit. nothing like the actual games. this makes it more lethal while keeping it fair.

## Technical details
The yaml. It sings to me.
FTL is literally a txt file man. its braindead.

## Media

https://github.com/user-attachments/assets/5fe057c6-0189-49b1-8504-b92e01c933cd

# Changelog

:cl: Billy boy
- tweak: all lasers reworked heavily. Hood chuds rejoice.
- add: Added so much fun. .308 sniper buffed, legion can make more sks clips, buffed 5.56 by 2 points.
- tweak: MF cells are more expensive for vault and BOS, you'll realize why very quickly.
- tweak: touched up legion speed boosts. im sorry little guys.