### PR TITLE
Added Boots with Chains for Prisoners, (Need Sprites)

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Shoes/Shoes.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Shoes/Shoes.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: ClothingShoesBase
+  id: MisfitsShackledBoots
+  name: Chained boots
+  description: Boots with chains on them to slow down prisoners.
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Clothing/Shoes/FalloutShoes/blackshoes.rsi
+  - type: Clothing
+    sprite: _Nuclear14/Clothing/Shoes/FalloutShoes/blackshoes.rsi
+    unequipDelay: 60
+  - type: ClothingSpeedModifier
+    walkModifier: 0.4
+    sprintModifier: 0.4

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
@@ -121,6 +121,7 @@
   components:
   - type: Blueprint
     recipes:
+    - MisfitsShackledBoots
     - N14BPNCRArmorVestSnow
     - N14BPNCRArmorVestWoods
     - N14BPNCRArmorVestDesert

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -644,6 +644,20 @@
 
     Leather: 500
 
+- type: latheRecipe
+  id: MisfitsShackledBoots
+  result: MisfitsShackledBoots
+  category: N14BlueprintNCRArmorT1
+  completetime: 6
+  requiresBlueprint: true
+  availableFaction:
+  - NCR
+  materials:
+    Cloth: 800
+
+    Thread: 500
+
+    Steel: 500
 
 - type: latheRecipe
   id: N14BPNCRArmorVestWoods


### PR DESCRIPTION
🆑 






- add: Added chained boots for prisoners. (60% speed debuff and takes 1 minute to unequip.) (still needs sprites so pretend for now) (craftable for NCR)

