### PR TITLE
Adds Lighters to Cigarette Pack WL

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -41,6 +41,9 @@
       visible: false
       shader: unshaded
       map: [ "flame" ]
+  - type: Tag
+    tags:
+    - Lighter
   - type: Appearance
   - type: RandomSprite
     available:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Smokeables/packs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Smokeables/packs.yml
@@ -61,6 +61,10 @@
   - type: Storage
     grid:
     - 0,0,4,1
+    whitelist:
+      tags:
+      - Cigarette
+      - Lighter
   - type: StorageFill
     contents:
     - id: Cigarette

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Smokeables/packs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Consumable/Smokeables/packs.yml
@@ -61,9 +61,6 @@
   - type: Storage
     grid:
     - 0,0,4,1
-    whitelist:
-      tags:
-      - Cigarette
   - type: StorageFill
     contents:
     - id: Cigarette
@@ -91,7 +88,7 @@
   # id: N14CigarettePack
   # name: cigarette packet
   # description: A generic pack of cigarettes.
-  
+
 - type: entity
   parent: N14CigPackBase
   id: N14CigarettePackSalem
@@ -106,7 +103,7 @@
     contents:
     - id: N14CigaretteSalem
       amount: 8
-    
+
 - type: entity
   parent: N14CigPackBase
   id: N14CigarettePackKool
@@ -121,7 +118,7 @@
     contents:
     - id: N14CigaretteKool
       amount: 8
-    
+
 - type: entity
   parent: N14CigPackBase
   id: N14CigarettePackMarlboro
@@ -136,7 +133,7 @@
     contents:
     - id: N14CigaretteMarlboro
       amount: 8
-    
+
 - type: entity
   parent: N14CigPackBase
   id: N14CigarettePackWinston
@@ -151,7 +148,7 @@
     contents:
     - id: N14CigaretteWinston
       amount: 8
-    
+
 - type: entity
   parent: N14CigPackBase
   id: N14CigarettePackCustom
@@ -167,7 +164,7 @@
     contents:
     - id: N14CigaretteRollie
       amount: 8
-    
+
 - type: entity
   parent: N14CigPackBase
   id: N14CigarettePackRepublics

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -853,6 +853,9 @@
   id: Lemon
 
 - type: Tag
+  id: Lighter
+
+- type: Tag
   id: Lime
 
 - type: Tag


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Cigarette packs had a very strict whitelist for no reason. Now people can store other tiny items like their lighter in cigarette packs. Rejoice.

## Why / Balance
Classic space station trick was impossible, now it's possible.

## Technical details
grug smash whitelist with rock

## Media
<img width="687" height="798" alt="image" src="https://github.com/user-attachments/assets/429955eb-7700-4eb2-bed4-0057ab2eebd2" />


# Changelog

:cl:
- tweak: Removed Cigarette pack whitelist. Store your lighters freely in your packs once more.

