### PR TITLE
No Ghostrole Cooldown for Observer/Bunkered

### DIFF
--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -544,18 +544,19 @@ namespace Content.Server.Ghost.Roles
         }
 
         // #Misfits Add - Ghost role cooldown: checks if the player must wait before accessing ghost roles.
-        // Mirrors the death-time logic in GhostReturnToRoundSystem so both timers stay in sync.
+		// Mirrors the death-time logic in GhostReturnToRoundSystem so both timers stay in sync.
+        // Only apply the cooldown to ghosts that came from an actual death. Lobby observers / bunkered / those who ghost in console
+        //  do not have a ghost role cooldown, and GhostComponent.TimeOfDeath is set when the ghost is created -pierow 🫃
         private bool IsOnGhostRoleCooldown(ICommonSession session, EntityUid ghostUid)
         {
             var cooldownMinutes = _cfg.GetCVar(CCVars.GhostRespawnTime);
             if (cooldownMinutes <= 0)
                 return false; // server has no respawn timer — no ghost role cooldown either
 
-            // Prefer mind's death time (more accurate), fall back to GhostComponent time.
-            var deathTime = EnsureComp<GhostComponent>(ghostUid).TimeOfDeath;
-            if (_mindSystem.TryGetMind(ghostUid, out _, out var mind) && mind.TimeOfDeath.HasValue)
-                deathTime = mind.TimeOfDeath.Value;
+            if (!_mindSystem.TryGetMind(ghostUid, out _, out var mind) || !mind.TimeOfDeath.HasValue)
+                return false; // lobby observer / non-death ghost — skip ghost role cooldown
 
+            var deathTime = mind.TimeOfDeath.Value;
             var timeUntilAllowed = TimeSpan.FromMinutes(cooldownMinutes);
             var timePast = _timing.CurTime - deathTime;
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->Removes Ghostrole Cooldown for Observer/Bunkered. Those who die in-game no not get the cooldown bypass.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->Godd Howard said so :godmode: 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- add: No more Ghostrole cooldown for lobby observer/bunkered! You STILL get a cooldown if you die in-game.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
