### PR TITLE
Fixes And Mapping Back-End

### DIFF
--- a/Resources/Prototypes/Corvax/Roles/ai_factions.yml
+++ b/Resources/Prototypes/Corvax/Roles/ai_factions.yml
@@ -20,6 +20,7 @@
   - Feral
   - HostileRobot
   - Raider
+  - Enclave
 
 # - type: npcFaction
 #   id: BrotherhoodWest

--- a/Resources/Prototypes/_Misfits/Entities/Markers/Spawners/enclave_base.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Markers/Spawners/enclave_base.yml
@@ -1,0 +1,116 @@
+- type: entity
+  name: Enclave Eyebot Spawner
+  id: MisfitsSpawnerEnclaveEyebot
+  suffix: Mapping
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: _Nuclear14/Mobs/Robots/eyebot.rsi
+      state: icon
+    - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+    - N14MobRobotEyebot
+
+- type: entity
+  name: Enclave Protectron Spawner
+  id: MisfitsSpawnerEnclaveProtectron
+  suffix: Mapping
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: _Nuclear14/Mobs/Robots/protectron.rsi
+      state: icon
+    - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+    - N14MobRobotProtectronHostile
+
+- type: entity
+  name: Enclave Mr. Gutsy Spawner
+  id: MisfitsSpawnerEnclaveMrGutsy
+  suffix: Mapping
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: _Nuclear14/Mobs/Robots/mrhandygutsy.rsi
+      state: icon
+    - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+    - N14MobRobotMrHandyGutsy
+
+- type: entity
+  name: Enclave Assaultron Spawner
+  id: MisfitsSpawnerEnclaveAssaultron
+  suffix: Mapping
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: _Nuclear14/Mobs/Robots/assaultron.rsi
+      state: icon
+    - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+    - N14MobRobotAssaultronHostile
+
+- type: entity
+  name: Enclave Sentry Bot Spawner
+  id: MisfitsSpawnerEnclaveSentryBot
+  suffix: Mapping
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: _Nuclear14/Mobs/Robots/sentrybot.rsi
+      state: icon
+    - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+    - N14MobRobotSentryBot
+
+- type: entity
+  name: Enclave Sentry Bot Spawner (Ballistic)
+  id: MisfitsSpawnerEnclaveSentryBotBallistic
+  suffix: Mapping
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: _Nuclear14/Mobs/Robots/sentrybot.rsi
+      state: icon
+    - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+    - N14MobRobotSentryBotBallistic
+
+- type: entity
+  name: Enclave Robot Security Spawner
+  id: MisfitsSpawnerEnclaveRobotSecurity
+  suffix: Mapping, Random
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - sprite: _Nuclear14/Mobs/Robots/eyebot.rsi
+      state: icon
+    - state: ai
+  - type: ConditionalSpawner
+    prototypes:
+    - N14MobRobotEyebot
+    - N14MobRobotProtectronHostile
+    - N14MobRobotMrHandyGutsy
+    - N14MobRobotAssaultronHostile
+    - N14MobRobotSentryBot
+    - N14MobRobotSentryBotBallistic

--- a/Resources/Prototypes/_Misfits/Entities/Structures/Decoration/enclave_power_armor_display.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Structures/Decoration/enclave_power_armor_display.yml
@@ -1,0 +1,27 @@
+- type: entity
+  parent: BaseStructure
+  id: MisfitsDecorationPowerArmorX01Display
+  name: X-01 power armor display
+  description: A secured display suit of Enclave X-01 power armor. It is decorative and cannot be worn.
+  suffix: Enclave, Mapping
+  components:
+  - type: Sprite
+    drawdepth: Objects
+    noRot: true
+    sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/advanced1.rsi
+    state: icon
+  - type: InteractionOutline
+
+- type: entity
+  parent: BaseStructure
+  id: MisfitsDecorationPowerArmorMutantX01Display
+  name: Super Mutant X-01 power armor display
+  description: A secured display suit of oversized Enclave X-01 power armor. It is decorative and cannot be worn.
+  suffix: Enclave, Mapping
+  components:
+  - type: Sprite
+    drawdepth: Objects
+    noRot: true
+    sprite: _Misfits/Clothing/OuterClothing/PowerArmor/Mutant_PA.rsi
+    state: icon
+  - type: InteractionOutline

--- a/Resources/Prototypes/_Misfits/Entities/Structures/Doors/enclave_doors.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Structures/Doors/enclave_doors.yml
@@ -1,0 +1,119 @@
+- type: entity
+  parent: N14DoorBunker
+  id: N14DoorBunkerLockedEnclave
+  suffix: Enclave, Locked
+  components:
+  - type: AccessReader
+    access: [["Enclave"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunkerGlass
+  id: N14DoorBunkerGlassLockedEnclave
+  suffix: Enclave, Locked
+  components:
+  - type: AccessReader
+    access: [["Enclave"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunker3X
+  id: N14DoorBunker3XLockedEnclave
+  suffix: Enclave, Locked
+  components:
+  - type: AccessReader
+    access: [["Enclave"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunkerGlass3X
+  id: N14DoorBunkerGlass3XLockedEnclave
+  suffix: Enclave, Locked
+  components:
+  - type: AccessReader
+    access: [["Enclave"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorMetalSecure
+  id: N14DoorMetalSecureLockedEnclave
+  suffix: Enclave, Locked
+  components:
+  - type: AccessReader
+    access: [["Enclave"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorCellMetal
+  id: N14DoorCellMetalLockedEnclave
+  suffix: Enclave, Locked
+  components:
+  - type: AccessReader
+    access: [["Enclave"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunker
+  id: N14DoorBunkerLockedEnclaveSecurity
+  suffix: Enclave, Locked, Security
+  components:
+  - type: AccessReader
+    access: [["EnclaveNCO"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunker
+  id: N14DoorBunkerLockedEnclaveScience
+  suffix: Enclave, Locked, Science
+  components:
+  - type: AccessReader
+    access: [["EnclaveScience"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorBunker
+  id: N14DoorBunkerLockedEnclaveCommand
+  suffix: Enclave, Locked, Command
+  components:
+  - type: AccessReader
+    access: [["EnclaveCommand"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorMetalSecure
+  id: N14DoorMetalSecureLockedEnclaveSecurity
+  suffix: Enclave, Locked, Security
+  components:
+  - type: AccessReader
+    access: [["EnclaveNCO"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorMetalSecure
+  id: N14DoorMetalSecureLockedEnclaveScience
+  suffix: Enclave, Locked, Science
+  components:
+  - type: AccessReader
+    access: [["EnclaveScience"]]
+  - type: Wires
+    layoutId: HighSec
+
+- type: entity
+  parent: N14DoorMetalSecure
+  id: N14DoorMetalSecureLockedEnclaveCommand
+  suffix: Enclave, Locked, Command
+  components:
+  - type: AccessReader
+    access: [["EnclaveCommand"]]
+  - type: Wires
+    layoutId: HighSec

--- a/Resources/Prototypes/_Misfits/Entities/Structures/Machines/enclave_tactical_map.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Structures/Machines/enclave_tactical_map.yml
@@ -1,0 +1,44 @@
+- type: entity
+  parent: N14BrotherhoodTacticalmap
+  id: MisfitsEnclaveTacticalMap
+  name: Enclave TacMap
+  description: A secured Enclave tactical map used to coordinate base operations.
+  suffix: Enclave, Mapping
+  components:
+  - type: WastelandMap
+    mapTexturePath: _Misfits/Maps/wendover_map.png
+    mapTitle: Enclave TacMap - Wendover
+    worldBounds: "-517,-308,484,311"
+    tacticalFeed: Enclave
+  - type: AccessReader
+    access: [["Enclave"]]
+  - type: ActivatableUIRequiresAccess
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MisfitsEnclaveTacticalMapBroken:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+
+- type: entity
+  parent: N14BrotherhoodTacticalmapBroken
+  id: MisfitsEnclaveTacticalMapBroken
+  name: Enclave TacMap
+  description: A broken Enclave tactical map.
+  suffix: Enclave, Broken
+  components:
+  - type: WastelandMap
+    mapTexturePath: _Misfits/Maps/wendover_map.png
+    mapTitle: Enclave TacMap - Wendover
+    worldBounds: "-517,-308,484,311"
+    tacticalFeed: Enclave
+  - type: AccessReader
+    access: [["Enclave"]]
+  - type: ActivatableUIRequiresAccess

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
@@ -477,7 +477,6 @@
           factions:
             - PlayerSuperMutant
             - Enclave
-            - Wastelander
         - type: PowerArmorProficiency
 - type: startingGear
   id: SuperMutantEnclaveGear

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
@@ -466,6 +466,8 @@
   spawnLoadout: true
   applyTraits: true
   startingGear: SuperMutantEnclaveGear
+  accessGroups:
+  - EnclaveEnlisted
   requirements:
     - !type:CharacterSpeciesRequirement
       species:

--- a/Resources/Prototypes/_Misfits/Roles/ai_factions.yml
+++ b/Resources/Prototypes/_Misfits/Roles/ai_factions.yml
@@ -124,6 +124,7 @@
   - Deathclaw #Misfits Add - Deathclaw is enemy of everything
   - Raider
   - HostileRobot
+  - Enclave
   - Feral
 
 - type: npcFaction
@@ -150,6 +151,7 @@
   - Raider
   - CaesarLegion
   - HostileRobot
+  - Enclave
   - Feral
 
 # #Misfits Add - Enclave remnant faction for player jobs and future map-side automation.
@@ -165,7 +167,6 @@
   - WastelandAnimal
   - Deathclaw
   - Raider
-  - HostileRobot
   - Feral
 
 # #Misfits Add - Followers of the Apocalypse player faction.
@@ -200,3 +201,4 @@
   - Feral
   - CaesarLegion
   - SuperMutant
+  - Enclave

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/powerarmorhelmet.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/powerarmorhelmet.yml
@@ -126,6 +126,12 @@
         Radiation: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.85
+  - type: NightVision
+    isEquipment: true
+  - type: ThermalVision
+    isEquipment: true
+    pulseTime: 2
+    toggleAction: PulseThermalVision
   - type: BreathMask # Misfits Change
   - type: GasFilterMask # Misfits Change
   - type: IngestionBlocker # Misfits Change
@@ -391,6 +397,12 @@
         Radiation: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.85
+  - type: NightVision
+    isEquipment: true
+  - type: ThermalVision
+    isEquipment: true
+    pulseTime: 2
+    toggleAction: PulseThermalVision
   - type: BreathMask # Misfits Change
   - type: GasFilterMask # Misfits Change
   - type: IngestionBlocker # Misfits Change

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/powerarmorhelmet.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Head/powerarmorhelmet.yml
@@ -410,6 +410,21 @@
     tags:
     - HidesHair
     - HidesBeard
+  # #Misfits Change - Enclave tactical HUD
+  - type: WastelandMap
+    mapTexturePath: _Misfits/Maps/wendover_map.png
+    mapTitle: Enclave Tactical HUD
+    # #Misfits Fix - Match the corrected Wendover AABB so helmet-linked tactical markers align with the map art.
+    worldBounds: "-517,-308,484,311"
+    tacticalFeed: Enclave
+    compactHud: true
+  - type: WastelandMapAction
+    requiredSlot: HEAD
+  - type: UserInterface
+    interfaces:
+      enum.WastelandMapUiKey.Key:
+        type: WastelandMapBoundUserInterface
+  # End Misfits Change
 
 - type: entity
   parent: N14ClothingHeadHelmetPowerArmorX01

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -137,7 +137,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 960 # #Misfits Tweak: By Bill, 960 durability.
+    maxIntegrity: 480 # #Misfits Tweak: By Bill, 480 durability.
   - type: Sprite
     sprite: _Misfits/Clothing/OuterClothing/PowerArmor/Mutant_PA.rsi
   - type: Clothing
@@ -255,7 +255,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 920 # #Misfits Tweak: By Bill, 920 a little better than T60 but not T51.
+    maxIntegrity: 460 # #Misfits Tweak: By Bill, 460 a little better than T60 but not T51.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/advanced1.rsi
   - type: Clothing
@@ -296,7 +296,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 970 # #Misfits Tweak: doubled X-02 durability.
+    maxIntegrity: 485 # #Misfits Tweak: X-02 durability.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/advanced2.rsi
   - type: Clothing
@@ -352,7 +352,7 @@
   description: A deep black suit of Enclave-manufactured heavy power armor based on pre-war designs such as the T-51 and improving off of data gathered by post-war designs such as the X-01. Most commonly fielded on the East Coast, no suit rivals its strength.
   components:
   - type: PowerArmorIntegrity
-    maxIntegrity: 1000 # #Misfits Tweak: doubled Hellfire durability.
+    maxIntegrity: 500 # #Misfits Tweak: Hellfire durability.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/hellfire.rsi
   - type: Clothing

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -137,7 +137,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 480 # #Misfits Tweak: By Bill, 480 durability.
+    maxIntegrity: 960 # #Misfits Tweak: By Bill, 960 durability.
   - type: Sprite
     sprite: _Misfits/Clothing/OuterClothing/PowerArmor/Mutant_PA.rsi
   - type: Clothing
@@ -255,7 +255,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 460 # #Misfits Tweak: By Bill, 460 a little better than T60 but not T51.
+    maxIntegrity: 920 # #Misfits Tweak: By Bill, 920 a little better than T60 but not T51.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/advanced1.rsi
   - type: Clothing

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -296,7 +296,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 485 # #Misfits Tweak: By Bill, better by a tiny bit than T51. TINY BIT
+    maxIntegrity: 970 # #Misfits Tweak: doubled X-02 durability.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/advanced2.rsi
   - type: Clothing
@@ -352,7 +352,7 @@
   description: A deep black suit of Enclave-manufactured heavy power armor based on pre-war designs such as the T-51 and improving off of data gathered by post-war designs such as the X-01. Most commonly fielded on the East Coast, no suit rivals its strength.
   components:
   - type: PowerArmorIntegrity
-    maxIntegrity: 500 # #Misfits Tweak: By Bill, Hellfire. Literally a rarer than rare armor. Not mapped nor makeable.
+    maxIntegrity: 1000 # #Misfits Tweak: doubled Hellfire durability.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/hellfire.rsi
   - type: Clothing

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Materials/materials.yml
@@ -150,6 +150,32 @@
   - type: Construction
     graph: N14Paper
     node: paper
+  - type: Flammable
+    fireSpread: true
+    canResistFire: false
+    alwaysCombustible: true
+    canExtinguish: false
+    damage:
+      types:
+        Heat: 1
+  - type: FireVisuals
+    sprite: Effects/fire.rsi
+    normalState: fire
+  - type: Damageable
+    damageModifierSet: Wood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 15
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Ash:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
   - type: PhysicalComposition
     materialComposition:
       N14Paper: 100

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Misc/identification.yml
@@ -285,7 +285,6 @@
   id: N14IDEnclaveTrooper
   name: holotag
   description: An ID holotag worn by the Enclave.
-  categories: [ HideSpawnMenu ]
   suffix: Trooper
   components:
   - type: Sprite
@@ -306,7 +305,6 @@
   id: N14IDEnclaveOfficer
   name: holotag
   description: An ID holotag worn by higher ranking memebers of the Enclave.
-  categories: [ HideSpawnMenu ]
   suffix: Officer
   components:
   - type: Sprite
@@ -323,7 +321,6 @@
   id: N14IDEnclaveNoncombat
   name: holotag
   description: An ID holotag worn by the non-combat members of Enclave.
-  categories: [ HideSpawnMenu ]
   suffix: Scientist , Noncombat
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Nuclear14/Roles/ai_factions.yml
+++ b/Resources/Prototypes/_Nuclear14/Roles/ai_factions.yml
@@ -137,6 +137,7 @@
   - Deathclaw #Misfits Add - Deathclaw is enemy of everything
   - Raider
   - HostileRobot
+  - Enclave
   - Feral
 
 - type: npcFaction
@@ -164,6 +165,7 @@
   - Feral
   - CaesarLegion #Corvax-Legion
   - BrotherhoodOfSteel
+  - Enclave
 
 - type: npcFaction
   id: Rangers
@@ -329,6 +331,7 @@
   - Deathclaw #Misfits Add - Deathclaw is enemy of everything
   - Zetan
   - HostileRobot
+  - Enclave
   - Feral
   - CaesarLegion #Corvax-Legion
   - BrotherhoodOfSteelSecureArea
@@ -355,6 +358,7 @@
   - Deathclaw #Misfits Add - Deathclaw is enemy of everything
   - Zetan
   - HostileRobot
+  - Enclave
   - Raider
   - CaesarLegion #Corvax-Legion
   - BrotherhoodOfSteelSecureArea
@@ -380,6 +384,7 @@
   - Deathclaw #Misfits Add - Deathclaw is now a separate faction; yaoguai etc. attack deathclaws
   - Raider
   - HostileRobot
+  - Enclave
   - Feral
   - CaesarLegion #Corvax-Legion
   - BrotherhoodOfSteelSecureArea
@@ -405,6 +410,7 @@
   - Deathclaw #Misfits Add - Deathclaw is enemy of everything
   - Raider
   - HostileRobot
+  - Enclave
   - Feral
   - CaesarLegion #Corvax-Legion
   - BrotherhoodOfSteelSecureArea


### PR DESCRIPTION
## About the PR

Updated Enclave NPC faction behavior, added Enclave mapping tools, improved Enclave power armor utility, and temporarily increased Enclave power armor durability for event use.

## Why / Balance

Enclave characters should still be attacked by hostile wasteland NPC factions, but hostile robots should not target them by faction.

Enclave power armor helmets now provide Enclave TacMap access, night vision, and thermal vision where appropriate, making them more consistent with the Super Mutant Enclave X-01 suit.

## Technical details

Removed `HostileRobot` from the `Enclave` hostile faction list.

Added `Enclave` to relevant non-robot hostile faction lists.

Added Enclave-only mapper doors and tools:
- Enclave-locked bunker, glass bunker, 3x bunker, secure metal, and cell doors
- Enclave security, science, and command access door variants
- Enclave TacMap structure
- Enclave power armor display props
- Enclave robot security spawners

Made Enclave holotags visible in the entity spawn menu:
- `N14IDEnclaveTrooper`
- `N14IDEnclaveOfficer`
- `N14IDEnclaveNoncombat`

Added `EnclaveEnlisted` access to `SuperMutantEnclave`.

Added Enclave TacMap, night vision, and thermal vision support to relevant Enclave power armor helmets:
- `N14ClothingHeadHelmetPowerArmorX01`
- `N14ClothingHeadHelmetPowerArmorX02`
- `N14ClothingHeadHelmetPowerArmorHellfire`
- `MisfitsEnclavePowerArmorHelmet`

## Media

N/A, prototype data changes only.

# Changelog

:cl:
- fix: Fixed Enclave characters being incorrectly targeted by hostile robots while preserving hostility from other NPC factions.
- fix: Made Enclave holotags visible in the entity spawn menu.
- add: Added Enclave TacMap, night vision, and thermal vision support to Enclave power armor helmets.
- add: Added Enclave-locked doors and mapper tools for Enclave base mapping.
- fix: Makes N14Paper burnable.