### PR TITLE
NCR Citizen Loadout Tweak + Ranger Loadout Fix 

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
@@ -25,7 +25,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingEyesGlassesGoggles
@@ -49,7 +51,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingHandsGlovesNCR
@@ -73,7 +77,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingHeadHatWinterBoonie
@@ -97,7 +103,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingHeadHatWoodBoonie
@@ -121,7 +129,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingHeadHatDesertBoonie
@@ -145,7 +155,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingNeckCloakNCR
@@ -169,7 +181,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingNeckCloakGhillie
@@ -193,7 +207,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingNeckCloakNCRSnow
@@ -217,7 +233,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingNeckCloakNCRWoods
@@ -241,7 +259,9 @@
         - NCRHeavyTrooper
         - NCRCadet
 
+        - NCRRangerRecruit
         - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingMaskBrownBalaclava
@@ -272,6 +292,8 @@
         - NCRFieldRanger
         - NCRPatrolRanger
         - NCRVeteranRanger
+        - NCRCitizen
+        - NCRTrader
   items:
     - N14ClothingUniformDesertPants
 
@@ -301,6 +323,8 @@
         - NCRFieldRanger
         - NCRPatrolRanger
         - NCRVeteranRanger
+        - NCRCitizen
+        - NCRTrader
   items:
     - N14ClothingUniformDesertPantsFull
 


### PR DESCRIPTION

## About the PR
What this PR does is adds the ncr uniform pants and ncr desert pants full selectable as a loadout option as ncr citizen and trader. These items are NCR exclusive drip and drip should be shared with people who plan on playing ncr citizen. This also tweaks most of the ranger stuff so they can finally get stuff that was selectable to other rangers but now seletable by all rangers.

## Why / Balance
This shouldnt effect balance at all.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="768" height="136" alt="image" src="https://github.com/user-attachments/assets/0985f392-aafb-43b9-a1ff-123efa18b89e" />

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Oli
- tweak: uniform pants and desert pants to ncr citizen under loadout.
- tweak: All rangers are allowed to select all of the drip that was allowed by other ranks.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
