### PR TITLE
Eighties Loadouts

### DIFF
--- a/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
@@ -777,3 +777,80 @@ undecided-loadout-category-misfits-priestess-order-desc =
     2 Bolas, a box of handcuffs, 2 muzzles.
     2 Collars, with keys, a police baton,
     2 K rations, and a ceramic flask.
+
+undecided-loadout-category-misfits-eighties-block-road-captain-name = Road Captain Kit
+undecided-loadout-category-misfits-eighties-block-road-captain-description =
+    Includes a .45 SMG with 4 magazines, an upgraded .44 revolver
+    with 2 speedloaders, a radio, 2 smoke grenades, Psycho,
+    a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-block-boss-brawler-name = Boss Brawler Kit
+undecided-loadout-category-misfits-eighties-block-boss-brawler-description =
+    Includes a sledgehammer, a .45 pistol with 4 magazines,
+    a frag grenade, a smoke grenade, Psycho, a stimpak,
+    gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-block-lead-foot-name = Lead Foot Kit
+undecided-loadout-category-misfits-eighties-block-lead-foot-description =
+    Includes a 10mm SMG with 4 magazines, a combat knife,
+    a radio, a smoke grenade, Psycho, a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-cylinders-tommy-name = Cylinders Tommy Kit
+undecided-loadout-category-misfits-eighties-cylinders-tommy-description =
+    Includes a .45 SMG with 3 magazines, a combat knife,
+    a smoke grenade, a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-cylinders-shotcaller-name = Cylinders Shotcaller Kit
+undecided-loadout-category-misfits-eighties-cylinders-shotcaller-description =
+    Includes an upgraded .44 revolver with 3 speedloaders,
+    a radio, 2 smoke grenades, Psycho, a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-cylinders-road-marshal-name = Cylinders Road Marshal Kit
+undecided-loadout-category-misfits-eighties-cylinders-road-marshal-description =
+    Includes a 10mm SMG with 3 magazines, a hatchet,
+    a smoke grenade, a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-pistons-skirmisher-name = Pistons Skirmisher Kit
+undecided-loadout-category-misfits-eighties-pistons-skirmisher-description =
+    Includes a pipe 10mm SMG with 3 magazines, a combat knife,
+    a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-pistons-scattergun-name = Pistons Scattergun Kit
+undecided-loadout-category-misfits-eighties-pistons-scattergun-description =
+    Includes a pump shotgun, a box of 12 gauge shells,
+    a hatchet, a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-pistons-blade-name = Pistons Blade Kit
+undecided-loadout-category-misfits-eighties-pistons-blade-description =
+    Includes a machete, a 9mm pistol with 3 magazines,
+    Psycho, a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-oilers-mechanic-name = Oilers Mechanic Kit
+undecided-loadout-category-misfits-eighties-oilers-mechanic-description =
+    Includes a filled mechanical toolbox, a pipe 10mm pistol
+    with 3 magazines, 2 flares, a stimpak, and gauze.
+
+undecided-loadout-category-misfits-eighties-oilers-firebug-name = Oilers Firebug Kit
+undecided-loadout-category-misfits-eighties-oilers-firebug-description =
+    Includes a sawed-off shotgun, a box of 12 gauge shells,
+    2 smoke grenades, 2 flares, a stimpak, and gauze.
+
+undecided-loadout-category-misfits-eighties-oilers-patch-name = Oilers Patch Kit
+undecided-loadout-category-misfits-eighties-oilers-patch-description =
+    Includes a 9mm pistol with 2 magazines, 2 stimpaks,
+    2 gauze packs, and a flare.
+
+undecided-loadout-category-misfits-eighties-road-rash-runner-name = Road Rash Runner Kit
+undecided-loadout-category-misfits-eighties-road-rash-runner-description =
+    Includes a 9mm pistol with 2 magazines, a combat knife,
+    a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-road-rash-scrapper-name = Road Rash Scrapper Kit
+undecided-loadout-category-misfits-eighties-road-rash-scrapper-description =
+    Includes a baseball bat, a pipe 10mm pistol with 2 magazines,
+    a stimpak, gauze, and a flare.
+
+undecided-loadout-category-misfits-eighties-road-rash-lookout-name = Road Rash Lookout Kit
+undecided-loadout-category-misfits-eighties-road-rash-lookout-description =
+    Includes a 9mm pistol, a box of 9mm ammo, a tribal knife,
+    a smoke grenade, 2 flares, a stimpak, and gauze.

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/eighties_rank_loadoutkits.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/eighties_rank_loadoutkits.yml
@@ -1,0 +1,572 @@
+# #Misfits Add - Eighties role-specific undecided loadout kits.
+
+- type: entity
+  id: EightiesTheBlockloadoutkits
+  name: Undecided Eighties The Block Loadout Kit
+  parent: BaseLoadoutKit
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: pointman
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - Eighties_BlockRoadCaptainSet
+    - Eighties_BlockBossBrawlerSet
+    - Eighties_BlockLeadFootSet
+
+- type: entity
+  id: EightiesCylindersloadoutkits
+  name: Undecided Eighties Cylinders Loadout Kit
+  parent: BaseLoadoutKit
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: gunner
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - Eighties_CylindersTommySet
+    - Eighties_CylindersShotcallerSet
+    - Eighties_CylindersRoadMarshalSet
+
+- type: entity
+  id: EightiesPistonsloadoutkits
+  name: Undecided Eighties Pistons Loadout Kit
+  parent: BaseLoadoutKit
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: rifleman
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - Eighties_PistonsSkirmisherSet
+    - Eighties_PistonsScattergunSet
+    - Eighties_PistonsBladeSet
+
+- type: entity
+  id: EightiesOilersloadoutkits
+  name: Undecided Eighties Oilers Loadout Kit
+  parent: BaseLoadoutKit
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: pointman
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - Eighties_OilersMechanicSet
+    - Eighties_OilersFirebugSet
+    - Eighties_OilersPatchSet
+
+- type: entity
+  id: EightiesRoadRashloadoutkits
+  name: Undecided Eighties Road Rash Loadout Kit
+  parent: BaseLoadoutKit
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: marksman
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - Eighties_RoadRashRunnerSet
+    - Eighties_RoadRashScrapperSet
+    - Eighties_RoadRashLookoutSet
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_BlockRoadCaptainSet
+  name: undecided-loadout-category-misfits-eighties-block-road-captain-name
+  description: undecided-loadout-category-misfits-eighties-block-road-captain-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: pointman
+  content:
+  - KitEighties_BlockRoadCaptain
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_BlockBossBrawlerSet
+  name: undecided-loadout-category-misfits-eighties-block-boss-brawler-name
+  description: undecided-loadout-category-misfits-eighties-block-boss-brawler-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: gunner
+  content:
+  - KitEighties_BlockBossBrawler
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_BlockLeadFootSet
+  name: undecided-loadout-category-misfits-eighties-block-lead-foot-name
+  description: undecided-loadout-category-misfits-eighties-block-lead-foot-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: marksman
+  content:
+  - KitEighties_BlockLeadFoot
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_CylindersTommySet
+  name: undecided-loadout-category-misfits-eighties-cylinders-tommy-name
+  description: undecided-loadout-category-misfits-eighties-cylinders-tommy-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: rifleman
+  content:
+  - KitEighties_CylindersTommy
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_CylindersShotcallerSet
+  name: undecided-loadout-category-misfits-eighties-cylinders-shotcaller-name
+  description: undecided-loadout-category-misfits-eighties-cylinders-shotcaller-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: pointman
+  content:
+  - KitEighties_CylindersShotcaller
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_CylindersRoadMarshalSet
+  name: undecided-loadout-category-misfits-eighties-cylinders-road-marshal-name
+  description: undecided-loadout-category-misfits-eighties-cylinders-road-marshal-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: marksman
+  content:
+  - KitEighties_CylindersRoadMarshal
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_PistonsSkirmisherSet
+  name: undecided-loadout-category-misfits-eighties-pistons-skirmisher-name
+  description: undecided-loadout-category-misfits-eighties-pistons-skirmisher-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: rifleman
+  content:
+  - KitEighties_PistonsSkirmisher
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_PistonsScattergunSet
+  name: undecided-loadout-category-misfits-eighties-pistons-scattergun-name
+  description: undecided-loadout-category-misfits-eighties-pistons-scattergun-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: gunner
+  content:
+  - KitEighties_PistonsScattergun
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_PistonsBladeSet
+  name: undecided-loadout-category-misfits-eighties-pistons-blade-name
+  description: undecided-loadout-category-misfits-eighties-pistons-blade-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: marksman
+  content:
+  - KitEighties_PistonsBlade
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_OilersMechanicSet
+  name: undecided-loadout-category-misfits-eighties-oilers-mechanic-name
+  description: undecided-loadout-category-misfits-eighties-oilers-mechanic-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: pointman
+  content:
+  - KitEighties_OilersMechanic
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_OilersFirebugSet
+  name: undecided-loadout-category-misfits-eighties-oilers-firebug-name
+  description: undecided-loadout-category-misfits-eighties-oilers-firebug-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: gunner
+  content:
+  - KitEighties_OilersFirebug
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_OilersPatchSet
+  name: undecided-loadout-category-misfits-eighties-oilers-patch-name
+  description: undecided-loadout-category-misfits-eighties-oilers-patch-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: medic
+  content:
+  - KitEighties_OilersPatch
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_RoadRashRunnerSet
+  name: undecided-loadout-category-misfits-eighties-road-rash-runner-name
+  description: undecided-loadout-category-misfits-eighties-road-rash-runner-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: marksman
+  content:
+  - KitEighties_RoadRashRunner
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_RoadRashScrapperSet
+  name: undecided-loadout-category-misfits-eighties-road-rash-scrapper-name
+  description: undecided-loadout-category-misfits-eighties-road-rash-scrapper-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: rifleman
+  content:
+  - KitEighties_RoadRashScrapper
+
+- type: UndecidedLoadoutBackpackSet
+  id: Eighties_RoadRashLookoutSet
+  name: undecided-loadout-category-misfits-eighties-road-rash-lookout-name
+  description: undecided-loadout-category-misfits-eighties-road-rash-lookout-description
+  sprite:
+    sprite: _Nuclear14/Objects/Misc/kits.rsi
+    state: marksman
+  content:
+  - KitEighties_RoadRashLookout
+
+- type: entity
+  id: KitEighties_BlockRoadCaptain
+  name: road captain kit
+  parent: KitBase
+  description: A command kit for keeping the road gang moving.
+  components:
+  - type: Sprite
+    state: pointman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponSMG45
+    - id: Magazine45SubMachineGun
+      amount: 4
+    - id: N14WeaponRevolver44TribalUpgraded
+    - id: SpeedLoader44
+      amount: 2
+    - id: RadioHandheld
+    - id: SmokeGrenade
+      amount: 2
+    - id: N14Psycho
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_BlockBossBrawler
+  name: boss brawler kit
+  parent: KitBase
+  description: Heavy-handed tools for a boss who leads from the front.
+  components:
+  - type: Sprite
+    state: gunner
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14SledgeHammer
+    - id: N14WeaponPistol45Colt
+    - id: N14MagazinePistol45
+      amount: 4
+    - id: GrenadeFrag
+    - id: SmokeGrenade
+    - id: N14Psycho
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_BlockLeadFoot
+  name: lead foot kit
+  parent: KitBase
+  description: A fast-response kit for running down trouble.
+  components:
+  - type: Sprite
+    state: marksman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponSMG10mm
+    - id: N14MagazineSMG10mm
+      amount: 4
+    - id: N14CombatKnife
+    - id: RadioHandheld
+    - id: SmokeGrenade
+    - id: N14Psycho
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_CylindersTommy
+  name: cylinders tommy kit
+  parent: KitBase
+  description: A loud officer kit built around a .45 SMG.
+  components:
+  - type: Sprite
+    state: rifleman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponSMG45
+    - id: Magazine45SubMachineGun
+      amount: 3
+    - id: N14CombatKnife
+    - id: SmokeGrenade
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_CylindersShotcaller
+  name: cylinders shotcaller kit
+  parent: KitBase
+  description: A sidearm and command kit for an Eighties officer.
+  components:
+  - type: Sprite
+    state: pointman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponRevolver44TribalUpgraded
+    - id: SpeedLoader44
+      amount: 3
+    - id: RadioHandheld
+    - id: SmokeGrenade
+      amount: 2
+    - id: N14Psycho
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_CylindersRoadMarshal
+  name: cylinders road marshal kit
+  parent: KitBase
+  description: A mobile patrol kit for keeping the road locked down.
+  components:
+  - type: Sprite
+    state: marksman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponSMG10mm
+    - id: N14MagazineSMG10mm
+      amount: 3
+    - id: N14Hatchet
+    - id: SmokeGrenade
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_PistonsSkirmisher
+  name: pistons skirmisher kit
+  parent: KitBase
+  description: A mid-rank road fighter kit with a 10mm SMG.
+  components:
+  - type: Sprite
+    state: rifleman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponSMG10mmPipe
+    - id: N14MagazineSMG10mm
+      amount: 3
+    - id: N14CombatKnife
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_PistonsScattergun
+  name: pistons scattergun kit
+  parent: KitBase
+  description: A close-range kit for hard pushes and dirty corners.
+  components:
+  - type: Sprite
+    state: gunner
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponShotgun
+    - id: MagazineBox12gauge
+    - id: N14Hatchet
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_PistonsBlade
+  name: pistons blade kit
+  parent: KitBase
+  description: A melee-forward kit with a pistol backup.
+  components:
+  - type: Sprite
+    state: marksman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14Machete
+    - id: N14WeaponPistol9mm
+    - id: N14MagazinePistol9mm
+      amount: 3
+    - id: N14Psycho
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_OilersMechanic
+  name: oilers mechanic kit
+  parent: KitBase
+  description: Tools, a pipe gun, and road-side supplies for an Oiler.
+  components:
+  - type: Sprite
+    state: pointman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: ToolboxMechanicalFilled
+    - id: N14WeaponPistol10mmPipe
+    - id: N14MagazinePistol10mm
+      amount: 3
+    - id: N14Flare
+      amount: 2
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_OilersFirebug
+  name: oilers firebug kit
+  parent: KitBase
+  description: A dirty close-range kit for flushing enemies out.
+  components:
+  - type: Sprite
+    state: gunner
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponShotgunSawedOff
+    - id: MagazineBox12gauge
+    - id: SmokeGrenade
+      amount: 2
+    - id: N14Flare
+      amount: 2
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_OilersPatch
+  name: oilers patch kit
+  parent: KitBase
+  description: A support kit for patching up the gang after a wreck.
+  components:
+  - type: Sprite
+    state: medic
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponPistol9mm
+    - id: N14MagazinePistol9mm
+      amount: 2
+    - id: N14Stimpak
+      amount: 2
+    - id: N14CleanGauze10
+      amount: 2
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_RoadRashRunner
+  name: road rash runner kit
+  parent: KitBase
+  description: A light kit for fresh Eighties runners.
+  components:
+  - type: Sprite
+    state: marksman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponPistol9mm
+    - id: N14MagazinePistol9mm
+      amount: 2
+    - id: N14CombatKnife
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_RoadRashScrapper
+  name: road rash scrapper kit
+  parent: KitBase
+  description: Scrap weapons for someone still earning their colors.
+  components:
+  - type: Sprite
+    state: rifleman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14BaseBallBat
+    - id: N14WeaponPistol10mmPipe
+    - id: N14MagazinePistol10mm
+      amount: 2
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    - id: N14Flare
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  id: KitEighties_RoadRashLookout
+  name: road rash lookout kit
+  parent: KitBase
+  description: Smoke, flares, and a sidearm for keeping watch.
+  components:
+  - type: Sprite
+    state: marksman
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+    - id: N14WeaponPistol9mm
+    - id: MagazineBox9mm
+    - id: N14TribalKnife
+    - id: SmokeGrenade
+    - id: N14Flare
+      amount: 2
+    - id: N14Stimpak
+    - id: N14CleanGauze10
+    sound:
+      path: /Audio/Effects/unwrap.ogg

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
@@ -51,15 +51,12 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
-    pocket1: N14WeaponRevolver44TribalUpgraded
+    pocket1: EightiesTheBlockloadoutkits
+    pocket2: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesTheBlock
@@ -111,14 +108,12 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
+    pocket1: EightiesCylindersloadoutkits
+    pocket2: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesCylinders
@@ -169,14 +164,12 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
+    pocket1: EightiesPistonsloadoutkits
+    pocket2: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesPistons
@@ -227,14 +220,12 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
+    pocket1: EightiesOilersloadoutkits
+    pocket2: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesOilers
@@ -285,14 +276,12 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
+    pocket1: EightiesRoadRashloadoutkits
+    pocket2: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesRoadRash


### PR DESCRIPTION
## About the PR

Added themed starting loadout kits for all Eighties roles and gave each Eighties role a motorbike key.

## Why / Balance

The Eighties previously spawned with mostly identical fixed gear, centered around a `.45 SMG` and spare magazines. This made the faction roles feel less distinct and did not reflect the road-gang theme well.

The new kits let each rank choose from role-appropriate options while avoiding stacking extra weapons on top of the old fixed SMG loadout. Higher ranks receive stronger command/frontline options, while lower ranks receive lighter raider-style kits.

Motorbike keys were added so Eighties members can use faction-appropriate motorbikes.

## Technical details

Updated `Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml`:
- Replaced fixed `.45 SMG` starting spawns with role-specific loadout selector kits.
- Added `VehicleKeyMotorbike` to `pocket2` for all Eighties roles.

Added `Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/eighties_rank_loadoutkits.yml`:
- Added loadout selectors for The Block, Cylinders, Pistons, Oilers, and Road Rash.
- Added 15 total Eighties kit options.

Updated `Resources/Locale/en-US/_Misfits/undecidedloadout.ftl`:
- Added names and descriptions for all new Eighties loadout kit options.

## Media

N/A, prototype data changes only.

# Changelog

:cl:
- add: Added themed starting loadout kits for all Eighties roles.
- add: Added motorbike keys to all Eighties roles.
- tweak: Replaced the Eighties' fixed starting SMG loadout with rank-specific kit selectors.