### PR TITLE
Rotations And Cloning

### DIFF
--- a/Content.IntegrationTests/Tests/_Misfits/Special/AdminCloneSpecialTest.cs
+++ b/Content.IntegrationTests/Tests/_Misfits/Special/AdminCloneSpecialTest.cs
@@ -1,0 +1,110 @@
+using Content.Client.Lobby;
+using Content.Server.GameTicking;
+using Content.Server.Preferences.Managers;
+using Content.Server.Station.Systems;
+using Content.Shared._Misfits.Special;
+using Content.Shared._Misfits.Special.Components;
+using Content.Shared.Preferences;
+using Robust.Server.Player;
+using Robust.Client.State;
+using Robust.Shared.Network;
+
+namespace Content.IntegrationTests.Tests._Misfits.Special;
+
+[TestFixture]
+[TestOf(typeof(SharedSpecialSystem))]
+public sealed class AdminCloneSpecialTest
+{
+    [Test]
+    public async Task AdminCloneBodyUsesSelectedProfileSpecial()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+        var server = pair.Server;
+        var client = pair.Client;
+
+        var clientNetManager = client.ResolveDependency<IClientNetManager>();
+        var clientStateManager = client.ResolveDependency<IStateManager>();
+        var clientPrefManager = client.ResolveDependency<IClientPreferencesManager>();
+        var serverPrefManager = server.ResolveDependency<IServerPreferencesManager>();
+        var playerManager = server.ResolveDependency<IPlayerManager>();
+        var map = await pair.CreateTestMap();
+
+        await pair.RunTicksSync(1);
+        await PoolManager.WaitUntil(client, () => clientStateManager.CurrentState is LobbyState, 600);
+
+        var userId = clientNetManager.ServerChannel!.UserId;
+        var selectedSpecial = new SpecialProfile
+        {
+            Strength = 1,
+            Perception = 2,
+            Endurance = 3,
+            Charisma = 4,
+            Intelligence = 6,
+            Agility = 10,
+            Luck = 9,
+        };
+
+        HumanoidCharacterProfile selectedProfile = default!;
+
+        await client.WaitAssertion(() =>
+        {
+            selectedProfile = HumanoidCharacterProfile.DefaultWithSpecies()
+                .WithName("Selected Special")
+                .WithSpecial(selectedSpecial);
+
+            clientPrefManager.CreateCharacter(selectedProfile);
+        });
+
+        await PoolManager.WaitUntil(
+            server,
+            () => serverPrefManager.GetPreferences(userId).Characters.Count == 2,
+            maxTicks: 60);
+
+        await client.WaitAssertion(() => clientPrefManager.SelectCharacter(1));
+
+        await PoolManager.WaitUntil(
+            server,
+            () => serverPrefManager.GetPreferences(userId).SelectedCharacterIndex == 1,
+            maxTicks: 60);
+
+        await server.WaitAssertion(() =>
+        {
+            var ticker = server.EntMan.System<GameTicker>();
+            var spawning = server.EntMan.System<StationSpawningSystem>();
+            var special = server.EntMan.System<SharedSpecialSystem>();
+            var session = playerManager.GetSessionById(userId);
+
+            var oldBody = spawning.SpawnPlayerMob(
+                map.GridCoords,
+                null,
+                HumanoidCharacterProfile.DefaultWithSpecies().WithName("Previous Body"),
+                null);
+
+            Assert.That(special.TryModifyTemporary(oldBody, SpecialStat.Strength, 3, source: "clone-test"), Is.True);
+            Assert.That(server.EntMan.GetComponent<SpecialComponent>(oldBody).TemporaryStrengthModifier, Is.EqualTo(3));
+
+            var profile = ticker.GetPlayerProfile(session);
+            Assert.That(profile.MemberwiseEquals(selectedProfile), Is.True);
+
+            var newBody = spawning.SpawnPlayerMob(map.GridCoords, null, profile, null);
+
+            Assert.That(server.EntMan.TryGetComponent<SpecialComponent>(newBody, out var newSpecial), Is.True);
+            Assert.That(newSpecial!.BaseStrength, Is.EqualTo(selectedSpecial.Strength));
+            Assert.That(newSpecial.BasePerception, Is.EqualTo(selectedSpecial.Perception));
+            Assert.That(newSpecial.BaseEndurance, Is.EqualTo(selectedSpecial.Endurance));
+            Assert.That(newSpecial.BaseCharisma, Is.EqualTo(selectedSpecial.Charisma));
+            Assert.That(newSpecial.BaseIntelligence, Is.EqualTo(selectedSpecial.Intelligence));
+            Assert.That(newSpecial.BaseAgility, Is.EqualTo(selectedSpecial.Agility));
+            Assert.That(newSpecial.BaseLuck, Is.EqualTo(selectedSpecial.Luck));
+            Assert.That(newSpecial.TemporaryStrengthModifier, Is.Zero);
+            Assert.That(newSpecial.TemporaryPerceptionModifier, Is.Zero);
+            Assert.That(newSpecial.TemporaryEnduranceModifier, Is.Zero);
+            Assert.That(newSpecial.TemporaryCharismaModifier, Is.Zero);
+            Assert.That(newSpecial.TemporaryIntelligenceModifier, Is.Zero);
+            Assert.That(newSpecial.TemporaryAgilityModifier, Is.Zero);
+            Assert.That(newSpecial.TemporaryLuckModifier, Is.Zero);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -9,6 +9,7 @@ using Content.Server.Silicon.IPC;
 using Content.Server.Spawners.EntitySystems;
 using Content.Server.Spawners.Components;
 using Content.Server.Station.Components;
+using Content.Shared._Misfits.Special;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.CCVar;
@@ -52,6 +53,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
     [Dependency] private readonly ArrivalsSystem _arrivalsSystem = default!;
     [Dependency] private readonly ContainerSpawnPointSystem _containerSpawnPointSystem = default!;
     [Dependency] private readonly CharacterRequirementsSystem _characterRequirements = default!;
+    [Dependency] private readonly SharedSpecialSystem _special = default!;
 
     private bool _randomizeCharacters;
 
@@ -164,6 +166,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
         if (profile != null)
         {
             _humanoidSystem.LoadProfile(entity.Value, profile);
+            _special.TryApplyProfileBaseValues(entity.Value, profile);
             _metaSystem.SetEntityName(entity.Value, profile.Name);
             if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
                 EnsureComp<DetailExaminableComponent>(entity.Value).Content = profile.FlavorText;

--- a/Content.Server/_Misfits/PlayerData/PersistentPlayerDataSystem.cs
+++ b/Content.Server/_Misfits/PlayerData/PersistentPlayerDataSystem.cs
@@ -81,8 +81,8 @@ public sealed class PersistentPlayerDataSystem : EntitySystem
     {
         // Ensure the persistent data component exists on the player entity
         var comp = EnsureComp<PersistentPlayerDataComponent>(args.Mob);
-        var special = EnsureComp<SpecialComponent>(args.Mob);
-        _special.TrySetBaseValues(args.Mob, args.Profile.Special, special);
+        _special.TryApplyProfileBaseValues(args.Mob, args.Profile);
+        TryComp<SpecialComponent>(args.Mob, out var special);
         SyncPersistentSpecialFromComponent(args.Mob, comp, special);
 
         // Load immediately if the player is already attached (they will be for normal spawns)

--- a/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
+++ b/Content.Shared/_Misfits/Special/SharedSpecialSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._Misfits.Special.Prototypes;
 using Content.Shared.Chemistry;
 using Content.Shared.Ghost;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Preferences;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -344,6 +345,18 @@ public sealed class SharedSpecialSystem : EntitySystem
         Dirty(uid, component);
         RaiseSpecialChanged(uid);
         return true;
+    }
+
+    /// <summary>
+    /// Ensures SPECIAL runtime state exists and copies authoritative base values from a character profile.
+    /// </summary>
+    public bool TryApplyProfileBaseValues(EntityUid uid, HumanoidCharacterProfile profile, SpecialComponent? component = null)
+    {
+        if (!UsesSpecialStats(uid))
+            return false;
+
+        component ??= EnsureComp<SpecialComponent>(uid);
+        return TrySetBaseValues(uid, profile.Special, component);
     }
 
     public bool TryModifyTemporary(

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -169,6 +169,9 @@
   parent: Grille
   name: diagonal grille
   components:
+    - type: Tag
+      tags:
+      - ForceNoFixRotations
     - type: Sprite
       drawdepth: Walls
       sprite: Structures/Walls/grille.rsi
@@ -204,6 +207,9 @@
   parent: ClockworkGrille
   name: diagonal clockwork grille
   components:
+    - type: Tag
+      tags:
+      - ForceNoFixRotations
     - type: Sprite
       drawdepth: Walls
       sprite: Structures/Walls/clockwork_grille.rsi

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -144,6 +144,9 @@
     snap:
     - Window
   components:
+  - type: Tag
+    tags:
+    - ForceNoFixRotations
   - type: Sprite
     drawdepth: WallTops
     sprite: Structures/Windows/reinforced_window_diagonal.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/access_slanted.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/access_slanted.yml
@@ -358,6 +358,9 @@
   id: N14DoorMetalSlantedLockedBrass
   suffix: Locked, IronKey
   components:
+  - type: Tag
+    tags:
+    - ForceNoFixRotations
   - type: AccessReader
     access: [["BrassKey"]]
   - type: Wires

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/slanteddoors.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Doors/slanteddoors.yml
@@ -70,6 +70,9 @@
   id: N14DoorMetalBlueAltSlanted
   name: alt blue metal door
   components:
+  - type: Tag
+    tags:
+    - ForceNoFixRotations
   - type: Sprite
     sprite: _Nuclear14/Structures/Doors/SlantedDoors/metalbluealt.rsi
     layers:
@@ -167,6 +170,9 @@
   suffix: Slanted
   description: A wooden door.
   components:
+  - type: Tag
+    tags:
+    - ForceNoFixRotations
   - type: Sprite
     sprite: _Nuclear14/Structures/Doors/SlantedDoors/wood.rsi
     layers:


### PR DESCRIPTION
## About the PR
Fixes two issues:
- Prevents selected diagonal/slanted structures from being auto-corrected by the rotation fixer.
- Fixes admin-created player bodies not receiving the selected character profile’s Misfits SPECIAL values.

## Technical details
Added `ForceNoFixRotations` tags to affected diagonal/slanted prototypes so the rotation fixer leaves their intended orientation alone:
- Diagonal grilles
- Clockwork diagonal grilles
- Reinforced diagonal windows
- Specific slanted Nuclear14 doors

Added `SharedSpecialSystem.TryApplyProfileBaseValues`, which ensures a valid `SpecialComponent` exists and copies base values from `HumanoidCharacterProfile.Special` through `TrySetBaseValues`.

Updated `StationSpawningSystem.SpawnPlayerMob` to apply profile SPECIAL values when spawning humanoid bodies. This covers admin Spawn/Clone verbs, which create bodies directly and bypass `PlayerSpawnCompleteEvent`.

Updated `PersistentPlayerDataSystem` to reuse the same helper for normal player spawns.

Added an integration regression test for admin clone SPECIAL behavior, including verification that temporary modifiers from the old body are not copied.

# Changelog

:cl:
- fix: Fixed some diagonal and slanted structures having their intended rotations corrected incorrectly.
- fix: Fixed admin-spawned/cloned player bodies not receiving the selected character profile's SPECIAL values.