### PR TITLE
Legion Armor Retooling, Overpressure Addition, RCW Nerf

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/armor.yml
@@ -41,7 +41,7 @@
         Piercing: 0.45
         Heat: 0.45
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.60
   - type: StaminaDamageResistance
     coefficient: 0.85 # 15%
 #  - type: ClothingSpecialModifier
@@ -70,7 +70,7 @@
         Piercing: 0.45
         Heat: 0.45
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.60
   - type: StaminaDamageResistance
     coefficient: 0.85
 
@@ -97,7 +97,7 @@
         Piercing: 0.45
         Heat: 0.45
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.60
   - type: StaminaDamageResistance
     coefficient: 0.85
 
@@ -188,15 +188,15 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/veteranarmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.05 # makes veterans a big threat (not really) -Bill
-    sprintModifier: 1.05
+    walkModifier: 1 # NO MO SPEED
+    sprintModifier: 1
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.75
         Slash: 0.75
         Piercing: 0.7
-        Heat: 0.7
+        Heat: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.8
 
@@ -234,8 +234,8 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/lightreconnaissancearmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.10
-    sprintModifier: 1.10
+    walkModifier: 1.05
+    sprintModifier: 1.05
   - type: Armor
     modifiers:
       coefficients:
@@ -284,7 +284,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Piercing: 0.80 # 10% is worse than some COATS btw. just want you to know that. gave them 20% -Bill
+        Piercing: 0.85 # 10% is worse than some COATS btw. just want you to know that. gave them 15% -Bill
         Heat: 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.95
@@ -327,8 +327,8 @@
       coefficients:
         Blunt: 0.85
         Slash: 0.85
-        Piercing: 0.85
-        Heat: 0.85
+        Piercing: 0.90
+        Heat: 0.90
   - type: ExplosionResistance
     damageCoefficient: 0.90
 

--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/armor.yml
@@ -113,7 +113,7 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/deanveteranarmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
+    walkModifier: 0.9 # This is better than Mk2 combat it can be slow.
     sprintModifier: 0.9
   - type: Armor
     modifiers:
@@ -121,9 +121,9 @@
         Blunt: 0.65
         Slash: 0.65
         Piercing: 0.55 # Billy again. This shit is for veteran decani. 35% with 10% slow? you fuckin kidding me? buff to 45%.
-        Heat: 0.60 # light buff by bill. just 5%
+        Heat: 0.60 # light buff just 5%
   - type: ExplosionResistance
-    damageCoefficient: 0.75
+    damageCoefficient: 0.65
 #  - type: ClothingSpecialModifier
 #    strengthModifier: 2
 
@@ -138,7 +138,7 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/deanprimearmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
+    walkModifier: 0.9 # this is combat mk2 it can be slower
     sprintModifier: 0.9
   - type: Armor
     modifiers:
@@ -148,7 +148,7 @@
         Piercing: 0.60 # prime is slightly above "recruit" so here is 5% extra resist. sprite does literally have more metal on it.
         Heat: 0.60 # light 5% buff.
   - type: ExplosionResistance
-    damageCoefficient: 0.75
+    damageCoefficient: 0.65
 #  - type: ClothingSpecialModifier
 #    strengthModifier: 2
 
@@ -163,8 +163,8 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/deanrecruitarmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.95 # made a little faster since its just worse than combat mk2
+    sprintModifier: 0.95
   - type: Armor
     modifiers:
       coefficients:
@@ -173,7 +173,7 @@
         Piercing: 0.65 # liquid dogshit but you're the bitch decani. -Bill
         Heat: 0.65
   - type: ExplosionResistance
-    damageCoefficient: 0.75
+    damageCoefficient: 0.65 # Heavy leather absorbs blasts and acts as padding
 #  - type: ClothingSpecialModifier
 #    strengthModifier: 2
 
@@ -188,15 +188,15 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/veteranarmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1 # NO MO SPEED
-    sprintModifier: 1
+    walkModifier: 1.05
+    sprintModifier: 1.05
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.75
         Slash: 0.75
         Piercing: 0.7
-        Heat: 0.85
+        Heat: 0.8 #Legion weak to heat type damage
   - type: ExplosionResistance
     damageCoefficient: 0.8
 
@@ -211,7 +211,7 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/reconnaissancearmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.05
+    walkModifier: 1.05 #same as ranger recon
     sprintModifier: 1.05
   - type: Armor
     modifiers:
@@ -234,14 +234,14 @@
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/lightreconnaissancearmor.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.05
-    sprintModifier: 1.05
+    walkModifier: 1.10 #A little faster than the previous recon
+    sprintModifier: 1.10
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.85
         Slash: 0.85
-        Piercing: 0.80
+        Piercing: 0.85 #20% was a bit too good for what it provided
         Heat: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.85
@@ -262,7 +262,7 @@
         Blunt: 0.85
         Slash: 0.85
         Piercing: 0.75 # 20 fucking %? no. dogshit. here is 25%. You get nothing else. -Bill
-        Heat: 0.8
+        Heat: 0.85 #Legion is weak to heat
   - type: ExplosionResistance
     damageCoefficient: 0.85
 
@@ -282,10 +282,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
+        Blunt: 0.85
+        Slash: 0.85
         Piercing: 0.85 # 10% is worse than some COATS btw. just want you to know that. gave them 15% -Bill
-        Heat: 0.9
+        Heat: 0.9 # Legion is weak to heat
   - type: ExplosionResistance
     damageCoefficient: 0.95
 
@@ -299,13 +299,16 @@
     sprite: Corvax/Clothing/OuterClothing/Armor/vexillariusarmor.rsi
   - type: Clothing
     sprite: Corvax/Clothing/OuterClothing/Armor/vexillariusarmor.rsi
+  - type: ClothingSpeedModifier
+    walkModifier: 1.05 # basically the same as veteran
+    sprintModifier: 1.05
   - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.75
         Slash: 0.75
-        Piercing: 0.70
-        Heat: 0.70
+        Piercing: 0.70 #Vex is a honored veteran
+        Heat: 0.70 #more heat resist, metal pans cover chest and abdomen 
   - type: ExplosionResistance
     damageCoefficient: 0.80
 

--- a/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
@@ -184,7 +184,7 @@
       - id: N14WeaponRifle308SniperRifle  # #Misfits Change - bolt-action .50 replaces semi-auto AMR; Frumentarii use a slower, precise weapon for covert ops
       - id: ClothingBeltRope
       # #Misfits Change - AMR magazines removed; bolt-action uses single cartridges from ammo boxes
-      - id: Magazine308RifleSniper
+      - id: MagazineOver308RifleSniper
         amount: 2
       - id: ClothingEyesNightVisionGoggles
       - id: N14HealingPoultice #Misfits Change /Tweak/: replaces dirty stimpak, Legion uses tribal medicine
@@ -266,7 +266,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -299,7 +298,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -331,7 +329,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary (replaces SMG)
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -360,7 +357,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -390,7 +386,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -422,7 +417,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -454,7 +448,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary (equiv to NCR service rifle)
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -481,7 +474,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle baseline
       - id: N14AmmoBox308
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
@@ -511,7 +503,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
@@ -739,7 +730,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireVeteranArmor
       - id: N14WeaponRifleSKS # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
       - id: SKSEnbloc308
         amount: 4
@@ -771,7 +761,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireVeteranArmor
       - id: N14WeaponRifleSKS # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
       - id: SKSEnbloc308
         amount: 4
@@ -805,7 +794,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireVeteranArmor
       - id: N14WeaponRifleSKS # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
       - id: SKSEnbloc308
         amount: 4
@@ -838,7 +826,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireVeteranArmor
       - id: N14WeaponRifleSKS # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
       - id: SKSEnbloc308
         amount: 4
@@ -868,7 +855,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -899,7 +885,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -930,7 +915,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -968,7 +952,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary (replaces SMG)
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -997,7 +980,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireBaseArmor
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
@@ -1028,7 +1010,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: ClothingBeltQuiverSpear
       - id: N14WeaponSMGGreaseGun
       - id: Magazine45SubMachineGun
@@ -1055,7 +1036,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: ClothingBeltQuiverSpear
       - id: N14PilumSpear
         amount: 4
@@ -1082,7 +1062,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: N14LongSword
       - id: N14LegionnaireBuckler
       - id: N14HealingPowder #Misfits Change /Tweak/: replaces dirty stimpak, Legion uses tribal medicine
@@ -1106,7 +1085,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: N14TribalMachete
       - id: ClothingBeltMedical
       - id: N14Bandage
@@ -1134,7 +1112,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: N14TribalMachete
       - id: N14LegionnaireBuckler
       - id: N14HealingPowder
@@ -1157,7 +1134,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: ClothingBeltQuiverSpear
       - id: N14PilumSpear
         amount: 3
@@ -1181,7 +1157,6 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14ClothingOuterLegionnaireRecruitArmor
       - id: ClothingBeltMedical
       - id: N14TribalMachete
       - id: N14Bandage

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/CenturionArmor.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/CenturionArmor.yml
@@ -20,7 +20,7 @@
         Piercing: 0.45
         Heat: 0.45
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.60
   - type: StaminaDamageResistance
     coefficient: 0.85 # 15%
 #  - type: ClothingSpecialModifier
@@ -74,7 +74,7 @@
         Piercing: 0.45
         Heat: 0.45
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.60
   - type: StaminaDamageResistance
     coefficient: 0.85 # 15%
 
@@ -126,7 +126,7 @@
         Piercing: 0.45
         Heat: 0.45
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.60
   - type: StaminaDamageResistance
     coefficient: 0.85 # 15%
 
@@ -178,7 +178,7 @@
         Piercing: 0.45
         Heat: 0.45
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.60
   - type: StaminaDamageResistance
     coefficient: 0.85 # 15%
 
@@ -230,7 +230,7 @@
         Piercing: 0.45
         Heat: 0.45
   - type: ExplosionResistance
-    damageCoefficient: 0.40
+    damageCoefficient: 0.60
   - type: StaminaDamageResistance
     coefficient: 0.85 # 15%
 

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
@@ -244,6 +244,7 @@
     - N14BPNCRAmmoBox45-70
     - N14BPNCRAmmoMag556Long
     - N14BPNCRAmmoMag308LMG
+    - N14BPNCRAmmoOverMag308
     - N14BPNCRAmmoMagTopSMG12mm
 
 # =====================================================================
@@ -446,6 +447,7 @@
     - N14BPLegionAmmo40mmGrenadeIncendiary
     - N14BPLegionAmmoMagazine308RifleLong  # #Misfits Add - .308 Long mag for Bren LMG
     - N14BPLegionAmmoMagazine308M60Box     # #Misfits Add - .308 50-round box mag for M60 LMG
+    - N14BPLegionAmmoOverMag308
 
 # =====================================================================
 # BROTHERHOOD OF STEEL BLUEPRINTS

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -1371,6 +1371,21 @@
 
 
 - type: latheRecipe
+  id: N14BPNCRAmmoOverMag308
+  result: MagazineOver308RifleSniper
+  category: N14BlueprintNCRAmmoT4
+  completetime: 8
+  requiresBlueprint: true
+  availableFaction:
+  - NCR
+  materials:
+    Steel: 1000
+
+    Lead: 500
+
+    N14Gunpowder: 750
+
+- type: latheRecipe
   id: N14BPNCRAmmoMagTopSMG12mm
   result: N14TopMagazineSMG12mm
   category: N14BlueprintNCRAmmoT4
@@ -2534,6 +2549,21 @@
     Lead: 1000
 
     N14Gunpowder: 900
+
+- type: latheRecipe
+  id: N14BPLegionAmmoOverMag308
+  result: MagazineOver308RifleSniper
+  category: N14BlueprintLegionAmmoT4
+  completetime: 8
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 1000
+
+    Lead: 500
+
+    N14Gunpowder: 750
 
 
 # =====================================================================

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
@@ -97,7 +97,7 @@
   materials:
     Steel: 5000
     Glass: 575
-    Circuitry: 500
+    Circuitry: 400
     Plastic: 750
 
 - type: latheRecipe
@@ -158,7 +158,7 @@
   materials:
     Steel: 7000
     Glass: 1500
-    Circuitry: 575
+    Circuitry: 500
     ScrapElectronic: 500
     Plastic: 750
     N14Gold: 300

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -1070,6 +1070,9 @@
     priceMultiplier: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.7
+  - type: ClothingSpeedModifier
+    walkModifier: 1.05
+    sprintModifier: 1.05
 
 #MARK: Veteran
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -1070,9 +1070,6 @@
     priceMultiplier: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.7
-  - type: ClothingSpeedModifier
-    walkModifier: 1.1 # same as legion recon armor
-    sprintModifier: 1.1
 
 #MARK: Veteran
 

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -497,7 +497,7 @@
       - id: N14ClothingHeadHatNCRBeretRecon
       - id: N14ClothingNeckCloakNCR # Forge-Change
       - id: N14WeaponRifle308SniperRifle
-      - id: Magazine308RifleSniper
+      - id: MagazineOver308RifleSniper
       - id: N14WeaponPistol45Colt
       - id: N14MagazinePistol45
         amount: 2

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/308.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/308.yml
@@ -21,3 +21,27 @@
       collection: N14RifleCasingEject
       params:
         volume: -1
+
+- type: entity
+  id: N14CartridgeOver308Rifle
+  name: cartridge (Overpressure .308)
+  parent: BaseCartridgeLightRifle
+  components:
+  - type: CartridgeAmmo
+    proto: N14BulletOver308
+    soundEject:
+      collection: N14RifleCasingEject
+  - type: Tag
+    tags:
+      - Cartridge
+      - N14CartridgeOver308Rifle
+  - type: EmitSoundOnLand
+    sound:
+      collection: N14RifleCasingEject
+      params:
+        volume: -1
+  - type: EmitSoundOnCollide
+    sound:
+      collection: N14RifleCasingEject
+      params:
+        volume: -1

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/308.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/308.yml
@@ -174,4 +174,25 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
 
+- type: entity # Forge-add-start
+  id: MagazineOver308RifleSniper
+  name: "sniper magazine (Overpressure .308)"
+  parent: BaseMagazine308Rifle
+  components:
+  - type: Tag
+    tags:
+      - N14MagazineOver308RifleSnipers
+  - type: BallisticAmmoProvider
+    proto: N14CartridgeOver308Rifle
+    capacity: 5
+  - type: Sprite
+    netsync: false
+    sprite: _Nuclear14/Objects/Weapons/Guns/Ammunition/Magazines/308/mag5.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+
 # Forge-add-end

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/308.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/308.yml
@@ -13,3 +13,20 @@
     falloffStartTiles: 11.0
     maxFalloffTiles: 22.0
     minDamageMultiplier: 0.65
+
+- type: entity
+  id: N14BulletOver308
+  name: bullet (Overpressure .308 rifle)
+  parent: BaseBullet
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 58
+        Structural: 30
+  # Misfits Add -  Overpressure. Best of the best ammo. Long range, high damage, lethal impact. 
+  - type: BallisticDamageFalloff
+    falloffStartTiles: 15.0
+    maxFalloffTiles: 25.0
+    minDamageMultiplier: 0.85

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1207,7 +1207,7 @@
   name: laser RCW
   parent: N14BaseWeaponPowerCell
   id: N14WeaponLaserRCW
-  description: A rapid-cycling laser weapon with the silhouette of a submachine gun. Designed for close-quarters energy weapon deployment. Inaccurate and battery-hungry, but capable of sustained continuous laser fire.
+  description: A rapid-cycling Electron laser weapon with the silhouette of a submachine gun. Designed for close-quarters energy weapon deployment. Inaccurate and battery-hungry, but capable of sustained continuous fire.
   components:
   - type: Sprite
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/laserrcw.rsi
@@ -1231,12 +1231,12 @@
     slots:
       gun_magazine:
         name: Power Cell
-        startingItem: N14MicrofusionCell # #Misfits Change - consolidated to single generic MFC; RCW fires red beam
+        startingItem: N14ElectronChargePack # #Misfits Change - They abused my good will and now they lose their giga yummy shit fuck these BOS players man.
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/batrifle_magout.ogg
         whitelist:
           tags:
-            - N14MicrofusionCell
+            - N14ElectronChargePack
   - type: Item
     size: Large
     shape:
@@ -1259,7 +1259,7 @@
       collection: N14LaserAutoRifleGunshot
   # #Misfits Add - Red beam override; weapon controls its own beam color
   - type: GunDamageBonus
-    hitscanProtoOverride: N14MFLaserRed
+    hitscanProtoOverride: N14PulseRed
   - type: FollowDistance
     backStrength: 5
   - type: StaticPrice

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -691,7 +691,7 @@
   name: Neostead 2000
   parent: N14WeaponShotgunBase
   id: N14WeaponShotgunNeostead
-  description: A Brotherhood-issue semi-automatic shotgun fed from twin underbarrel tubes holding twelve shells total. Technology well ahead of the pre-war mainstream — and very hard to find outside Brotherhood hands.
+  description: A Brotherhood-issue semi-automatic shotgun fed from twin underbarrel tubes holding ten shells total. Technology well ahead of the pre-war mainstream — This one has the markings of Legion make.
   components:
   - type: Clothing
     sprite: _Nuclear14/Objects/Weapons/Guns/Shotguns/neostead.rsi
@@ -702,7 +702,6 @@
   - type: Sprite
     sprite: _Nuclear14/Objects/Weapons/Guns/Shotguns/neostead.rsi
   - type: Wieldable
-  - type: GunRequiresWield
   - type: GunWieldBonus
     minAngle: -14
     maxAngle: -38
@@ -711,7 +710,7 @@
     maxAngle: 50
     angleIncrease: 4
     angleDecay: 14
-    fireRate: 3
+    fireRate: 2
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -512,7 +512,7 @@
   name: 308 Sniper Rifle
   parent: N14WeaponRifleBase
   id: N14WeaponRifle308SniperRifle
-  description:  sniper rifle chambered in .308.
+  description:  sniper rifle chambered in .308, its chamber can handle overpressured .308 ammo.
   components:
   - type: Clothing
     sprite: _Nuclear14/Objects/Weapons/Guns/Snipers/308SniperRifle.rsi
@@ -537,7 +537,7 @@
     angleDecay: 16
     soundGunshot:
       collection: N14MarksmanGunshot
-    fireRate: 0.5
+    fireRate: 1
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -545,29 +545,26 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: Magazine308RifleSniper
+        startingItem: N14MagazineOver308RifleSnipers
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
         whitelist:
           tags:
+            - N14MagazineOver308RifleSnipers
             - N14Magazine308RifleSnipers
       gun_chamber:
         name: Chamber
-        startingItem: N14Cartridge308Rifle
+        startingItem: N14CartridgeOver308Rifle
         priority: 1
         whitelist:
           tags:
+            - N14CartridgeOver308Rifle
             - N14Cartridge308Rifle
   - type: FollowDistance
     backStrength: 3
   - type: StaticPrice
     price: 175
-  - type: GunDamageBonus
-    bonusDamage:
-      types:
-        Pierce: 20 # High bullet velocity sniper rifle. makes the .308 more lethal without requiring a massive rebalance of calibers.
-        Structural: 30 # Lighter anti-PA weapon. Bring down the metal monsters.
 # Forge-add-end
 
 # #Misfits Add — Cowboy Repeater, Paciencia, Ratslayer, M1 Carbine, Rangemaster

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -545,7 +545,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: N14MagazineOver308RifleSnipers
+        startingItem: MagazineOver308RifleSnipers
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -545,7 +545,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazineOver308RifleSnipers
+        startingItem: MagazineOver308RifleSniper
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2

--- a/Resources/Prototypes/_Nuclear14/tags.yml
+++ b/Resources/Prototypes/_Nuclear14/tags.yml
@@ -281,6 +281,12 @@
 - type: Tag
   id: N14Cartridge308Rifle
 
+- type: Tag
+  id: N14CartridgeOver308Rifle
+
+- type: Tag
+  id: N14MagazineOver308RifleSnipers
+
 #MARK: Ammo tags(Magazines).
 - type: Tag
   id: N14MagazinePistol44


### PR DESCRIPTION
## About the PR
Removed armors from legion kits they were duping armors since they already spawn wearing armor
Added overpressure .308. a higher damage form of .308 that only feeds into the .308 sniper. also increased ROF to 1rps
Added BPs for overpressure .308 to the legion and NCR BPs. Go my chudlet specialists and frumetarii. Kill
Nerfed legion cent armors explosion resists 
Actually buffed some legion armors and returned some of their speeds. Several lost some protection because of what they provided (speed wise) while some gained protection (like light legionnaire and vex armor)
Also lowered ranger duster speed by 5%, now its the same as a recon armor (25% across board with 5% speed boost)
Made neostead 1 handed again, following what I discussed with brady. Decreased ROF by 1 and changed it description to match how its found in game.

Also tweaked vault laser rifle prices, they were a little odd before. Now its 4 circuits for the AER-9 and 5 for the auto (not including the various other needed mats)

## Why / Balance
.308 overpressure makes the sniper USEFUL!!!!!!! also cool awesome anti-PA weapon that ISN'T A FITY? WOAH!!!!
Cent armor was face tanking multiple GL shots to the nose. no man. no.
Some legion armor balance didn't make sense, like the light legionnaire being worse than light recon. Also buffed some explosive resists while touching up heat resists.
Brady nerfed shields to shit, Neo-shield combo is nowhere near as busted now. Lets give legion back its baby.
It was 5 circuits for an AER-9 and 5.75 for an auto, kinda stupid. I'll admit.

## Technical details
YAML YAML YAML YAML YAML

## Media

https://github.com/user-attachments/assets/7cd76295-7dcd-462b-9754-f1516f2a56b5

# Changelog

:cl: BILL AGAIN
- add: Added .308 overpressure ammo. the .308 sniper exclusively can use it. it won't feed into anything else.
- tweak: Screwed with legion armors more. A moderate retooling and some buffs, like for vex and light legionnaire armor.
- add: added .308 overpressure BPs to legion and NCR prints.
- tweak: reduced centurion explosive resists
- tweak: changed the RCW to take electron charge packs, like it does in the games! yes it does fire the electron bolts now.
- remove: Legion lost the extra armors they got from kits. sorry not sorry.
- tweak: I FORGOT TO MENTION LAST PR THAT I INCREASED SHOPKEEP PRICES for: MFCs, 40mm, various melee weapons, plasma carts, and the wasteland polearm that was stupidly cheap.
- remove: removed the forced wield on neostead. Legion REJOICE. It lost 1 ROF for this
- tweak: decreased circuit costs on vault BP for AER-9 and AER-9 auto. 