### PR TITLE
Fix Compost Despawning when It Shouldn't

### DIFF
--- a/Content.Server/_Misfits/Storage/PauseTimedDespawnInEntityStorageSystem.cs
+++ b/Content.Server/_Misfits/Storage/PauseTimedDespawnInEntityStorageSystem.cs
@@ -7,17 +7,30 @@ namespace Content.Server._Misfits.Storage;
 
 public sealed class PauseTimedDespawnInEntityStorageSystem : EntitySystem
 {
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
     public override void Initialize()
     {
+        SubscribeLocalEvent<PauseTimedDespawnInEntityStorageComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<PauseTimedDespawnInEntityStorageComponent, EntGotInsertedIntoContainerMessage>(OnInserted);
         SubscribeLocalEvent<PauseTimedDespawnInEntityStorageComponent, EntGotRemovedFromContainerMessage>(OnRemoved);
     }
 
+    private void OnStartup(EntityUid uid, PauseTimedDespawnInEntityStorageComponent pauseComp, ComponentStartup _)
+    {
+        if (_container.IsEntityInContainer(uid))
+            PauseDespawn(uid, pauseComp);
+    }
+
     private void OnInserted(EntityUid uid, PauseTimedDespawnInEntityStorageComponent pauseComp, EntGotInsertedIntoContainerMessage _)
+    {
+        PauseDespawn(uid, pauseComp);
+    }
+
+    private void PauseDespawn(EntityUid uid, PauseTimedDespawnInEntityStorageComponent pauseComp)
     {
         if (!TryComp<TimedDespawnComponent>(uid, out var timedDespawn))
             return;
-
         // Keep compost from disappearing while a crate is intentionally storing it.
         pauseComp.PausedLifetime = timedDespawn.Lifetime;
         RemComp<TimedDespawnComponent>(uid);

--- a/Content.Server/_Misfits/Storage/PauseTimedDespawnInEntityStorageSystem.cs
+++ b/Content.Server/_Misfits/Storage/PauseTimedDespawnInEntityStorageSystem.cs
@@ -1,5 +1,5 @@
 using Content.Shared._Misfits.Storage;
-using Content.Shared.Storage.Components;
+using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Spawners;
 
@@ -9,27 +9,23 @@ public sealed class PauseTimedDespawnInEntityStorageSystem : EntitySystem
 {
     public override void Initialize()
     {
-        SubscribeLocalEvent<InsideEntityStorageComponent, ComponentStartup>(OnStorageEntered);
-        SubscribeLocalEvent<InsideEntityStorageComponent, ComponentShutdown>(OnStorageExited);
+        SubscribeLocalEvent<PauseTimedDespawnInEntityStorageComponent, EntGotInsertedIntoContainerMessage>(OnInserted);
+        SubscribeLocalEvent<PauseTimedDespawnInEntityStorageComponent, EntGotRemovedFromContainerMessage>(OnRemoved);
     }
 
-    private void OnStorageEntered(EntityUid uid, InsideEntityStorageComponent component, ComponentStartup args)
+    private void OnInserted(EntityUid uid, PauseTimedDespawnInEntityStorageComponent pauseComp, EntGotInsertedIntoContainerMessage _)
     {
-        if (!TryComp<PauseTimedDespawnInEntityStorageComponent>(uid, out var pauseComp) ||
-            !TryComp<TimedDespawnComponent>(uid, out var timedDespawn))
-        {
+        if (!TryComp<TimedDespawnComponent>(uid, out var timedDespawn))
             return;
-        }
 
         // Keep compost from disappearing while a crate is intentionally storing it.
         pauseComp.PausedLifetime = timedDespawn.Lifetime;
         RemComp<TimedDespawnComponent>(uid);
     }
 
-    private void OnStorageExited(EntityUid uid, InsideEntityStorageComponent component, ComponentShutdown args)
+    private void OnRemoved(EntityUid uid, PauseTimedDespawnInEntityStorageComponent pauseComp, EntGotRemovedFromContainerMessage _)
     {
         if (MetaData(uid).EntityLifeStage >= EntityLifeStage.Terminating ||
-            !TryComp<PauseTimedDespawnInEntityStorageComponent>(uid, out var pauseComp) ||
             pauseComp.PausedLifetime is not { } pausedLifetime)
         {
             return;


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Any inventory now blocks despawn
Compost that spawns in a storage no longer despawns
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Vixting
- fix: Any inventory now blocks despawn of compost
- fix: Compost that spawns in a storage no longer despawns