### PR TITLE
Weather Fix

### DIFF
--- a/Content.Server/Weather/WeatherSystem.cs
+++ b/Content.Server/Weather/WeatherSystem.cs
@@ -35,6 +35,7 @@ public sealed class WeatherSystem : SharedWeatherSystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     private const float WeatherEffectInterval = 1f;
+    private const string DefaultWeatherPrototype = "Default";
     private static readonly TimeSpan RandomWeatherMinDelay = TimeSpan.FromMinutes(30);
     private static readonly TimeSpan RandomWeatherMaxDelay = TimeSpan.FromMinutes(60);
     private static readonly TimeSpan RandomWeatherMinDuration = TimeSpan.FromMinutes(5);
@@ -58,6 +59,10 @@ public sealed class WeatherSystem : SharedWeatherSystem
             Loc.GetString("cmd-randomweather-desc"),
             Loc.GetString("cmd-randomweather-help"),
             RandomWeatherCommand);
+        _console.RegisterCommand("nextweather",
+            Loc.GetString("cmd-nextweather-desc"),
+            Loc.GetString("cmd-nextweather-help"),
+            NextWeatherCommand);
     }
 
     public override void Update(float frameTime)
@@ -70,7 +75,7 @@ public sealed class WeatherSystem : SharedWeatherSystem
             return;
         }
 
-        if (WeatherRunning())
+        if (WeatherEventRunning())
         {
             _nextRandomWeatherTime = null;
             return;
@@ -224,13 +229,16 @@ public sealed class WeatherSystem : SharedWeatherSystem
         return CanWeatherAffect(gridUid, grid, tile, roof);
     }
 
-    private bool WeatherRunning()
+    private bool WeatherEventRunning()
     {
         var query = EntityQueryEnumerator<WeatherComponent>();
-        while (query.MoveNext(out var uid, out var comp))
+        while (query.MoveNext(out _, out var comp))
         {
-            if (comp.Weather.Count > 0)
+            foreach (var (protoId, _) in comp.Weather)
             {
+                if (protoId == DefaultWeatherPrototype)
+                    continue;
+
                 return true;
             }
         }
@@ -301,6 +309,71 @@ public sealed class WeatherSystem : SharedWeatherSystem
         {
             shell.WriteLine($"Picked {weather.ID} to run on map {map}");
         }
+    }
+
+    [AdminCommand(AdminFlags.Admin)]
+    private void NextWeatherCommand(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (!_config.GetCVar(CCVars.AutoWeather))
+        {
+            shell.WriteLine(Loc.GetString("cmd-nextweather-auto-disabled"));
+            return;
+        }
+
+        if (_gameTicker.RunLevel != GameRunLevel.InRound)
+        {
+            shell.WriteLine(Loc.GetString("cmd-nextweather-not-in-round"));
+            return;
+        }
+
+        if (TryWriteActiveWeather(shell))
+            return;
+
+        if (_nextRandomWeatherTime == null)
+            ScheduleNextRandomWeather();
+
+        if (_nextRandomWeatherTime is not { } nextWeatherTime)
+        {
+            shell.WriteLine(Loc.GetString("cmd-nextweather-not-scheduled"));
+            return;
+        }
+
+        var remaining = nextWeatherTime - Timing.CurTime;
+        if (remaining < TimeSpan.Zero)
+            remaining = TimeSpan.Zero;
+
+        shell.WriteLine(Loc.GetString("cmd-nextweather-scheduled",
+            ("time", FormatWeatherTime(remaining))));
+    }
+
+    private bool TryWriteActiveWeather(IConsoleShell shell)
+    {
+        var found = false;
+        var query = EntityQueryEnumerator<WeatherComponent>();
+        while (query.MoveNext(out _, out var comp))
+        {
+            foreach (var (protoId, data) in comp.Weather)
+            {
+                if (protoId == DefaultWeatherPrototype)
+                    continue;
+
+                found = true;
+                var ending = data.EndTime == null
+                    ? Loc.GetString("cmd-nextweather-active-indefinite")
+                    : Loc.GetString("cmd-nextweather-active-ending",
+                        ("time", FormatWeatherTime(data.EndTime.Value - Timing.CurTime)));
+
+                shell.WriteLine(Loc.GetString("cmd-nextweather-active",
+                    ("weather", protoId),
+                    ("state", data.State),
+                    ("ending", ending)));
+            }
+        }
+
+        if (found)
+            shell.WriteLine(Loc.GetString("cmd-nextweather-active-note"));
+
+        return found;
     }
 
     private (WeatherPrototype?, MapId) SetRandomWeather()
@@ -378,6 +451,20 @@ public sealed class WeatherSystem : SharedWeatherSystem
             curr += proto.Chance;
         }
         return null;
+    }
+
+    private static string FormatWeatherTime(TimeSpan time)
+    {
+        if (time < TimeSpan.Zero)
+            time = TimeSpan.Zero;
+
+        if (time.TotalHours >= 1)
+            return $"{(int) time.TotalHours}h {time.Minutes}m {time.Seconds}s";
+
+        if (time.TotalMinutes >= 1)
+            return $"{time.Minutes}m {time.Seconds}s";
+
+        return $"{time.Seconds}s";
     }
 
     private CompletionResult WeatherCompletion(IConsoleShell shell, string[] args)

--- a/Content.Server/_Misfits/Traits/GrantTraitSystem.cs
+++ b/Content.Server/_Misfits/Traits/GrantTraitSystem.cs
@@ -1,0 +1,64 @@
+// #Misfits Add - Generic system for training items that grant character traits.
+using Content.Server.Traits;
+using Content.Shared._Misfits.Traits;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Popups;
+using Content.Shared.Traits;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Misfits.Traits;
+
+public sealed class GrantTraitSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly TraitSystem _traits = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GrantTraitComponent, UseInHandEvent>(OnUseInHand);
+    }
+
+    private void OnUseInHand(EntityUid uid, GrantTraitComponent comp, UseInHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        var user = args.User;
+
+        foreach (var entry in comp.AlreadyKnownComponents.Values)
+        {
+            if (!HasComp(user, entry.Component.GetType()))
+                continue;
+
+            if (comp.AlreadyKnownMessage != null)
+                _popup.PopupEntity(Loc.GetString(comp.AlreadyKnownMessage.Value), uid, user, PopupType.Small);
+
+            return;
+        }
+
+        if (!_prototype.TryIndex<TraitPrototype>(comp.Trait, out var trait))
+            return;
+
+        _traits.AddTrait(user, trait);
+
+        if (comp.LearnMessage != null)
+            _popup.PopupEntity(Loc.GetString(comp.LearnMessage.Value), uid, user, PopupType.Large);
+
+        if (comp.SoundOnUse != null)
+            _audio.PlayEntity(comp.SoundOnUse, user, user);
+
+        args.Handled = true;
+
+        if (comp.MultiUse)
+            return;
+
+        if (!string.IsNullOrEmpty(comp.SpawnedProto))
+            Spawn(comp.SpawnedProto, Transform(uid).Coordinates);
+
+        QueueDel(uid);
+    }
+}

--- a/Content.Shared/_Misfits/Traits/GrantTraitComponent.cs
+++ b/Content.Shared/_Misfits/Traits/GrantTraitComponent.cs
@@ -1,0 +1,39 @@
+// #Misfits Add - Generic trait-training item component.
+using Content.Shared.Traits;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Content.Shared._Misfits.Traits;
+
+/// <summary>
+///     Placed on an item that grants a trait to the user when used in hand.
+/// </summary>
+[RegisterComponent]
+public sealed partial class GrantTraitComponent : Component
+{
+    [DataField(required: true)]
+    public ProtoId<TraitPrototype> Trait;
+
+    [DataField]
+    public LocId? LearnMessage;
+
+    [DataField]
+    public LocId? AlreadyKnownMessage;
+
+    [DataField]
+    public bool MultiUse;
+
+    [DataField]
+    public string? SpawnedProto;
+
+    [DataField]
+    public SoundSpecifier? SoundOnUse;
+
+    /// <summary>
+    ///     Components that identify the trait as already known.
+    ///     If any are already present on the user, the item is not consumed.
+    /// </summary>
+    [DataField]
+    public ComponentRegistry AlreadyKnownComponents = new();
+}

--- a/Resources/Locale/en-US/_Misfits/grant-trait.ftl
+++ b/Resources/Locale/en-US/_Misfits/grant-trait.ftl
@@ -1,0 +1,2 @@
+grant-trait-riding-learned = You study the manual and learn how to handle a wasteland motorcycle.
+grant-trait-riding-already-known = You already know how to ride wasteland motorcycles.

--- a/Resources/Locale/en-US/_Misfits/traits.ftl
+++ b/Resources/Locale/en-US/_Misfits/traits.ftl
@@ -41,8 +41,8 @@ trait-description-N14PetCentaur =
 
 trait-name-N14RidingPerk = Riding
 trait-description-N14RidingPerk =
-    You know how to saddle up wasteland pack animals.
-    Brahmin and brahdo will let you ride them instead of throwing a fit the moment you reach for the straps.
+    You know how to handle wasteland motorcycles.
+    Old engines, bad roads, and improvised frames are familiar enough that you can keep a bike moving without wrecking yourself.
 
 trait-name-LanguageTribalGeneral = Tribal Language
 trait-description-LanguageTribalGeneral = You can understand and speak the local Tribal language. Were you from the Tribe?

--- a/Resources/Locale/en-US/weather/weather.ftl
+++ b/Resources/Locale/en-US/weather/weather.ftl
@@ -7,3 +7,14 @@ cmd-weather-error-unknown-proto = Unknown Weather prototype!
 cmd-weather-error-wrong-time = Time is in the wrong format!
 
 cmd-randomweather-desc = Randomly set the current weather
+
+cmd-nextweather-desc = Shows when the next automatic weather event will happen.
+cmd-nextweather-help = nextweather
+cmd-nextweather-auto-disabled = Automatic weather is disabled.
+cmd-nextweather-not-in-round = Automatic weather is only scheduled during an active round.
+cmd-nextweather-not-scheduled = No automatic weather event is currently scheduled.
+cmd-nextweather-scheduled = Next automatic weather event is scheduled in {$time}.
+cmd-nextweather-active = Active weather: {$weather} ({$state}); {$ending}.
+cmd-nextweather-active-ending = ending in {$time}
+cmd-nextweather-active-indefinite = no scheduled end time
+cmd-nextweather-active-note = The next automatic weather event will be scheduled after active weather clears.

--- a/Resources/Prototypes/_Misfits/MartialArts/training_manuals.yml
+++ b/Resources/Prototypes/_Misfits/MartialArts/training_manuals.yml
@@ -198,3 +198,37 @@
   - type: GrantShadowStrike
     soundOnUse:
       path: /Audio/Items/Handling/book_pickup.ogg
+
+# Eighties riding manual - grants the Riding trait. Admin-spawn only.
+- type: entity
+  name: "Eighties motorcycle riding manual"
+  id: TrainingManualEightiesRider
+  parent: BaseItem
+  description: "A grease-stained Eighties booklet full of road signs, clutch diagrams, and hard-earned advice on keeping a wasteland motorcycle upright when the road turns ugly."
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#245C91"
+    - state: decor_wingette
+      color: "#D9B44A"
+    - state: icon_text
+  - type: Item
+    size: Small
+  - type: Tag
+    tags:
+      - Book
+  - type: EmitSoundOnPickup
+    sound: /Audio/SimpleStation14/Items/Handling/book_pickup.ogg
+  - type: EmitSoundOnDrop
+    sound: /Audio/SimpleStation14/Items/Handling/book_drop.ogg
+  - type: GrantTrait
+    trait: N14RidingPerk
+    learnMessage: grant-trait-riding-learned
+    alreadyKnownMessage: grant-trait-riding-already-known
+    alreadyKnownComponents:
+      - type: RidingPerk
+    soundOnUse:
+      path: /Audio/Items/Handling/book_pickup.ogg

--- a/Resources/Prototypes/_Nuclear14/weather.yml
+++ b/Resources/Prototypes/_Nuclear14/weather.yml
@@ -13,6 +13,7 @@
       volume: -6
   temperature: 400
   duration: 600
+  chance: 1
   visibilityClearRadius: 5
   visibilityClearBuffer: 2
   showMessage: true

--- a/Resources/Prototypes/weather.yml
+++ b/Resources/Prototypes/weather.yml
@@ -1,49 +1,51 @@
 #! Corvax-Change
 
-# - type: weather
-#   id: Ashfall
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: ashfall
-#   sound:
-#     path: /Audio/Effects/Weather/snowstorm_weak.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 330
-#   duration: 500
-#   message: weather-ashfall
+- type: weather
+  id: Ashfall
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: ashfall
+  sound:
+    path: /Audio/Effects/Weather/snowstorm_weak.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 330
+  duration: 500
+  chance: 1
+  message: weather-ashfall
 
-# - type: weather
-#   id: AshfallLight
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: ashfall_light
-#   sound:
-#     path: /Audio/Effects/Weather/snowstorm_weak.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 320
-#   duration: 500
-#   message: weather-ashfall-light
+- type: weather
+  id: AshfallLight
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: ashfall_light
+  sound:
+    path: /Audio/Effects/Weather/snowstorm_weak.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 320
+  duration: 500
+  chance: 1
+  message: weather-ashfall-light
 
-# - type: weather
-#   id: AshfallHeavy
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: ashfall_heavy
-#   sound:
-#     path: /Audio/Effects/Weather/snowstorm.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 340
-#   duration: 20
-#   chance: 0
-#   showMessage: true
-#   sender: weather-announcement
-#   message: weather-ashfall-heavy
+- type: weather
+  id: AshfallHeavy
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: ashfall_heavy
+  sound:
+    path: /Audio/Effects/Weather/snowstorm.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 340
+  duration: 20
+  chance: 1
+  showMessage: true
+  sender: weather-announcement
+  message: weather-ashfall-heavy
 
 - type: weather
   id: Default
@@ -51,38 +53,39 @@
   chance: 0 # Misfits: calm periods are handled by WeatherSystem's random delay
   message: weather-default
 
-# - type: weather
-#   id: Fallout
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: fallout
-#   sound:
-#     path: /Audio/Effects/Weather/snowstorm_weak.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 340
-#   duration: 500
-#   chance: 0
-#   showMessage: true
-#   sender: weather-announcement
-#   message: weather-fallout
-#   radioactive: true
+- type: weather
+  id: Fallout
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: fallout
+  sound:
+    path: /Audio/Effects/Weather/snowstorm_weak.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 340
+  duration: 500
+  chance: 1
+  showMessage: true
+  sender: weather-announcement
+  message: weather-fallout
+  radioactive: true
 
-# - type: weather
-#   id: Hail
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: hail
-#   sound:
-#     path:
-#       /Audio/Effects/Weather/rain.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 300
-#   duration: 500
-#   message: weather-hail
+- type: weather
+  id: Hail
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: hail
+  sound:
+    path:
+      /Audio/Effects/Weather/rain.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 300
+  duration: 500
+  chance: 1
+  message: weather-hail
 
 - type: weather
   id: Rain
@@ -122,82 +125,84 @@
     - /Audio/Effects/Weather/rain.ogg
     - /Audio/Effects/Weather/rain2.ogg
 
-# - type: weather
-#   id: Sandstorm
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: sandstorm
-#   sound:
-#     path: /Audio/Effects/Weather/snowstorm_weak.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 320
-#   duration: 500
-#   chance: 0
-#   message: weather-sandstorm
+- type: weather
+  id: Sandstorm
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: sandstorm
+  sound:
+    path: /Audio/Effects/Weather/snowstorm_weak.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 320
+  duration: 500
+  chance: 1
+  message: weather-sandstorm
 
-# - type: weather
-#   id: SandstormHeavy
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: sandstorm_heavy
-#   sound:
-#     path: /Audio/Effects/Weather/snowstorm.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 330
-#   duration: 500
-#   chance: 0
-#   showMessage: true
-#   sender: weather-announcement
-#   message: weather-sandstorm-heavy
+- type: weather
+  id: SandstormHeavy
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: sandstorm_heavy
+  sound:
+    path: /Audio/Effects/Weather/snowstorm.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 330
+  duration: 500
+  chance: 1
+  showMessage: true
+  sender: weather-announcement
+  message: weather-sandstorm-heavy
 
-# - type: weather
-#   id: SnowfallLight
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: snowfall_light
-#   sound:
-#     path: /Audio/Effects/Weather/snowstorm_weak.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 280
-#   duration: 500
-#   message: weather-snowfall-light
+- type: weather
+  id: SnowfallLight
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: snowfall_light
+  sound:
+    path: /Audio/Effects/Weather/snowstorm_weak.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 280
+  duration: 500
+  chance: 0 # Misfits: snow events are excluded from random weather pool
+  message: weather-snowfall-light
 
-# - type: weather
-#   id: SnowfallMedium
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: snowfall_med
-#   sound:
-#     path: /Audio/Effects/Weather/snowstorm_weak.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 270
-#   duration: 500
-#   message: weather-snowfall-medium
+- type: weather
+  id: SnowfallMedium
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: snowfall_med
+  sound:
+    path: /Audio/Effects/Weather/snowstorm_weak.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 270
+  duration: 500
+  chance: 0 # Misfits: snow events are excluded from random weather pool
+  message: weather-snowfall-medium
 
-# - type: weather
-#   id: SnowfallHeavy
-#   sprite:
-#     sprite: /Textures/Effects/weather.rsi
-#     state: snowfall_heavy
-#   sound:
-#     path: /Audio/Effects/Weather/snowstorm.ogg
-#     params:
-#       loop: true
-#       volume: -6
-#   temperature: 260
-#   duration: 500
-#   chance: 0
-#   showMessage: true
-#   sender: weather-announcement
-#   message: weather-snowfall-heavy
+- type: weather
+  id: SnowfallHeavy
+  sprite:
+    sprite: /Textures/Effects/weather.rsi
+    state: snowfall_heavy
+  sound:
+    path: /Audio/Effects/Weather/snowstorm.ogg
+    params:
+      loop: true
+      volume: -6
+  temperature: 260
+  duration: 500
+  chance: 0 # Misfits: snow events are excluded from random weather pool
+  showMessage: true
+  sender: weather-announcement
+  message: weather-snowfall-heavy
 
 - type: weather
   id: Storm


### PR DESCRIPTION
## Why / Balance

The Riding manual gives admins a clean way to grant the Riding perk during Eighties test events without manually editing characters.

The weather fixes make automatic weather actually function during rounds. Previously, default/calm weather could be treated like an active weather event, preventing random weather from progressing properly. Admins now also have better visibility into when the next event is scheduled.

Weather event chances were normalized so random weather is easier to reason about and tune. Snow events were excluded from random selection for now, while still remaining available as prototypes/admin-controlled weather if needed.

## Technical details

- Added shared `GrantTraitComponent`.
- Added server-side `GrantTraitSystem` for consuming trait manuals and applying trait components.
- Added locale strings for trait manual use/already-known messages.
- Added `TrainingManualEightiesRider` prototype.
- Added `nextweather` admin command.
- Updated weather scheduling logic to distinguish default/calm weather from active weather events.
- Updated weather prototype chances:
  - Non-snow random weather set to `chance: 1`.
  - Snowfall weather set to `chance: 0`.
  - Default weather remains `chance: 0`.

# Changelog

:cl:
- add: Added an admin-spawn Eighties motorcycle riding manual that grants the Riding perk.
- add: Added an admin command to check when the next automatic weather event will occur.
- fix: Fixed automatic weather scheduling so default weather no longer blocks random weather events.
- tweak: Normalized random weather event chances and disabled snow events from the random pool.