### PR TITLE
80s Kits (Alternative to Squag's Kits)

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Objects/Kits/80s_kits.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Kits/80s_kits.yml
@@ -1,0 +1,463 @@
+- type: entity
+  name: The Block Ripper kit
+  parent: KitBase
+  id: KitBlockRipper
+  description: "A pile of loot fit for a Block of the 80s."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14ripper
+      - id: N14TribalBigClubDecorated
+      - id: N14WeaponSMG12mm
+      - id: N14MagazineSMG12mm
+        amount: 2
+      - id: N14WeaponRevolver45-70Hunter
+      - id: SpeedLoader45-70
+        amount: 4
+      - id: BoxHandcuff
+      - id: N14HealingPoultice 
+      - id: N14SuperStimpak
+        amount: 2
+      - id: N14FoodTinK
+        amount: 2
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  name: The Block Steel Hunter kit
+  parent: KitBase
+  id: KitBlockHunter
+  description: "A pile of loot fit for a Block of the 80s."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14WeaponSniper50Pipe
+      - id: MagazineBox50
+        amount: 2
+      - id: N14WeaponRevolver45-70Hunter
+      - id: SpeedLoader45-70
+        amount: 4
+      - id: BoxHandcuff
+      - id: N14HealingPoultice 
+      - id: N14SuperStimpak
+        amount: 2
+      - id: N14FoodTinK
+        amount: 2
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  name: Cylinders Turbo kit
+  parent: KitBase
+  id: KitCylinderTurbo
+  description: "A collection of fitting equipment for a Cylinder."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14WeaponSMGAmerican180
+      - id: N14MagazineAmerican180Drum
+        amount: 2
+      - id: N14WeaponRevolver44TribalUpgraded
+      - id: SpeedLoader44
+        amount: 4
+      - id: N14Turbo
+        amount: 2
+      - id: N14HealingPoultice 
+      - id: N14Stimpak
+        amount: 2
+      - id: N14FoodTinK
+        amount: 2
+      - id: SmokeGrenade
+        amount: 2
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  name: Cylinders Rider kit
+  parent: KitBase
+  id: KitCylinderRider
+  description: "A collection of fitting equipment for a Cylinder."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14WeaponSMG10mm
+      - id: N14MagazineSMG10mm
+        amount: 4
+      - id: N14WeaponRevolver44TribalUpgraded
+      - id: SpeedLoader44
+        amount: 2
+      - id: N14Stimpak
+        amount: 2
+      - id: N14HealingPoultice 
+      - id: N14SuperStimpak
+      - id: N14FoodTinK
+        amount: 2
+      - id: SmokeGrenade
+        amount: 2
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  name: Pistons Slave Driver kit
+  parent: KitBase
+  id: KitPistonSlaver
+  description: "A personal supply of gear belonging to a piston."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14WeaponSMG10mm
+      - id: N14MagazineSMG10mm
+        amount: 4
+      - id: N14WeaponRevolver44TribalUpgraded
+      - id: SpeedLoader44
+        amount: 2
+      - id: N14Stimpak
+        amount: 2
+      - id: N14HealingPoultice 
+      - id: Bola
+        amount: 2
+      - id: N14FoodTinK
+        amount: 2
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  name: Pistons Skirmisher kit
+  parent: KitBase
+  id: KitPistonSkirmisher
+  description: "A personal supply of gear belonging to a piston."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14WeaponRifle556CarbineOld
+      - id: Magazine556Rifle
+        amount: 4
+      - id: N14WeaponRevolver44TribalUpgraded
+      - id: SpeedLoader44
+        amount: 2
+      - id: N14Stimpak
+        amount: 2
+      - id: N14HealingPoultice 
+      - id: SmokeGrenade
+        amount: 2
+      - id: N14FoodTinK
+        amount: 2
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  name: 80s looted equipment kit
+  parent: KitBase
+  id: Kitlooted80s
+  description: "A pitiful supply of equipment looted from others."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14WeaponShotgunLever
+      - id: MagazineBox20gauge
+        amount: 2
+      - id: N14WeaponRevolver44TribalUpgraded
+      - id: SpeedLoader44
+        amount: 2
+      - id: N14Stimpak
+        amount: 2 
+      - id: N14ShieldMetalLight
+      - id: N14FoodTinK
+        amount: 1
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  name: 80s scrapped equipment kit
+  parent: KitBase
+  id: Kitscrapped80s
+  description: "A pitiful supply of equipment made of scrap."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14WeaponSMG10mmPipe
+      - id: N14MagazineSMG10mm
+        amount: 3
+      - id: N14TribalClub
+      - id: N14WeaponPistol10mmPipe
+      - id: N14MagazinePistol10mm
+        amount: 2
+      - id: N14Stimpak
+        amount: 2 
+      - id: N14ShieldMetalLight
+      - id: N14FoodTinK
+        amount: 1
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  name: 80s brawler kit
+  parent: KitBase
+  id: Kitbrawler80s
+  description: "A pitiful pile of gear for getting in close."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: Bola
+      - id: N14TribalBigClub
+      - id: N14WeaponPistol10mmPipe
+      - id: N14MagazinePistol10mm
+        amount: 2
+      - id: N14Stimpak
+        amount: 2 
+      - id: N14Psycho
+      - id: N14Jet
+        amount: 2
+      - id: N14FoodTinK
+        amount: 1
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: entity
+  name: 80s rash kit
+  parent: KitBase
+  id: KitRash80s
+  description: "The equipment of a man who will not survive first contact."
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: Item
+    size: Huge
+  - type: SpawnItemsOnUse
+    items:
+      - id: N14ScrapMachete
+      - id: N14WeaponPistol10mmPipe
+      - id: N14MagazinePistol10mm
+        amount: 2
+      - id: N14Stimpak
+      - id: N14Jet
+      - id: N14FoodTinK
+        amount: 1
+      - id: N14JunkCeramicFlask
+    sound:
+      path: /Audio/Effects/unwrap.ogg
+
+- type: UndecidedLoadoutBackpackSet
+  id: BigBlockRipperSet
+  name: The Big Block's Ripper kit.
+  description: A pile of loot fit for the Big Block of the 80s. Comes with a ripper and SMG.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - KitBlockRipper
+
+- type: UndecidedLoadoutBackpackSet
+  id: BigBlockHunterSet
+  name: The Big Block's Steel Hunting kit.
+  description: A pile of loot fit for the Big Block of the 80s. Comes with everything needed to kill a tin can.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - KitBlockHunter
+
+- type: UndecidedLoadoutBackpackSet
+  id: CylinderTurboSet
+  name: A Cylinder's Turbo stash.
+  description: An acceptable collection of equipment fit for a cylinder. Filled with turbo and a 180 SMG.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - KitCylinderTurbo
+
+- type: UndecidedLoadoutBackpackSet
+  id: CylinderRiderSet
+  name: A Cylinder's Riding stash.
+  description: An acceptable collection of equipment fit for a cylinder. Filled with chems and guns perfect for riding.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - KitCylinderRider
+
+- type: UndecidedLoadoutBackpackSet
+  id: PistonSlaverSet
+  name: A Piston's slaving kit.
+  description: Personal gear of a piston, this one is made for capturing slaves or runaways.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - KitPistonSlaver
+
+- type: UndecidedLoadoutBackpackSet
+  id: PistonSkirmisherSet
+  name: A Piston's slaving kit.
+  description: Personal gear of a piston, this gear is made for skirmishing and picking off stragglers.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - KitPistonSkirmisher
+
+- type: UndecidedLoadoutBackpackSet
+  id: 80sLootedSet
+  name: A pile of looted gear.
+  description: A small pile of looted equipment. Comes with a lever action, shield, and handgun.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - Kitlooted80s
+
+- type: UndecidedLoadoutBackpackSet
+  id: 80sscrappedSet
+  name: A pile of cobbled together weapons.
+  description: Scrap weapons. A tribal club and metal shield may be the only reliable thing here. Comes with a scrap 10mm and scrap handgun.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - Kitscrapped80s
+
+- type: UndecidedLoadoutBackpackSet
+  id: 80sBrawlerSet
+  name: A stash of melee equipment.
+  description: A pitiful selection of melee weapons, a heavy tribal club with jet and a psycho syringe are your saving grace.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - Kitbrawler80s
+
+- type: UndecidedLoadoutBackpackSet
+  id: 80sRashSet
+  name: Gear deserving of a Rash.
+  description: Barely even qualifies. A machete and a 10mm pipe pistol with barely any chems. Good luck.
+  sprite:
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  content:
+  - KitRash80s
+
+- type: entity
+  id: BigBlockloadoutkits
+  name: kit
+  description: "Take your fill."
+  parent: LegionCenturionloadoutkits
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - BigBlockRipperSet
+    - BigBlockHunterSet
+
+- type: entity
+  id: Cylinderloadoutkits
+  name: kit
+  description: "Take your fill."
+  parent: LegionCenturionloadoutkits
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - CylinderTurboSet
+    - CylinderRiderSet
+
+- type: entity
+  id: Pistonloadoutkits
+  name: kit
+  description: "Take your Stash."
+  parent: LegionCenturionloadoutkits
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - PistonSlaverSet
+    - PistonSkirmisherSet
+
+- type: entity
+  id: Oilersloadoutkits
+  name: kit
+  description: "Take your loot."
+  parent: LegionCenturionloadoutkits
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - 80sBrawlerSet
+    - 80sLootedSet
+    - 80sscrappedSet
+
+- type: entity
+  id: Rashloadoutkits
+  name: kit
+  description: "Take your shit."
+  parent: LegionCenturionloadoutkits
+  components:
+  - type: Sprite
+    sprite: Corvax/Objects/Misc/kits.rsi
+    state: base
+  - type: UndecidedLoadoutBackpack
+    possibleSets:
+    - 80sRashSet

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
@@ -52,7 +52,8 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    pocket1: VehicleKeyMotorbike
+    suitstorage: N14WeaponSMG45
+    pocket1: N14WeaponRevolver44TribalUpgraded
     belt: ClothingBeltMilitary
   storage:
     back:

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
@@ -57,6 +57,9 @@
   storage:
     back:
     - N14BoxPlasticFilledWastelander
+    belt:
+    - Magazine45SubMachineGun
+    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesTheBlock
@@ -109,11 +112,14 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
+    suitstorage: N14WeaponSMG45
     belt: ClothingBeltMilitary
-    pocket1: VehicleKeyMotorbike
   storage:
     back:
     - N14BoxPlasticFilledWastelander
+    belt:
+    - Magazine45SubMachineGun
+    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesCylinders
@@ -165,10 +171,14 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
+    suitstorage: N14WeaponSMG45
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
+    belt:
+    - Magazine45SubMachineGun
+    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesPistons

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
@@ -52,15 +52,12 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
-    pocket1: N14WeaponRevolver44TribalUpgraded
+    pocket1: BigBlockloadoutkits
+    pocket2: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesTheBlock
@@ -113,14 +110,12 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
+    pocket1: Cylinderloadoutkits
+    pocket2: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesCylinders
@@ -172,14 +167,12 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
+    pocket1: Pistonloadoutkits
+    pocket2: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesPistons
@@ -231,14 +224,12 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
+    pocket1: Oilersloadoutkits
+    pocket2: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesOilers
@@ -290,14 +281,11 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
+    pocket1: Rashloadoutkits
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesRoadRash

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
@@ -37,6 +37,7 @@
         factions:
           - PlayerRaider
           - Wastelander
+      - type: RidingPerk
 
 - type: startingGear
   id: EightiesTheBlockGear
@@ -51,15 +52,11 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
-    pocket1: N14WeaponRevolver44TribalUpgraded
+    pocket1: VehicleKeyMotorbike
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesTheBlock
@@ -99,6 +96,7 @@
         factions:
           - PlayerRaider
           - Wastelander
+      - type: RidingPerk
 
 - type: startingGear
   id: EightiesCylindersGear
@@ -111,14 +109,11 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
     belt: ClothingBeltMilitary
+    pocket1: VehicleKeyMotorbike
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesCylinders
@@ -157,6 +152,7 @@
         factions:
           - PlayerRaider
           - Wastelander
+      - type: RidingPerk
 
 - type: startingGear
   id: EightiesPistonsGear
@@ -169,14 +165,10 @@
     head: N14ClothingHeadHatBeanie
     ears: MisfitsClothingHeadsetWastelandScrap
     back: N14ClothingBackpackMilitary
-    suitstorage: N14WeaponSMG45
     belt: ClothingBeltMilitary
   storage:
     back:
     - N14BoxPlasticFilledWastelander
-    belt:
-    - Magazine45SubMachineGun
-    - Magazine45SubMachineGun
 
 - type: playTimeTracker
   id: EightiesPistons
@@ -215,6 +207,7 @@
         factions:
           - PlayerRaider
           - Wastelander
+      - type: RidingPerk
 
 - type: startingGear
   id: EightiesOilersGear
@@ -273,6 +266,7 @@
         factions:
           - PlayerRaider
           - Wastelander
+      - type: RidingPerk
 
 - type: startingGear
   id: EightiesRoadRashGear

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/baton-club.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Melee/baton-club.yml
@@ -61,7 +61,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 23 #NOT SO BROKEN NOW LOLOLOLOL -pierow
+        Blunt: 38 #"NOT SO BROKEN NOW LOLOLOLOL -pierow" 23 damage is useless gng. -bill
   - type: Sprite
     sprite: _Nuclear14/Objects/Weapons/Melee/pipe.rsi
     state: icon


### PR DESCRIPTION
## About the PR
This is the alternative PR to squag's kits for the 80s. balancing their weapons around 1-handers and heavy melees on certain kits, with few exceptions. Several kits provide and borderline demand the use of your provided chems for their speed and increased lethality. 
Also added rider perk to the 80s dudes meant to actually ride motorcycles.
Also also gave the 80s meant to ride motorcycles roundstart keys for them in their pocket
Didn't give one to rashes though.
Also removed their 45 SMGS

## Why / Balance
This places the 80s as dangerous to wasters, but still overpowered by a full faction if they put their backbone into it. Although, a single patrol or small group could be wiped out by a full 80s raid. They are still capable and pistons/cylinders could easily take down a legionnaire or NCR enlisted in a 1v1.

## Technical details
yml, a good bit of yml.

## Media

https://github.com/user-attachments/assets/e745df9c-061e-47d4-85b8-54b61f0bf848

# Changelog

:cl: Bill
- add: Added kits to the 80s
- add: Added rider perk to several of the 80s
- add: Added keys to the pockets of the 80s meant to ride motorcyles (oilers and above)
- tweak: increased broken pipe melee damage to a whopping 38 blunt!!!!!!