### PR TITLE
Gives C-27 Wastelander Comms

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/C27/c27.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/C27/c27.yml
@@ -150,6 +150,7 @@
   id: C27GearGeneric
   equipment:
     jumpsuit: ClothingC27Chassis
+    ears: MisfitsClothingHeadsetWastelandScrap
     id: N14ClothingNeckDogtags
 
 # NCR: chassis jumpsuit + Light NCR kit + NCR headset + NCR soldier dogtag.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Gives C-27 Wastelander their comms they were missing, specifically the MisfitsClothingHeadsetWastelandScrap

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> They forgot :godo:

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- add: Gives C-27 Wastelander the wasteland radio earpiece that they were missing.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
