### PR TITLE
Adds Languages to C-27s

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
@@ -64,11 +64,18 @@
     proto: robot
   - type: LanguageKnowledge # #Misfits Fix - use N14 language IDs (TauCetiBasic/RobotTalk are SS14 upstream only)
     speaks:
-    - English    # default spoken language; language system uses first entry
-    - N14Robot   # binary 0/1 obfuscation; player can switch via language menu
-    understands:
-    - English
+    - English #first language is default
     - N14Robot
+    - N14BrotherBeep
+    - Latin
+    - Chinese
+    understands:
+    - English #first language is default
+    - N14Robot
+    - N14BrotherBeep
+    - Latin
+    - Chinese
+    - Tribal
   - type: Icon
     sprite: _Misfits/Mobs/Species/C27/parts.rsi
     state: full


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->Adds Languages to C-27s:
    speaks:
    - English #first language is default
    - N14Robot
    - N14BrotherBeep
    - Latin
    - Chinese
    understands:
    - English #first language is default
    - N14Robot
    - N14BrotherBeep
    - Latin
    - Chinese
    - Tribal

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Godd Howard requested it themself. :godmode: 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="855" height="638" alt="image" src="https://github.com/user-attachments/assets/500b5c9e-2593-4b55-ba6c-318440cc93a7" />


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- add: C-27's now can speak/understand Brotherhood Code/Latin/Chinese, and understand (not speak) Tribal in addition.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
