### PR TITLE
More Rain Fixes

### DIFF
--- a/Content.Client/Overlays/StencilOverlay.Weather.cs
+++ b/Content.Client/Overlays/StencilOverlay.Weather.cs
@@ -9,6 +9,9 @@ namespace Content.Client.Overlays;
 
 public sealed partial class StencilOverlay
 {
+    private const int RoofFadeSteps = 4;
+    private const float RoofFadeTiles = 1.5f;
+
     private List<Entity<MapGridComponent>> _grids = new();
 
     private void DrawWeather(in OverlayDrawArgs args, WeatherPrototype weatherProto, float alpha, Matrix3x2 invMatrix)
@@ -56,18 +59,24 @@ public sealed partial class StencilOverlay
                     var gridTile = new Box2(tile.GridIndices * grid.Comp.TileSize,
                         (tile.GridIndices + Vector2i.One) * grid.Comp.TileSize);
 
+                    for (var step = RoofFadeSteps; step > 0; step--)
+                    {
+                        var fadeDistance = RoofFadeTiles * step / RoofFadeSteps;
+                        var fadeAlpha = (RoofFadeSteps - step + 1f) / (RoofFadeSteps + 1f);
+                        worldHandle.DrawRect(gridTile.Enlarged(fadeDistance), Color.White.WithAlpha(fadeAlpha));
+                    }
+
                     worldHandle.DrawRect(gridTile, Color.White);
                 }
             }
         }, Color.Transparent);
 
         worldHandle.SetTransform(Matrix3x2.Identity);
-        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilMask").Instance());
-        worldHandle.DrawTextureRect(_blep!.Texture, worldBounds);
         var curTime = _timing.RealTime;
         var sprite = _sprite.GetFrame(weatherProto.Sprite, curTime);
 
-        // Draw the rain
+        _weatherDrawShader.SetParameter("MASK_TEXTURE", _blep!.Texture);
+
         if (weatherProto.VisibilityClearRadius > 0f && hasEye)
         {
             var length = eyeZoom.X;
@@ -76,18 +85,20 @@ public sealed partial class StencilOverlay
             var pixelBufferRange = MathF.Max(1f, weatherProto.VisibilityClearBuffer * renderScale / length * EyeManager.PixelsPerMeter);
             var pixelMinRange = MathF.Max(0f, pixelMaxRange - pixelBufferRange);
 
-            _weatherVisibilityShader.SetParameter("position", new Vector2(pixelCenter.X, viewportSize.Y - pixelCenter.Y));
-            _weatherVisibilityShader.SetParameter("maxRange", pixelMaxRange);
-            _weatherVisibilityShader.SetParameter("minRange", pixelMinRange);
-            _weatherVisibilityShader.SetParameter("bufferRange", pixelBufferRange);
-            _weatherVisibilityShader.SetParameter("gradient", 0.80f);
-
-            worldHandle.UseShader(_weatherVisibilityShader);
+            _weatherDrawShader.SetParameter("position", new Vector2(pixelCenter.X, viewportSize.Y - pixelCenter.Y));
+            _weatherDrawShader.SetParameter("maxRange", pixelMaxRange);
+            _weatherDrawShader.SetParameter("minRange", pixelMinRange);
+            _weatherDrawShader.SetParameter("bufferRange", pixelBufferRange);
         }
         else
         {
-            worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilDraw").Instance());
+            _weatherDrawShader.SetParameter("maxRange", 0f);
+            _weatherDrawShader.SetParameter("minRange", 0f);
+            _weatherDrawShader.SetParameter("bufferRange", 1f);
         }
+
+        _weatherDrawShader.SetParameter("gradient", 0.80f);
+        worldHandle.UseShader(_weatherDrawShader);
 
         _parallax.DrawParallax(worldHandle, worldAABB, sprite, curTime, position, Vector2.Zero, modulate: (weatherProto.Color ?? Color.White).WithAlpha(alpha));
 

--- a/Content.Client/Overlays/StencilOverlay.cs
+++ b/Content.Client/Overlays/StencilOverlay.cs
@@ -33,7 +33,7 @@ public sealed partial class StencilOverlay : Overlay
     private IRenderTexture? _blep;
 
     private readonly ShaderInstance _shader;
-    private readonly ShaderInstance _weatherVisibilityShader;
+    private readonly ShaderInstance _weatherDrawShader;
 
     public StencilOverlay(ParallaxSystem parallax, SharedTransformSystem transform, SpriteSystem sprite, WeatherSystem weather)
     {
@@ -44,7 +44,7 @@ public sealed partial class StencilOverlay : Overlay
         _weather = weather;
         IoCManager.InjectDependencies(this);
         _shader = _protoManager.Index<ShaderPrototype>("WorldGradientCircle").InstanceUnique();
-        _weatherVisibilityShader = _protoManager.Index<ShaderPrototype>("WeatherVisibilityDraw").InstanceUnique();
+        _weatherDrawShader = _protoManager.Index<ShaderPrototype>("WeatherDraw").InstanceUnique();
     }
 
     protected override void Draw(in OverlayDrawArgs args)

--- a/Content.Server/Weather/WeatherSystem.cs
+++ b/Content.Server/Weather/WeatherSystem.cs
@@ -153,7 +153,7 @@ public sealed class WeatherSystem : SharedWeatherSystem
             return true;
         }
 
-        var visibilityRadius = 0f;
+        var visibilityRadius = float.MaxValue;
         foreach (var (protoId, data) in weather.Weather)
         {
             if (data.State != WeatherState.Starting && data.State != WeatherState.Running)
@@ -165,10 +165,10 @@ public sealed class WeatherSystem : SharedWeatherSystem
                 continue;
             }
 
-            visibilityRadius = MathF.Max(visibilityRadius, weatherProto.VisibilityClearRadius);
+            visibilityRadius = MathF.Min(visibilityRadius, weatherProto.VisibilityClearRadius);
         }
 
-        if (visibilityRadius <= 0f)
+        if (visibilityRadius == float.MaxValue)
             return true;
 
         if (!IsWeatherExposed(viewerXform.MapUid.Value, viewerXform) &&
@@ -409,6 +409,9 @@ public sealed class WeatherSystem : SharedWeatherSystem
         var duration = _random.NextFloat(
             (float) minDuration.TotalSeconds,
             (float) maxDuration.TotalSeconds);
+
+        if (weather.Duration > 0f)
+            duration = MathF.Min(duration, weather.Duration);
 
         return Timing.CurTime + TimeSpan.FromSeconds(duration);
     }

--- a/Resources/Prototypes/Shaders/Stencils.yml
+++ b/Resources/Prototypes/Shaders/Stencils.yml
@@ -32,3 +32,8 @@
     ref: 1
     op: Keep
     func: NotEqual
+
+- type: shader
+  id: WeatherDraw
+  kind: source
+  path: "/Textures/Shaders/weather_draw.swsl"

--- a/Resources/Prototypes/weather.yml
+++ b/Resources/Prototypes/weather.yml
@@ -13,6 +13,8 @@
   temperature: 330
   duration: 500
   chance: 1
+  visibilityClearRadius: 5
+  visibilityClearBuffer: 2
   message: weather-ashfall
 
 - type: weather
@@ -41,8 +43,10 @@
       loop: true
       volume: -6
   temperature: 340
-  duration: 20
+  duration: 500
   chance: 1
+  visibilityClearRadius: 8
+  visibilityClearBuffer: 2
   showMessage: true
   sender: weather-announcement
   message: weather-ashfall-heavy
@@ -84,7 +88,7 @@
       volume: -6
   temperature: 300
   duration: 500
-  chance: 1
+  chance: 0 # Misfits: excluded from random weather pool
   message: weather-hail
 
 - type: weather
@@ -138,6 +142,8 @@
   temperature: 320
   duration: 500
   chance: 1
+  visibilityClearRadius: 8
+  visibilityClearBuffer: 2
   message: weather-sandstorm
 
 - type: weather
@@ -153,6 +159,8 @@
   temperature: 330
   duration: 500
   chance: 1
+  visibilityClearRadius: 6
+  visibilityClearBuffer: 2
   showMessage: true
   sender: weather-announcement
   message: weather-sandstorm-heavy
@@ -200,6 +208,8 @@
   temperature: 260
   duration: 500
   chance: 0 # Misfits: snow events are excluded from random weather pool
+  visibilityClearRadius: 6
+  visibilityClearBuffer: 2
   showMessage: true
   sender: weather-announcement
   message: weather-snowfall-heavy

--- a/Resources/Textures/Shaders/weather_draw.swsl
+++ b/Resources/Textures/Shaders/weather_draw.swsl
@@ -1,0 +1,34 @@
+uniform sampler2D MASK_TEXTURE;
+
+uniform highp vec2 position;
+uniform highp float maxRange;
+uniform highp float minRange;
+uniform highp float bufferRange;
+uniform highp float gradient;
+
+void fragment() {
+    highp vec4 color = zTexture(UV);
+    highp vec2 maskUv = FRAGCOORD.xy * SCREEN_PIXEL_SIZE;
+    highp float maskAlpha = texture2D(MASK_TEXTURE, maskUv).a;
+
+    color.a *= 1.0 - maskAlpha;
+
+    if (color.a <= 0.0) {
+        discard;
+    }
+
+    if (maxRange > 0.0) {
+        highp float distance = length(FRAGCOORD.xy - position);
+
+        if (distance < minRange) {
+            discard;
+        }
+
+        if (distance < maxRange) {
+            highp float ratio = pow((distance - minRange) / bufferRange, gradient);
+            color.a *= ratio;
+        }
+    }
+
+    COLOR = color;
+}


### PR DESCRIPTION
## About the PR

Fixes weather rendering around roofs and updates weather prototype tuning.

Weather overlays now fade out near roofs and weather-blocked tiles instead of cutting off abruptly at hard tile boundaries. This PR also updates `weather.yml` with the latest weather pool and visibility tuning.

## Why / Balance

The roof fade change is visual polish: weather should still be blocked by roofs, but the transition should not look like a harsh square cutoff.

The weather prototype changes make the automatic weather pool easier to tune and keep disruptive/less fitting events out of random rotation. Visibility limits are only applied to weather that should meaningfully obscure sight, such as ashfall and sandstorms.

## Technical details

- Added new `WeatherDraw` shader prototype.
- Added `weather_draw.swsl`.
- Updated `StencilOverlay` to use the new weather draw shader.
- Updated weather overlay roof/weather-blocker masking to draw a soft alpha falloff around blocked tiles.
- Updated `Resources/Prototypes/weather.yml`:
  - Re-enabled ashfall, fallout, sandstorm, and related weather prototypes.
  - Normalized enabled random weather chances to `chance: 1`.
  - Disabled snow weather from the random pool with `chance: 0`.
  - Disabled hail from the random pool with `chance: 0`.
  - Added visibility effects to ashfall, heavy ashfall, sandstorm, heavy sandstorm, and heavy snowfall.
  - Set `AshfallHeavy` duration to match normal ashfall.

## Media

N/A

# Changelog

:cl:
- fix: Weather now fades more smoothly around roofs and weather-blocked areas instead of abruptly cutting off.
- tweak: Updated random weather pool chances and visibility behavior for ashfall, sandstorms, snow, and hail.