### PR TITLE
Pa Self Destruct 

### DIFF
--- a/Content.Server/_Misfits/PowerArmor/PowerArmorSelfDestructSystem.cs
+++ b/Content.Server/_Misfits/PowerArmor/PowerArmorSelfDestructSystem.cs
@@ -130,9 +130,9 @@ public sealed class PowerArmorSelfDestructSystem : EntitySystem
             if (!TerminatingOrDeleted(uid))
                 QueueDel(uid);
 
-            _explosion.QueueExplosion(detonationCoords, "N14DefaultStructural", totalIntensity: 3000f, slope: 10f, maxTileIntensity: 80f);
+            _explosion.QueueExplosion(detonationCoords, "N14DefaultStructural", totalIntensity: 2000f, slope: 10f, maxTileIntensity: 40f);
 
-            _emp.EmpPulse(detonationCoords, range: 8f, energyConsumption: 1000f, duration: 30f);
+            _emp.EmpPulse(detonationCoords, range: 10f, energyConsumption: 1000f, duration: 30f);
 
             if (!TerminatingOrDeleted(performer))
                 _body.GibBody(performer, launchGibs: true);

--- a/Content.Server/_Misfits/PowerArmor/PowerArmorSelfDestructSystem.cs
+++ b/Content.Server/_Misfits/PowerArmor/PowerArmorSelfDestructSystem.cs
@@ -1,0 +1,141 @@
+using Content.Server.Body.Systems;
+using Content.Server.Emp;
+using Content.Server.Explosion.EntitySystems;
+using Content.Server._Misfits.Chat.Systems;
+using Content.Shared.Actions;
+using Content.Shared.Inventory.Events;
+using Content.Shared._Misfits.PowerArmor;
+using Content.Shared.Popups;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Maths;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Misfits.PowerArmor;
+
+public sealed class PowerArmorSelfDestructSystem : EntitySystem
+{
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly ActionContainerSystem _actionContainer = default!;
+    [Dependency] private readonly ExplosionSystem _explosion = default!;
+    [Dependency] private readonly EmpSystem _emp = default!;
+    [Dependency] private readonly BodySystem _body = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPointLightSystem _pointLight = default!;
+    [Dependency] private readonly MisfitsEmoteThrottleSystem _throttle = default!;
+
+    private const int CountdownSeconds = 10;
+    private static readonly SoundPathSpecifier ActivationSound = new("/Audio/Machines/Nuke/nuke_alarm.ogg");
+    private static readonly SoundPathSpecifier BeepSound = new("/Audio/Effects/Grenades/SelfDestruct/SDS_Charge.ogg");
+
+    private const float GlowRadiusStart = 2.0f;
+    private const float GlowRadiusEnd = 14.0f;
+    private const float GlowEnergyStart = 1.5f;
+    private const float GlowEnergyEnd = 10.0f;
+    private static readonly Color GlowColor = Color.FromHex("#3377FF");
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PowerArmorSelfDestructComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<PowerArmorSelfDestructComponent, GetItemActionsEvent>(OnGetItemActions);
+        SubscribeLocalEvent<PowerArmorSelfDestructComponent, ComponentRemove>(OnComponentRemove);
+        SubscribeLocalEvent<PowerArmorSelfDestructComponent, PowerArmorSelfDestructEvent>(OnSelfDestruct);
+    }
+
+    private void OnMapInit(EntityUid uid, PowerArmorSelfDestructComponent component, MapInitEvent args)
+    {
+        _actionContainer.EnsureAction(uid, ref component.SelfDestructActionEntity, component.SelfDestructAction);
+        Dirty(uid, component);
+    }
+
+    private void OnGetItemActions(EntityUid uid, PowerArmorSelfDestructComponent component, GetItemActionsEvent args)
+    {
+        if (args.SlotFlags != component.RequiredSlot || component.SelfDestructActionEntity == null)
+            return;
+
+        args.AddAction(component.SelfDestructActionEntity.Value);
+    }
+
+    private void OnComponentRemove(EntityUid uid, PowerArmorSelfDestructComponent component, ComponentRemove args)
+    {
+        _actions.RemoveAction(component.SelfDestructActionEntity);
+    }
+
+    private void OnSelfDestruct(EntityUid uid, PowerArmorSelfDestructComponent component, PowerArmorSelfDestructEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        args.Handled = true;
+
+        var performer = args.Performer;
+        if (TerminatingOrDeleted(performer))
+            return;
+
+        var fallbackCoords = _transform.GetMapCoordinates(performer);
+
+        _popup.PopupCoordinates(
+            Loc.GetString("power-armor-self-destruct-activated"),
+            Transform(performer).Coordinates,
+            PopupType.LargeCaution);
+
+        _audio.PlayPvs(ActivationSound, performer);
+
+        var armorName = Exists(uid) ? Name(uid) : "power armor";
+        _throttle.SendThrottledEmote(
+            performer,
+            "pa-selfdestruct",
+            Loc.GetString("power-armor-self-destruct-chat", ("armor", armorName)));
+
+        var glowEnt = Spawn(null, Transform(performer).Coordinates);
+        _transform.SetParent(glowEnt, performer);
+
+        var light = EnsureComp<PointLightComponent>(glowEnt);
+        _pointLight.SetColor(glowEnt, GlowColor, light);
+        _pointLight.SetRadius(glowEnt, GlowRadiusStart, light);
+        _pointLight.SetEnergy(glowEnt, GlowEnergyStart, light);
+        _pointLight.SetEnabled(glowEnt, true, light);
+
+        for (var i = 0; i < CountdownSeconds; i++)
+        {
+            var step = i;
+            Timer.Spawn(TimeSpan.FromSeconds(step), () =>
+            {
+                if (!TerminatingOrDeleted(performer))
+                    _audio.PlayPvs(BeepSound, performer);
+
+                if (!TerminatingOrDeleted(glowEnt))
+                {
+                    var t = (float)step / CountdownSeconds;
+                    _pointLight.SetRadius(glowEnt, MathHelper.Lerp(GlowRadiusStart, GlowRadiusEnd, t));
+                    _pointLight.SetEnergy(glowEnt, MathHelper.Lerp(GlowEnergyStart, GlowEnergyEnd, t));
+                }
+            });
+        }
+
+        Timer.Spawn(TimeSpan.FromSeconds(CountdownSeconds), () =>
+        {
+            var detonationCoords = !TerminatingOrDeleted(performer)
+                ? _transform.GetMapCoordinates(performer)
+                : fallbackCoords;
+
+            if (!TerminatingOrDeleted(glowEnt))
+                QueueDel(glowEnt);
+
+            if (!TerminatingOrDeleted(uid))
+                QueueDel(uid);
+
+            _explosion.QueueExplosion(detonationCoords, "N14DefaultStructural", totalIntensity: 3000f, slope: 10f, maxTileIntensity: 80f);
+
+            _emp.EmpPulse(detonationCoords, range: 8f, energyConsumption: 1000f, duration: 30f);
+
+            if (!TerminatingOrDeleted(performer))
+                _body.GibBody(performer, launchGibs: true);
+        });
+    }
+}

--- a/Content.Shared/_Misfits/PowerArmor/PowerArmorSelfDestructComponent.cs
+++ b/Content.Shared/_Misfits/PowerArmor/PowerArmorSelfDestructComponent.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Actions;
+using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Misfits.PowerArmor;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PowerArmorSelfDestructComponent : Component
+{
+    [DataField]
+    public EntProtoId SelfDestructAction = "ActionPowerArmorSelfDestruct";
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? SelfDestructActionEntity;
+
+    [DataField]
+    public SlotFlags RequiredSlot = SlotFlags.OUTERCLOTHING;
+}
+
+public sealed partial class PowerArmorSelfDestructEvent : InstantActionEvent { }

--- a/Resources/Locale/en-US/_Misfits/power-armor-selfdestruct.ftl
+++ b/Resources/Locale/en-US/_Misfits/power-armor-selfdestruct.ftl
@@ -1,0 +1,6 @@
+action-power-armor-self-destruct-name = Fusion Core Overload
+action-power-armor-self-destruct-desc = Initiate an emergency fusion core overload. The suit will detonate in a catastrophic explosion. WARNING: This will destroy the armor and kill you.
+
+power-armor-self-destruct-activated = FUSION CORE CRITICAL — DETONATION IN 10 SECONDS
+
+power-armor-self-destruct-chat = emits a critical fusion core overload warning from {THE($armor)}!

--- a/Resources/Prototypes/_Misfits/Actions/powerarmor_selfdestruct.yml
+++ b/Resources/Prototypes/_Misfits/Actions/powerarmor_selfdestruct.yml
@@ -1,0 +1,12 @@
+- type: entity
+  id: ActionPowerArmorSelfDestruct
+  name: action-power-armor-self-destruct-name
+  description: action-power-armor-self-destruct-desc
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    useDelay: 11
+    icon:
+      sprite: Objects/Devices/nuke.rsi
+      state: nuclearbomb_deployed
+    event: !type:PowerArmorSelfDestructEvent

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -79,6 +79,7 @@
     innate: true
     spread: 90
   - type: SpearBlock # #Misfits Change Add: Power armor deflects thrown polearms; falls to ground instead of embedding.
+  - type: PowerArmorSelfDestruct
   - type: PowerArmorBrace # #Misfits Change Add: Grants wearer a hotkey to brace (anchor in place, immobile but can fire, slight damage resistance). 5-second cooldown between stance changes.
     activeModifiers:
       coefficients:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Adds a self destruct action to pa, it gibs the user & creates large explosion alongside emp effect. It cannot be cancelled once initiated. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
idk I've never used pa but this could be fun
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/314dc005-3e17-478d-bbb1-53014644b59d


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Vixting
- add: Adds a self destruct action to pa, it gibs the user & creates large explosion alongside emp effect. It cannot be cancelled once initiated. 