### PR TITLE
Changes .308 Clip Size and Adds Description

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/308.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/308.yml
@@ -62,6 +62,7 @@
 - type: entity
   id: ClipMagazine308Rifle
   name: "clip (.308)"
+  description: A 8-round clip for .308 rifles.
   parent: BaseMagazine308Rifle
   components:
   - type: Tag
@@ -73,6 +74,10 @@
   - type: Sprite
     netsync: false
     sprite: _Nuclear14/Objects/Weapons/Guns/Ammunition/Magazines/308/mag2.rsi
+  - type: Item
+    size: Tiny
+    shape:
+    - 0,0,0,0
 
 - type: entity
   id: Magazine308M60Box
@@ -98,6 +103,7 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+
 
 # #Misfits Removed - GarandEnbloc308 replaced by ClipMagazine308Rifle; all Garands now use the shared .308 clip
 #- type: entity


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting. Also the description for the entity was missing so I added that as well.
-->

## About the PR
<!-- What did you change? -->Changes .308 Clip Size from 1x2 to 1x1

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Clips are smaller and more compact than magazines. Makes sense to meee~

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="514" height="205" alt="image" src="https://github.com/user-attachments/assets/57625f26-bb9f-4d54-8baa-718479f2f1cf" />


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- tweak: Changes .308 Clip Size from 1x2 to 1x1 (and adds description)
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
