### PR TITLE
80s Kit Changes, Bullet Changes, Plasma Weapon Nerfs

### DIFF
--- a/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
@@ -780,15 +780,15 @@ undecided-loadout-category-misfits-priestess-order-desc =
 
 undecided-loadout-category-misfits-eighties-block-road-captain-name = Road Captain Kit
 undecided-loadout-category-misfits-eighties-block-road-captain-description =
-    Includes a .45 SMG with 4 magazines, an upgraded .44 revolver
-    with 2 speedloaders, a radio, 2 smoke grenades, Psycho,
-    a stimpak, gauze, and a flare.
+    A kit filled with everything a block needs to rip them apart.
+    Comes with a 12.7 SMG, a ripper, and some meds with various other 
+    looted equipment. 
 
 undecided-loadout-category-misfits-eighties-block-boss-brawler-name = Boss Brawler Kit
 undecided-loadout-category-misfits-eighties-block-boss-brawler-description =
-    Includes a sledgehammer, a .45 pistol with 4 magazines,
-    a frag grenade, a smoke grenade, Psycho, a stimpak,
-    gauze, and a flare.
+    A homemade stash filled with what the block needs to brawl with armor.
+    Comes with a .50 pipe, a 45-70 hunter, and some assorted meds and food.
+    A smoke and a frag are included.
 
 undecided-loadout-category-misfits-eighties-block-lead-foot-name = Lead Foot Kit
 undecided-loadout-category-misfits-eighties-block-lead-foot-description =
@@ -797,13 +797,15 @@ undecided-loadout-category-misfits-eighties-block-lead-foot-description =
 
 undecided-loadout-category-misfits-eighties-cylinders-tommy-name = Cylinders Tommy Kit
 undecided-loadout-category-misfits-eighties-cylinders-tommy-description =
-    Includes a .45 SMG with 3 magazines, a combat knife,
-    a smoke grenade, a stimpak, gauze, and a flare.
+    Everything a cylinder would need to kill from his bike, and on foot.
+    Comes with an american 180, some turbo, some meds, some food.
+    Two smoke grenades included.
 
 undecided-loadout-category-misfits-eighties-cylinders-shotcaller-name = Cylinders Shotcaller Kit
 undecided-loadout-category-misfits-eighties-cylinders-shotcaller-description =
-    Includes an upgraded .44 revolver with 3 speedloaders,
-    a radio, 2 smoke grenades, Psycho, a stimpak, gauze, and a flare.
+    A looted stash with extra meds for a cylinder, including a super stim.
+    Comes with a 10mm, a 44 revolver, some smoke grenades, the extra meds,
+    and gauze.
 
 undecided-loadout-category-misfits-eighties-cylinders-road-marshal-name = Cylinders Road Marshal Kit
 undecided-loadout-category-misfits-eighties-cylinders-road-marshal-description =
@@ -812,13 +814,15 @@ undecided-loadout-category-misfits-eighties-cylinders-road-marshal-description =
 
 undecided-loadout-category-misfits-eighties-pistons-skirmisher-name = Pistons Skirmisher Kit
 undecided-loadout-category-misfits-eighties-pistons-skirmisher-description =
-    Includes a pipe 10mm SMG with 3 magazines, a combat knife,
-    a stimpak, gauze, and a flare.
+    A small pile of gear for a piston to beat the wasties with.
+    Comes with a 10mm SMG, some assorted meds, a tribal club, 
+    a light shield, spare 44 revolver, and bolas for capturing.
 
 undecided-loadout-category-misfits-eighties-pistons-scattergun-name = Pistons Scattergun Kit
 undecided-loadout-category-misfits-eighties-pistons-scattergun-description =
-    Includes a pump shotgun, a box of 12 gauge shells,
-    a hatchet, a stimpak, gauze, and a flare.
+    A kit meant to spray down enemies of the 80s from afar.
+    Comes with an old carbine, a 44 revolver, some meds, some smokes,
+    and a lot of extra ammo.
 
 undecided-loadout-category-misfits-eighties-pistons-blade-name = Pistons Blade Kit
 undecided-loadout-category-misfits-eighties-pistons-blade-description =
@@ -827,18 +831,20 @@ undecided-loadout-category-misfits-eighties-pistons-blade-description =
 
 undecided-loadout-category-misfits-eighties-oilers-mechanic-name = Oilers Mechanic Kit
 undecided-loadout-category-misfits-eighties-oilers-mechanic-description =
-    Includes a filled mechanical toolbox, a pipe 10mm pistol
-    with 3 magazines, 2 flares, a stimpak, and gauze.
+    A supply of looted gear and a filled toolbox. Worth more than you.
+    Comes with a lever action 20g, a 44, some meds, some food,
+    and a shield.
 
 undecided-loadout-category-misfits-eighties-oilers-firebug-name = Oilers Firebug Kit
 undecided-loadout-category-misfits-eighties-oilers-firebug-description =
-    Includes a sawed-off shotgun, a box of 12 gauge shells,
-    2 smoke grenades, 2 flares, a stimpak, and gauze.
-
+    Everything a trusted oiler needs to cave a skull and bash a tin.
+    Comes with a precious psycho syringe, two puffs of jet, a heavy
+    club, some meds, and a 10mm for the black-top.
+ 
 undecided-loadout-category-misfits-eighties-oilers-patch-name = Oilers Patch Kit
 undecided-loadout-category-misfits-eighties-oilers-patch-description =
-    Includes a 9mm pistol with 2 magazines, 2 stimpaks,
-    2 gauze packs, and a flare.
+    Scrap SMG, scrap pistol, scrap shield, the only thing that isn't 
+    scrap is the tribal club and the meds included. Good luck.
 
 undecided-loadout-category-misfits-eighties-road-rash-runner-name = Road Rash Runner Kit
 undecided-loadout-category-misfits-eighties-road-rash-runner-description =
@@ -847,10 +853,12 @@ undecided-loadout-category-misfits-eighties-road-rash-runner-description =
 
 undecided-loadout-category-misfits-eighties-road-rash-scrapper-name = Road Rash Scrapper Kit
 undecided-loadout-category-misfits-eighties-road-rash-scrapper-description =
-    Includes a baseball bat, a pipe 10mm pistol with 2 magazines,
-    a stimpak, gauze, and a flare.
+    Equipment for a man that likely won't survive first contact. 
+    Scrap machete, a 10mm scrap shooter, shit meds, the only thing
+    to save you is the two puffs of jet you get.
 
 undecided-loadout-category-misfits-eighties-road-rash-lookout-name = Road Rash Lookout Kit
 undecided-loadout-category-misfits-eighties-road-rash-lookout-description =
+    A simple mans loot stash. Barely worth more than a couple caps.
     Includes a 9mm pistol, a box of 9mm ammo, a tribal knife,
-    a smoke grenade, 2 flares, a stimpak, and gauze.
+    a smoke grenade, 2 flares, a stimpak, and gauze. Good for looting.

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/eighties_rank_loadoutkits.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/eighties_rank_loadoutkits.yml
@@ -12,7 +12,7 @@
     possibleSets:
     - Eighties_BlockRoadCaptainSet
     - Eighties_BlockBossBrawlerSet
-    - Eighties_BlockLeadFootSet
+#    - Eighties_BlockLeadFootSet
 
 - type: entity
   id: EightiesCylindersloadoutkits
@@ -26,7 +26,7 @@
     possibleSets:
     - Eighties_CylindersTommySet
     - Eighties_CylindersShotcallerSet
-    - Eighties_CylindersRoadMarshalSet
+#    - Eighties_CylindersRoadMarshalSet
 
 - type: entity
   id: EightiesPistonsloadoutkits
@@ -40,7 +40,7 @@
     possibleSets:
     - Eighties_PistonsSkirmisherSet
     - Eighties_PistonsScattergunSet
-    - Eighties_PistonsBladeSet
+#    - Eighties_PistonsBladeSet
 
 - type: entity
   id: EightiesOilersloadoutkits
@@ -90,15 +90,15 @@
   content:
   - KitEighties_BlockBossBrawler
 
-- type: UndecidedLoadoutBackpackSet
-  id: Eighties_BlockLeadFootSet
-  name: undecided-loadout-category-misfits-eighties-block-lead-foot-name
-  description: undecided-loadout-category-misfits-eighties-block-lead-foot-description
-  sprite:
-    sprite: _Nuclear14/Objects/Misc/kits.rsi
-    state: marksman
-  content:
-  - KitEighties_BlockLeadFoot
+#- type: UndecidedLoadoutBackpackSet
+#  id: Eighties_BlockLeadFootSet
+#  name: undecided-loadout-category-misfits-eighties-block-lead-foot-name
+#  description: undecided-loadout-category-misfits-eighties-block-lead-foot-description
+#  sprite:
+#    sprite: _Nuclear14/Objects/Misc/kits.rsi
+#    state: marksman
+#  content:
+#  - KitEighties_BlockLeadFoot
 
 - type: UndecidedLoadoutBackpackSet
   id: Eighties_CylindersTommySet
@@ -120,15 +120,15 @@
   content:
   - KitEighties_CylindersShotcaller
 
-- type: UndecidedLoadoutBackpackSet
-  id: Eighties_CylindersRoadMarshalSet
-  name: undecided-loadout-category-misfits-eighties-cylinders-road-marshal-name
-  description: undecided-loadout-category-misfits-eighties-cylinders-road-marshal-description
-  sprite:
-    sprite: _Nuclear14/Objects/Misc/kits.rsi
-    state: marksman
-  content:
-  - KitEighties_CylindersRoadMarshal
+#- type: UndecidedLoadoutBackpackSet
+#  id: Eighties_CylindersRoadMarshalSet
+#  name: undecided-loadout-category-misfits-eighties-cylinders-road-marshal-name
+#  description: undecided-loadout-category-misfits-eighties-cylinders-road-marshal-description
+#  sprite:
+#    sprite: _Nuclear14/Objects/Misc/kits.rsi
+#    state: marksman
+#  content:
+#  - KitEighties_CylindersRoadMarshal
 
 - type: UndecidedLoadoutBackpackSet
   id: Eighties_PistonsSkirmisherSet
@@ -150,15 +150,15 @@
   content:
   - KitEighties_PistonsScattergun
 
-- type: UndecidedLoadoutBackpackSet
-  id: Eighties_PistonsBladeSet
-  name: undecided-loadout-category-misfits-eighties-pistons-blade-name
-  description: undecided-loadout-category-misfits-eighties-pistons-blade-description
-  sprite:
-    sprite: _Nuclear14/Objects/Misc/kits.rsi
-    state: marksman
-  content:
-  - KitEighties_PistonsBlade
+#- type: UndecidedLoadoutBackpackSet
+#  id: Eighties_PistonsBladeSet
+#  name: undecided-loadout-category-misfits-eighties-pistons-blade-name
+#  description: undecided-loadout-category-misfits-eighties-pistons-blade-description
+#  sprite:
+#    sprite: _Nuclear14/Objects/Misc/kits.rsi
+#    state: marksman
+#  content:
+#  - KitEighties_PistonsBlade
 
 - type: UndecidedLoadoutBackpackSet
   id: Eighties_OilersMechanicSet
@@ -232,19 +232,22 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-    - id: N14WeaponSMG45
-    - id: Magazine45SubMachineGun
+    - id: N14ripper
+    - id: N14WeaponSMG12mm
+    - id: N14MagazineSMG12mm
+      amount: 2
+    - id: N14WeaponRevolver45-70Hunter
+    - id: SpeedLoader45-70
       amount: 4
-    - id: N14WeaponRevolver44TribalUpgraded
-    - id: SpeedLoader44
+    - id: BoxHandcuff
+    - id: N14HealingPoultice 
+    - id: N14SuperStimpak
       amount: 2
-    - id: RadioHandheld
-    - id: SmokeGrenade
-      amount: 2
-    - id: N14Psycho
-    - id: N14Stimpak
     - id: N14CleanGauze10
-    - id: N14Flare
+    - id: N14FoodTinK
+      amount: 2
+    - id: N14JunkCeramicFlask
+    - id: SmokeGrenade
     sound:
       path: /Audio/Effects/unwrap.ogg
 
@@ -260,49 +263,57 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-    - id: N14SledgeHammer
-    - id: N14WeaponPistol45Colt
-    - id: N14MagazinePistol45
+    - id: N14WeaponSniper50Pipe
+    - id: MagazineBox50
+      amount: 2
+    - id: N14TribalBigClubDecorated
+    - id: N14WeaponRevolver45-70Hunter
+    - id: SpeedLoader45-70
       amount: 4
-    - id: GrenadeFrag
-    - id: SmokeGrenade
-    - id: N14Psycho
-    - id: N14Stimpak
+    - id: BoxHandcuff
+    - id: N14HealingPoultice 
+    - id: N14SuperStimpak
+      amount: 2
     - id: N14CleanGauze10
-    - id: N14Flare
+    - id: N14FoodTinK
+      amount: 2
+    - id: N14JunkCeramicFlask
+    - id: SmokeGrenade
+    - id: GrenadeFrag
     sound:
       path: /Audio/Effects/unwrap.ogg
 
-- type: entity
-  id: KitEighties_BlockLeadFoot
-  name: lead foot kit
-  parent: KitBase
-  description: A fast-response kit for running down trouble.
-  components:
-  - type: Sprite
-    state: marksman
-  - type: Item
-    size: Huge
-  - type: SpawnItemsOnUse
-    items:
-    - id: N14WeaponSMG10mm
-    - id: N14MagazineSMG10mm
-      amount: 4
-    - id: N14CombatKnife
-    - id: RadioHandheld
-    - id: SmokeGrenade
-    - id: N14Psycho
-    - id: N14Stimpak
-    - id: N14CleanGauze10
-    - id: N14Flare
-    sound:
-      path: /Audio/Effects/unwrap.ogg
+# Commented out since it would require a balance pass that I don't have the time for rn. If someone else is willing to do so feel free.
+#- type: entity
+#  id: KitEighties_BlockLeadFoot
+#  name: lead foot kit
+#  parent: KitBase
+#  description: A fast-response kit for running down trouble.
+#  components:
+#  - type: Sprite
+#    state: marksman
+#  - type: Item
+#    size: Huge
+#  - type: SpawnItemsOnUse
+#    items:
+#    - id: N14WeaponSMG10mm
+#    - id: N14MagazineSMG10mm
+#      amount: 4
+#    - id: N14CombatKnife
+#    - id: RadioHandheld
+#    - id: SmokeGrenade
+#    - id: N14Psycho
+#    - id: N14Stimpak
+#    - id: N14CleanGauze10
+#    - id: N14Flare
+#    sound:
+#      path: /Audio/Effects/unwrap.ogg
 
 - type: entity
   id: KitEighties_CylindersTommy
   name: cylinders tommy kit
   parent: KitBase
-  description: A loud officer kit built around a .45 SMG.
+  description: A loud cylinder kit built around an american 180.
   components:
   - type: Sprite
     state: rifleman
@@ -310,14 +321,23 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-    - id: N14WeaponSMG45
-    - id: Magazine45SubMachineGun
-      amount: 3
-    - id: N14CombatKnife
-    - id: SmokeGrenade
+    - id: N14WeaponSMGAmerican180
+    - id: N14MagazineAmerican180Drum
+      amount: 2
+    - id: N14WeaponRevolver44TribalUpgraded
+    - id: SpeedLoader44
+      amount: 4
+    - id: N14Turbo
+      amount: 2
+    - id: N14HealingPoultice 
     - id: N14Stimpak
+      amount: 2
     - id: N14CleanGauze10
-    - id: N14Flare
+    - id: N14FoodTinK
+      amount: 2
+    - id: SmokeGrenade
+      amount: 2
+    - id: N14JunkCeramicFlask
     sound:
       path: /Audio/Effects/unwrap.ogg
 
@@ -325,7 +345,7 @@
   id: KitEighties_CylindersShotcaller
   name: cylinders shotcaller kit
   parent: KitBase
-  description: A sidearm and command kit for an Eighties officer.
+  description: A looted stash with extra meds, fit for a cylinder.
   components:
   - type: Sprite
     state: pointman
@@ -333,47 +353,55 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
+    - id: N14WeaponSMG10mm
+    - id: N14MagazineSMG10mm
+      amount: 4
+    - id: N14TribalClub
     - id: N14WeaponRevolver44TribalUpgraded
     - id: SpeedLoader44
-      amount: 3
-    - id: RadioHandheld
+      amount: 2
+    - id: N14Stimpak
+      amount: 2
+    - id: N14HealingPoultice 
+    - id: N14SuperStimpak
+    - id: N14CleanGauze10
+    - id: N14FoodTinK
+      amount: 2
     - id: SmokeGrenade
       amount: 2
-    - id: N14Psycho
-    - id: N14Stimpak
-    - id: N14CleanGauze10
-    - id: N14Flare
+    - id: N14JunkCeramicFlask
     sound:
       path: /Audio/Effects/unwrap.ogg
 
-- type: entity
-  id: KitEighties_CylindersRoadMarshal
-  name: cylinders road marshal kit
-  parent: KitBase
-  description: A mobile patrol kit for keeping the road locked down.
-  components:
-  - type: Sprite
-    state: marksman
-  - type: Item
-    size: Huge
-  - type: SpawnItemsOnUse
-    items:
-    - id: N14WeaponSMG10mm
-    - id: N14MagazineSMG10mm
-      amount: 3
-    - id: N14Hatchet
-    - id: SmokeGrenade
-    - id: N14Stimpak
-    - id: N14CleanGauze10
-    - id: N14Flare
-    sound:
-      path: /Audio/Effects/unwrap.ogg
+# Commented out since it would require a balance pass that I don't have the time for rn. If someone else is willing to do so feel free.
+#- type: entity
+#  id: KitEighties_CylindersRoadMarshal
+#  name: cylinders road marshal kit
+#  parent: KitBase
+#  description: A mobile patrol kit for keeping the road locked down.
+#  components:
+#  - type: Sprite
+#    state: marksman
+#  - type: Item
+#    size: Huge
+#  - type: SpawnItemsOnUse
+#    items:
+#    - id: N14WeaponSMG10mm
+#    - id: N14MagazineSMG10mm
+#      amount: 3
+#    - id: N14Hatchet
+#    - id: SmokeGrenade
+#    - id: N14Stimpak
+#    - id: N14CleanGauze10
+#    - id: N14Flare
+#    sound:
+#      path: /Audio/Effects/unwrap.ogg
 
 - type: entity
   id: KitEighties_PistonsSkirmisher
   name: pistons skirmisher kit
   parent: KitBase
-  description: A mid-rank road fighter kit with a 10mm SMG.
+  description: A piston's road pounder kit with a 10mm SMG.
   components:
   - type: Sprite
     state: rifleman
@@ -381,13 +409,23 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-    - id: N14WeaponSMG10mmPipe
+    - id: N14WeaponSMG10mm
     - id: N14MagazineSMG10mm
-      amount: 3
-    - id: N14CombatKnife
+      amount: 4
+    - id: N14WeaponRevolver44TribalUpgraded
+    - id: SpeedLoader44
+      amount: 2
     - id: N14Stimpak
-    - id: N14CleanGauze10
-    - id: N14Flare
+      amount: 2
+    - id: N14HealingPoultice
+    - id: N14CleanGauze10 
+    - id: N14TribalClub
+    - id: N14ShieldMetalLight
+    - id: Bola
+      amount: 2
+    - id: N14FoodTinK
+      amount: 2
+    - id: N14JunkCeramicFlask
     sound:
       path: /Audio/Effects/unwrap.ogg
 
@@ -395,7 +433,7 @@
   id: KitEighties_PistonsScattergun
   name: pistons scattergun kit
   parent: KitBase
-  description: A close-range kit for hard pushes and dirty corners.
+  description: A kit made for spraying down the enemy from afar.
   components:
   - type: Sprite
     state: gunner
@@ -403,43 +441,53 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-    - id: N14WeaponShotgun
-    - id: MagazineBox12gauge
-    - id: N14Hatchet
+    - id: N14WeaponRifle556CarbineOld
+    - id: Magazine556Rifle
+      amount: 5
+    - id: N14WeaponRevolver44TribalUpgraded
+    - id: SpeedLoader44
+      amount: 3
     - id: N14Stimpak
-    - id: N14CleanGauze10
-    - id: N14Flare
+      amount: 2
+    - id: N14HealingPoultice 
+    - id: N14CleanGauze10 
+    - id: SmokeGrenade
+      amount: 2
+    - id: N14FoodTinK
+      amount: 2
+    - id: N14JunkCeramicFlask
     sound:
       path: /Audio/Effects/unwrap.ogg
 
-- type: entity
-  id: KitEighties_PistonsBlade
-  name: pistons blade kit
-  parent: KitBase
-  description: A melee-forward kit with a pistol backup.
-  components:
-  - type: Sprite
-    state: marksman
-  - type: Item
-    size: Huge
-  - type: SpawnItemsOnUse
-    items:
-    - id: N14Machete
-    - id: N14WeaponPistol9mm
-    - id: N14MagazinePistol9mm
-      amount: 3
-    - id: N14Psycho
-    - id: N14Stimpak
-    - id: N14CleanGauze10
-    - id: N14Flare
-    sound:
-      path: /Audio/Effects/unwrap.ogg
+# Commented out since it would require a balance pass that I don't have the time for rn. If someone else is willing to do so feel free.
+#- type: entity
+#  id: KitEighties_PistonsBlade
+#  name: pistons blade kit
+#  parent: KitBase
+#  description: A melee-forward kit with a pistol backup.
+#  components:
+#  - type: Sprite
+#    state: marksman
+#  - type: Item
+#    size: Huge
+#  - type: SpawnItemsOnUse
+#    items:
+#    - id: N14Machete
+#    - id: N14WeaponPistol9mm
+#    - id: N14MagazinePistol9mm
+#      amount: 3
+#    - id: N14Psycho
+#    - id: N14Stimpak
+#    - id: N14CleanGauze10
+#    - id: N14Flare
+#    sound:
+#      path: /Audio/Effects/unwrap.ogg
 
 - type: entity
   id: KitEighties_OilersMechanic
   name: oilers mechanic kit
   parent: KitBase
-  description: Tools, a pipe gun, and road-side supplies for an Oiler.
+  description: A pitiful supply of equipment, looted from the wastes.
   components:
   - type: Sprite
     state: pointman
@@ -448,12 +496,18 @@
   - type: SpawnItemsOnUse
     items:
     - id: ToolboxMechanicalFilled
-    - id: N14WeaponPistol10mmPipe
-    - id: N14MagazinePistol10mm
-      amount: 3
-    - id: N14Flare
+    - id: N14WeaponShotgunLever
+    - id: MagazineBox20gauge
+      amount: 2
+    - id: N14WeaponRevolver44TribalUpgraded
+    - id: SpeedLoader44
       amount: 2
     - id: N14Stimpak
+      amount: 2 
+    - id: N14ShieldMetalLight
+    - id: N14FoodTinK
+      amount: 1
+    - id: N14JunkCeramicFlask
     - id: N14CleanGauze10
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -462,7 +516,7 @@
   id: KitEighties_OilersFirebug
   name: oilers firebug kit
   parent: KitBase
-  description: A dirty close-range kit for flushing enemies out.
+  description: A dirty close-range kit for flushing enemies out and caving skulls.
   components:
   - type: Sprite
     state: gunner
@@ -470,13 +524,19 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-    - id: N14WeaponShotgunSawedOff
-    - id: MagazineBox12gauge
-    - id: SmokeGrenade
-      amount: 2
-    - id: N14Flare
+    - id: Bola
+    - id: N14TribalBigClub
+    - id: N14WeaponPistol10mmPipe
+    - id: N14MagazinePistol10mm
       amount: 2
     - id: N14Stimpak
+      amount: 2 
+    - id: N14Psycho
+    - id: N14Jet
+      amount: 2
+    - id: N14FoodTinK
+      amount: 1
+    - id: N14JunkCeramicFlask
     - id: N14CleanGauze10
     sound:
       path: /Audio/Effects/unwrap.ogg
@@ -485,7 +545,7 @@
   id: KitEighties_OilersPatch
   name: oilers patch kit
   parent: KitBase
-  description: A support kit for patching up the gang after a wreck.
+  description: A patchwork of scrapguns and basic equipment. Pitiful.
   components:
   - type: Sprite
     state: medic
@@ -493,44 +553,50 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-    - id: N14WeaponPistol9mm
-    - id: N14MagazinePistol9mm
+    - id: N14WeaponSMG10mmPipe
+    - id: N14MagazineSMG10mm
+      amount: 3
+    - id: N14TribalClub
+    - id: N14WeaponPistol10mmPipe
+    - id: N14MagazinePistol10mm
       amount: 2
     - id: N14Stimpak
-      amount: 2
+      amount: 2 
+    - id: N14ShieldMetalLight
+    - id: N14FoodTinK
+      amount: 1
+    - id: N14JunkCeramicFlask
     - id: N14CleanGauze10
-      amount: 2
-    - id: N14Flare
     sound:
       path: /Audio/Effects/unwrap.ogg
 
-- type: entity
-  id: KitEighties_RoadRashRunner
-  name: road rash runner kit
-  parent: KitBase
-  description: A light kit for fresh Eighties runners.
-  components:
-  - type: Sprite
-    state: marksman
-  - type: Item
-    size: Huge
-  - type: SpawnItemsOnUse
-    items:
-    - id: N14WeaponPistol9mm
-    - id: N14MagazinePistol9mm
-      amount: 2
-    - id: N14CombatKnife
-    - id: N14Stimpak
-    - id: N14CleanGauze10
-    - id: N14Flare
-    sound:
-      path: /Audio/Effects/unwrap.ogg
+#- type: entity
+#  id: KitEighties_RoadRashRunner
+#  name: road rash runner kit
+#  parent: KitBase
+#  description: A light kit for fresh Eighties runners.
+#  components:
+#  - type: Sprite
+#    state: marksman
+#  - type: Item
+#    size: Huge
+#  - type: SpawnItemsOnUse
+#    items:
+#    - id: N14WeaponPistol9mm
+#    - id: N14MagazinePistol9mm
+#      amount: 2
+#    - id: N14CombatKnife
+#    - id: N14Stimpak
+#    - id: N14CleanGauze10
+#    - id: N14Flare
+#    sound:
+#      path: /Audio/Effects/unwrap.ogg
 
 - type: entity
   id: KitEighties_RoadRashScrapper
   name: road rash scrapper kit
   parent: KitBase
-  description: Scrap weapons for someone still earning their colors.
+  description: Scrap weapons for someone who isn't expected to survive.
   components:
   - type: Sprite
     state: rifleman
@@ -538,13 +604,17 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-    - id: N14BaseBallBat
+    - id: N14ScrapMachete
     - id: N14WeaponPistol10mmPipe
     - id: N14MagazinePistol10mm
       amount: 2
     - id: N14Stimpak
+    - id: N14Jet
+      amount: 2
+    - id: N14FoodTinK
+      amount: 1
+    - id: N14JunkCeramicFlask
     - id: N14CleanGauze10
-    - id: N14Flare
     sound:
       path: /Audio/Effects/unwrap.ogg
 

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/eighties_rank_loadoutkits.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/eighties_rank_loadoutkits.yml
@@ -66,7 +66,7 @@
     state: marksman
   - type: UndecidedLoadoutBackpack
     possibleSets:
-    - Eighties_RoadRashRunnerSet
+#    - Eighties_RoadRashRunnerSet
     - Eighties_RoadRashScrapperSet
     - Eighties_RoadRashLookoutSet
 
@@ -190,15 +190,15 @@
   content:
   - KitEighties_OilersPatch
 
-- type: UndecidedLoadoutBackpackSet
-  id: Eighties_RoadRashRunnerSet
-  name: undecided-loadout-category-misfits-eighties-road-rash-runner-name
-  description: undecided-loadout-category-misfits-eighties-road-rash-runner-description
-  sprite:
-    sprite: _Nuclear14/Objects/Misc/kits.rsi
-    state: marksman
-  content:
-  - KitEighties_RoadRashRunner
+#- type: UndecidedLoadoutBackpackSet
+#  id: Eighties_RoadRashRunnerSet
+#  name: undecided-loadout-category-misfits-eighties-road-rash-runner-name
+#  description: undecided-loadout-category-misfits-eighties-road-rash-runner-description
+#  sprite:
+#    sprite: _Nuclear14/Objects/Misc/kits.rsi
+#    state: marksman
+#  content:
+#  - KitEighties_RoadRashRunner
 
 - type: UndecidedLoadoutBackpackSet
   id: Eighties_RoadRashScrapperSet

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/22lr.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/22lr.yml
@@ -11,9 +11,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 8
+        Piercing: 10
   # Misfits Add - .22 LR is a small rimfire round; loses energy quickly at range
   - type: BallisticDamageFalloff
-    falloffStartTiles: 3.0
-    maxFalloffTiles: 9.0
-    minDamageMultiplier: 0.35
+    falloffStartTiles: 5.0
+    maxFalloffTiles: 10.0
+    minDamageMultiplier: 0.45

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/5.56.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 21
+        Piercing: 20
   # Misfits Add - 5.56mm intermediate rifle round; good range retention
   - type: BallisticDamageFalloff
     falloffStartTiles: 9.0

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/7.62.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 23
+        Piercing: 24
   # Misfits Add - 7.62mm full-power military rifle; excellent range retention
   - type: BallisticDamageFalloff
     falloffStartTiles: 10.0

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -204,7 +204,7 @@
   - type: Gun
     soundGunshot:
       collection: N14PlasmaPistolGunshot
-    fireRate: 1.5
+    fireRate: 1
   - type: FollowDistance
     backStrength: 6
   - type: StaticPrice
@@ -245,7 +245,7 @@
   - type: Gun
     soundGunshot:
       collection: N14PlasmaDefenderGunshot
-    fireRate: 2.5
+    fireRate: 1.5
   - type: FollowDistance
     backStrength: 6
   - type: StaticPrice
@@ -765,8 +765,8 @@
   components:
   - type: Wieldable
   - type: GunWieldBonus
-    minAngle: -24
-    maxAngle: -58
+    minAngle: -23
+    maxAngle: -53
   - type: Sprite
     scale: 0.8, 0.8
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/plasma_rifle_icon.rsi
@@ -819,7 +819,7 @@
   - type: Wieldable
   - type: GunWieldBonus
     minAngle: -23
-    maxAngle: -56
+    maxAngle: -50
   - type: Sprite
     scale: 0.8, 0.8
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/plasma_rifle_crude_icon.rsi
@@ -865,8 +865,8 @@
   components:
   - type: Wieldable
   - type: GunWieldBonus
-    minAngle: -23
-    maxAngle: -55
+    minAngle: -21
+    maxAngle: -53
   - type: Sprite
     scale: 0.8, 0.8
     sprite: _Nuclear14/Objects/Weapons/Guns/Battery/plasma_urban_icon.rsi
@@ -899,7 +899,7 @@
     steps: 3
     zeroVisible: true
   - type: Gun
-    fireRate: 3
+    fireRate: 2.5
     soundGunshot:
       collection: N14PlasmaAutoRifleGunshot
     selectedMode: SemiAuto
@@ -951,7 +951,7 @@
     steps: 5
     zeroVisible: true
   - type: Gun
-    fireRate: 2 # #Misfits Tweak - reduced from 6; shotgun pacing (1 spread burst per 0.5s)
+    fireRate: 1 # #Misfits Tweak - reduced from 6; shotgun pacing (1 spread burst per 0.5s) THIS THING EATS PEOPLE ALIVE
     soundGunshot:
       collection: N14MultiplasGunshot
     selectedMode: SemiAuto # #Misfits Fix - was Burst; Multiplas fires multiple bolts simultaneously like a shotgun

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -518,7 +518,7 @@
   - type: Item
     sprite: _Nuclear14/Objects/Weapons/Guns/Pistols/deserteagle.rsi
   - type: Gun
-    fireRate: 3
+    fireRate: 2.5
     soundGunshot:
       collection: N14PistolDesertEagleGunshot
   - type: ItemSlots


### PR DESCRIPTION
## About the PR
Requested changes by brady: FULFILLED. Yes the FTL was edited too, no it does not give them a full list of everything they get because they are braindead raiders that don't have a true logistical core to label everything for their meth-addled brains.
Nerfed 5.56 by 1 point of damage
Buffed 7.62 by 1 point of damage
Buffed 22lr to 10 damage (from 8) and increased its damage fallof start range from 3 (HORRID) to 5 (not horrid). Also increased max falloff range to 10. Reduced damage reduction from 65% loss to only 55% loss.
General nerfs to plasma weapons due to their TTKs being FAR too low with their current ROF. I can go into greater depth on these changes on discord easily.
Nerfed deagle by 0.5 ROF because holy shit it had 105 DPS as a fucking handgun previously

## Why / Balance
5.56 was a little too good.
7.62 felt a bit underwhelming compared to just using .308 or 5.56
22lr was HORRIBLE dogshit. I mean basically USELESS levels of horseshit.
Plasma weapons, due to ROF, often had sub 2 second TTKs. Making them MONSTERS in CQB or during defense. Instead of nerfing damage, I nerfed the weapons themselves. They are still painful, just not insanely lethal as they were before.
Deagle at 105 DPS was a bit nutty.

## Technical details
YAML AND FTL

## Media

https://github.com/user-attachments/assets/f9349bdd-40f0-4463-9236-bfeb7ad274cd

# Changelog

:cl: Big Block Bill
- add: Added 1 damage to 7.62
- tweak: made 22lr actually usable as a caliber (it still sucks.)
- remove: Removed 1 damage from 5.56
- tweak: Nerfed plasma weapons a bit, the shots still hit the same the guns just fire slower.
- tweak: changed out 80s kits for my version at the request of brady, we will see how they perform.
- tweak:  nerfed deagle by 0.5 ROF, down from 3 to 2.5