### PR TITLE
Role Locked Olive Oil.

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/items.yml
@@ -254,7 +254,14 @@
   cost: 1
   items:
   - N14ReagentContainerOliveoil
-
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+      - NCRCitizen
+      - BoSInitiate
+      - VaultDweller
+      - WastelandFarmer
+      - WastelandBartender
 
 
 


### PR DESCRIPTION
I don't trust the legion with this

🆑 




- tweak: Locked olive oil loadout item to roles you'd expect to find cooking sometimes.

