### PR TITLE
Makes Panic Bunker Secadmin+

### DIFF
--- a/Content.Server/Administration/Commands/PanicBunkerCommand.cs
+++ b/Content.Server/Administration/Commands/PanicBunkerCommand.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Console;
 
 namespace Content.Server.Administration.Commands;
 
+[AdminCommand(AdminFlags.Admin)]
 [AdminCommand(AdminFlags.Server)]
 public sealed class PanicBunkerCommand : LocalizedCommands
 {
@@ -47,6 +48,7 @@ public sealed class PanicBunkerCommand : LocalizedCommands
     }
 }
 
+[AdminCommand(AdminFlags.Admin)]
 [AdminCommand(AdminFlags.Server)]
 public sealed class PanicBunkerDisableWithAdminsCommand : LocalizedCommands
 {
@@ -67,6 +69,7 @@ public sealed class PanicBunkerDisableWithAdminsCommand : LocalizedCommands
     }
 }
 
+[AdminCommand(AdminFlags.Admin)]
 [AdminCommand(AdminFlags.Server)]
 public sealed class PanicBunkerEnableWithoutAdminsCommand : LocalizedCommands
 {
@@ -87,6 +90,7 @@ public sealed class PanicBunkerEnableWithoutAdminsCommand : LocalizedCommands
     }
 }
 
+[AdminCommand(AdminFlags.Admin)]
 [AdminCommand(AdminFlags.Server)]
 public sealed class PanicBunkerCountDeadminnedCommand : LocalizedCommands
 {
@@ -107,6 +111,7 @@ public sealed class PanicBunkerCountDeadminnedCommand : LocalizedCommands
     }
 }
 
+[AdminCommand(AdminFlags.Admin)]
 [AdminCommand(AdminFlags.Server)]
 public sealed class PanicBunkerShowReasonCommand : LocalizedCommands
 {
@@ -127,6 +132,7 @@ public sealed class PanicBunkerShowReasonCommand : LocalizedCommands
     }
 }
 
+[AdminCommand(AdminFlags.Admin)]
 [AdminCommand(AdminFlags.Server)]
 public sealed class PanicBunkerMinAccountAgeCommand : LocalizedCommands
 {
@@ -139,7 +145,8 @@ public sealed class PanicBunkerMinAccountAgeCommand : LocalizedCommands
         if (args.Length == 0)
         {
             var current = _cfg.GetCVar(CCVars.PanicBunkerMinAccountAge);
-            shell.WriteLine(Loc.GetString("panicbunker-command-min-account-age-is", ("hours", current / 60)));
+            shell.WriteLine(Loc.GetString("panicbunker-command-min-account-age-is", ("hours", current)));
+            return;
         }
 
         if (args.Length > 1)
@@ -154,11 +161,12 @@ public sealed class PanicBunkerMinAccountAgeCommand : LocalizedCommands
             return;
         }
 
-        _cfg.SetCVar(CCVars.PanicBunkerMinAccountAge, hours * 60);
+        _cfg.SetCVar(CCVars.PanicBunkerMinAccountAge, hours);
         shell.WriteLine(Loc.GetString("panicbunker-command-min-account-age-set", ("hours", hours)));
     }
 }
 
+[AdminCommand(AdminFlags.Admin)]
 [AdminCommand(AdminFlags.Server)]
 public sealed class PanicBunkerMinOverallHoursCommand : LocalizedCommands
 {
@@ -172,6 +180,7 @@ public sealed class PanicBunkerMinOverallHoursCommand : LocalizedCommands
         {
             var current = _cfg.GetCVar(CCVars.PanicBunkerMinOverallHours);
             shell.WriteLine(Loc.GetString("panicbunker-command-min-overall-hours-is", ("hours", current)));
+            return;
         }
 
         if (args.Length > 1)
@@ -187,6 +196,6 @@ public sealed class PanicBunkerMinOverallHoursCommand : LocalizedCommands
         }
 
         _cfg.SetCVar(CCVars.PanicBunkerMinOverallHours, hours);
-        shell.WriteLine(Loc.GetString("panicbunker-command-overall-hours-age-set", ("hours", hours)));
+        shell.WriteLine(Loc.GetString("panicbunker-command-min-overall-hours-set", ("hours", hours)));
     }
 }

--- a/Resources/Locale/en-US/administration/commands/panicbunker.ftl
+++ b/Resources/Locale/en-US/administration/commands/panicbunker.ftl
@@ -23,12 +23,12 @@ cmd-panicbunker_show_reason-help = Usage: panicbunker_show_reason
 panicbunker-command-show-reason-enabled = The panic bunker will now show a reason to users it blocks from connecting.
 panicbunker-command-show-reason-disabled = The panic bunker will no longer show a reason to users it blocks from connecting.
 
-cmd-panicbunker_min_account_age-desc = Gets or sets the minimum account age in minutes that an account must have to be allowed to connect with the panic bunker enabled.
-cmd-panicbunker_min_account_age-help = Usage: panicbunker_min_account_age <minutes>
-panicbunker-command-min-account-age-is = The minimum account age for the panic bunker is {$minutes} minutes.
-panicbunker-command-min-account-age-set = Set the minimum account age for the panic bunker to {$minutes} minutes.
+cmd-panicbunker_min_account_age-desc = Gets or sets the minimum account age in hours that an account must have to be allowed to connect with the panic bunker enabled.
+cmd-panicbunker_min_account_age-help = Usage: panicbunker_min_account_age <hours>
+panicbunker-command-min-account-age-is = The minimum account age for the panic bunker is {$hours} hours.
+panicbunker-command-min-account-age-set = Set the minimum account age for the panic bunker to {$hours} hours.
 
-cmd-panicbunker_min_overall_minutes-desc = Gets or sets the minimum overall playtime in minutes that an account must have to be allowed to connect with the panic bunker enabled.
-cmd-panicbunker_min_overall_minutes-help = Usage: panicbunker_min_overall_minutes <minutes>
-panicbunker-command-min-overall-minutes-is = The minimum overall playtime for the panic bunker is {$minutes} minutes.
-panicbunker-command-min-overall-minutes-set = Set the minimum overall playtime for the panic bunker to {$minutes} minutes.
+cmd-panicbunker_min_overall_hours-desc = Gets or sets the minimum overall playtime in hours that an account must have to be allowed to connect with the panic bunker enabled.
+cmd-panicbunker_min_overall_hours-help = Usage: panicbunker_min_overall_hours <hours>
+panicbunker-command-min-overall-hours-is = The minimum overall playtime for the panic bunker is {$hours} hours.
+panicbunker-command-min-overall-hours-set = Set the minimum overall playtime for the panic bunker to {$hours} hours.


### PR DESCRIPTION
## About the PR
Allows security admins to manage panic bunker settings.

## Technical details
Added `AdminFlags.Admin` as an allowed permission for the panic bunker command family while preserving existing `AdminFlags.Server` access.

Also fixed panic bunker command help/status paths to use the existing hour-based CVar semantics consistently and avoid argument handling issues when querying current values.

# Changelog

:cl:
- tweak: Security admins can now manage panic bunker settings.