### PR TITLE
Adjusted Patrol Ranger Timelock

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/chief_ranger.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/chief_ranger.yml
@@ -24,7 +24,6 @@
       department: Rangers
       min: 252000 # 70 hours — admin role
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots, super mutants, and glowing ghouls cannot be Rangers
-      inverted: true
       species:
       - Human
       - Ghoul

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/chief_ranger.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/chief_ranger.yml
@@ -26,21 +26,8 @@
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots, super mutants, and glowing ghouls cannot be Rangers
       inverted: true
       species:
-      - RobotMrHandy
-      - RobotProtectron
-      - RobotProtectronPolice
-      - RobotProtectronBuilder
-      - RobotProtectronFire
-      - RobotMrGutsy
-      - RobotAssaultron
-      - RobotAssaultronTesla
-      - RobotSentryBot
-      - RobotSentryBotLaser
-      - RobotRobobrain
-      - RobotRobobrainLaser
-      - SuperMutant
-      - GhoulGlowing # #Misfits Tweak - glowing ghouls not allowed in NCR Rangers
-      - Nightkin
+      - Human
+      - Ghoul
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ncr_ranger_recruit.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ncr_ranger_recruit.yml
@@ -29,20 +29,8 @@
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots, super mutants, and glowing ghouls cannot be Rangers
       inverted: true
       species:
-      - RobotMrHandy
-      - RobotProtectron
-      - RobotProtectronPolice
-      - RobotProtectronBuilder
-      - RobotProtectronFire
-      - RobotMrGutsy
-      - RobotAssaultron
-      - RobotAssaultronTesla
-      - RobotSentryBot
-      - RobotSentryBotLaser
-      - RobotRobobrain
-      - RobotRobobrainLaser
-      - SuperMutant
-      - GhoulGlowing # #Misfits Tweak - glowing ghouls not allowed in NCR Rangers
+      - Human
+      - Ghoul
 
 - type: startingGear
   id: NCRRangerRecruitGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ncr_ranger_recruit.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ncr_ranger_recruit.yml
@@ -27,7 +27,6 @@
     - !type:CharacterOverallTimeRequirement # #Misfits Fix - entry-level ranger uses overall playtime, not Rangers dept time
       min: 43200 # 12 hours
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots, super mutants, and glowing ghouls cannot be Rangers
-      inverted: true
       species:
       - Human
       - Ghoul

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger.yml
@@ -28,20 +28,8 @@
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots, super mutants, and glowing ghouls cannot be Rangers
       inverted: true
       species:
-      - RobotMrHandy
-      - RobotProtectron
-      - RobotProtectronPolice # #Misfits Fix - missing variant species
-      - RobotProtectronBuilder # #Misfits Fix - missing variant species
-      - RobotProtectronFire # #Misfits Fix - missing variant species
-      - RobotMrGutsy
-      - RobotAssaultron
-      - RobotAssaultronTesla # #Misfits Fix - missing variant species
-      - RobotSentryBot # #Misfits Fix - missing robot chassis
-      - RobotSentryBotLaser # #Misfits Fix - missing variant species
-      - RobotRobobrain # #Misfits Fix - missing robot chassis
-      - RobotRobobrainLaser # #Misfits Fix - missing variant species
-      - SuperMutant
-      - GhoulGlowing # #Misfits Tweak - glowing ghouls not allowed in NCR Rangers
+      - Human
+      - Ghoul
 
 - type: startingGear
   id: NCRFieldRangerGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger.yml
@@ -26,7 +26,6 @@
       department: Rangers
       min: 72000 # 20 hours
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots, super mutants, and glowing ghouls cannot be Rangers
-      inverted: true
       species:
       - Human
       - Ghoul

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_chief.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_chief.yml
@@ -26,22 +26,9 @@
   requirements:
     - !type:CharacterWhitelistRequirement
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots and super mutants cannot be Rangers
-      inverted: true
       species:
-      - RobotMrHandy
-      - RobotProtectron
-      - RobotProtectronPolice # #Misfits Fix - missing variant species
-      - RobotProtectronBuilder # #Misfits Fix - missing variant species
-      - RobotProtectronFire # #Misfits Fix - missing variant species
-      - RobotMrGutsy
-      - RobotAssaultron
-      - RobotAssaultronTesla # #Misfits Fix - missing variant species
-      - RobotSentryBot # #Misfits Fix - missing robot chassis
-      - RobotSentryBotLaser # #Misfits Fix - missing variant species
-      - RobotRobobrain # #Misfits Fix - missing robot chassis
-      - RobotRobobrainLaser # #Misfits Fix - missing variant species
-      - SuperMutant
-      - Nightkin
+      - Human
+      - Ghoul
 
 - type: startingGear
   id: RangerChiefGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -23,7 +23,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement
       department: Rangers
-      min: 57600 # 16 hours
+      min: 28800 # Misfits Change - Patrol Ranger only needs 8 hours
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots, super mutants, and glowing ghouls cannot be Rangers
       inverted: true
       species:

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_recruit.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_recruit.yml
@@ -25,23 +25,9 @@
       department: Rangers
       min: 28800 # Misfits Change - Patrol Ranger only needs 8 hours
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots, super mutants, and glowing ghouls cannot be Rangers
-      inverted: true
       species:
-      - RobotMrHandy
-      - RobotProtectron
-      - RobotProtectronPolice # #Misfits Fix - missing variant species
-      - RobotProtectronBuilder # #Misfits Fix - missing variant species
-      - RobotProtectronFire # #Misfits Fix - missing variant species
-      - RobotMrGutsy
-      - RobotAssaultron
-      - RobotAssaultronTesla # #Misfits Fix - missing variant species
-      - RobotSentryBot # #Misfits Fix - missing robot chassis
-      - RobotSentryBotLaser # #Misfits Fix - missing variant species
-      - RobotRobobrain # #Misfits Fix - missing robot chassis
-      - RobotRobobrainLaser # #Misfits Fix - missing variant species
-      - SuperMutant
-      - Nightkin
-      - GhoulGlowing # #Misfits Tweak - glowing ghouls not allowed in NCR Rangers
+      - Human
+      - Ghoul
 
 - type: startingGear
   id: NCRPatrolRangerGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_veteran.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Rangers/ranger_veteran.yml
@@ -30,23 +30,9 @@
       department: Rangers
       min: 144000 # 40 hours
     - !type:CharacterSpeciesRequirement # #Misfits Change - robots, super mutants, and glowing ghouls cannot be Rangers
-      inverted: true
       species:
-      - RobotMrHandy
-      - RobotProtectron
-      - RobotProtectronPolice # #Misfits Fix - missing variant species
-      - RobotProtectronBuilder # #Misfits Fix - missing variant species
-      - RobotProtectronFire # #Misfits Fix - missing variant species
-      - RobotMrGutsy
-      - RobotAssaultron
-      - RobotAssaultronTesla # #Misfits Fix - missing variant species
-      - RobotSentryBot # #Misfits Fix - missing robot chassis
-      - RobotSentryBotLaser # #Misfits Fix - missing variant species
-      - RobotRobobrain # #Misfits Fix - missing robot chassis
-      - RobotRobobrainLaser # #Misfits Fix - missing variant species
-      - SuperMutant
-      - GhoulGlowing # #Misfits Tweak - glowing ghouls not allowed in NCR Rangers
-      - Nightkin
+      - Human
+      - Ghoul
 
 - type: startingGear
   id: NCRVeteranRangerGear


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Halved patrol ranger time so the jump from patrol to field doesnt happen in one round.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> Complaints from the community regarding the difficulty of unlocking patrol ranger.

## Technical details
<!-- Summary of code changes for easier review. --> ymlchud

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: qevie
- tweak: Adjusted patrol ranger timelock
