### PR TITLE
Projects Tracker | 80s Raid, SM Melee, Ghosts & War, Access4Legion, SM Hunger - Misc .ftls

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
@@ -2,11 +2,13 @@ using Content.Server.Tools;
 using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared.Humanoid;
 using Content.Shared.Tools.Components;
+using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Nyanotrasen.Abilities.Oni;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Wieldable.Components;
 using Robust.Shared.Containers;
 
 namespace Content.Server.Abilities.Oni
@@ -58,26 +60,53 @@ namespace Content.Server.Abilities.Oni
             RemComp<HeldByOniComponent>(args.Entity);
         }
 
+
+
         private void OnGetMeleeDamage(EntityUid uid, MeleeWeaponComponent component, ref GetMeleeDamageEvent args)
         {
             if (!TryComp<OniComponent>(args.User, out var oni))
+
                 return;
 
-            // Super Mutants and Nightkin use logarithmic outgoing melee scaling before Oni multipliers.
-            if (TryComp<HumanoidAppearanceComponent>(args.User, out var appearance) &&
-                (appearance.Species == "SuperMutant" || appearance.Species == "Nightkin"))
+            // Super Mutants and Nightkin: log curve for wielded weapons only, flat 2x for everything else
+            bool isWielded = TryComp<WieldableComponent>(uid, out var wield) && wield.Wielded;
+            bool isSuperMutant = TryComp<HumanoidAppearanceComponent>(args.User, out var appearance) &&
+                (appearance.Species == "SuperMutant" || appearance.Species == "Nightkin");
+
+            // Important: `args.Damage` is the current damage spec after other melee damage adjustments
+            // have already been applied upstream at this hook (wield, two-hands, weapon bonuses, etc).
+            // The curve should use the same value we scale so "log damage math" lands in the expected range.
+            var baseDamage = args.Damage.GetTotal().Float();
+
+            if (isWielded && isSuperMutant)
             {
-                var baseDamage = args.Damage.GetTotal().Float();
                 if (baseDamage > 0f)
                 {
-                    var logCurveDamage = MutantMeleeDamageCeiling * MathF.Log(baseDamage + 1f) / MathF.Log(MutantMeleeDamageCeiling + 1f);
+                    var logCurveDamage = MutantMeleeDamageCeiling * MathF.Log(baseDamage + 1f) /
+                                          MathF.Log(MutantMeleeDamageCeiling + 1f);
                     var targetDamage = MathF.Min(MathF.Max(logCurveDamage, baseDamage), MutantMeleeDamageCeiling);
+
                     args.Damage *= targetDamage / baseDamage;
                 }
             }
 
+            // Apply Oni melee modifiers.
+            // (curve math above is intended to shape wielded mutant damage; final number should be capped via log curve)
             args.Modifiers.Add(oni.MeleeModifiers);
+
+            // Cap wielded mutant melee damage to 200 (pre-resistance; final damage pipeline may apply resistances).
+            // NOTE: Oni modifier coefficients (e.g. 2.0x Blunt) are applied after this event returns
+            // via DamageSpecifier.ApplyModifierSets, so we must pre-scale args.Damage to account for
+            // them, otherwise the final post-modifier damage blows past the cap.
+            if (isWielded && isSuperMutant)
+            {
+                var effectiveDamage = DamageSpecifier.ApplyModifierSet(args.Damage, oni.MeleeModifiers);
+                var total = effectiveDamage.GetTotal().Float();
+                if (total > 200f)
+                    args.Damage *= 200f / total;
+            }
         }
+
 
         private void OnStamHit(EntityUid uid, HeldByOniComponent component, TakeStaminaDamageEvent args)
         {

--- a/Content.Server/SuperMutant/Systems/SuperMutantMeleeSystem.cs
+++ b/Content.Server/SuperMutant/Systems/SuperMutantMeleeSystem.cs
@@ -1,3 +1,4 @@
+/*
 using Content.Shared.Humanoid;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Wieldable.Components;
@@ -12,7 +13,8 @@ public sealed class SuperMutantMeleeSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<GetMeleeDamageEvent>(OnGetMeleeDamage);
+        // Disabled: log curve logic moved to OniSystem.OnGetMeleeDamage.
+        // SubscribeLocalEvent<GetMeleeDamageEvent>(OnGetMeleeDamage);
     }
 
     private void OnGetMeleeDamage(ref GetMeleeDamageEvent args)
@@ -37,3 +39,4 @@ public sealed class SuperMutantMeleeSystem : EntitySystem
         args.Damage *= targetDamage / baseDamage;
     }
 }
+*/

--- a/Content.Server/_Misfits/FactionWar/FactionWarSystem.cs
+++ b/Content.Server/_Misfits/FactionWar/FactionWarSystem.cs
@@ -15,6 +15,7 @@ using Content.Server.Mind;
 using Content.Server.Roles.Jobs;
 using Content.Shared._Misfits.FactionWar;
 using Content.Shared.GameTicking;
+using Content.Shared.Ghost;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -403,6 +404,13 @@ public sealed class FactionWarSystem : EntitySystem
             return;
         }
 
+        // #Misfits Fix - Ghosts cannot declare war
+        if (HasComp<GhostComponent>(playerEntity))
+        {
+            SendResult(player, false, "Ghosts cannot declare war.");
+            return;
+        }
+
         if (msg.TargetPlayer == player.UserId)
         {
             SendResult(player, false, "You cannot declare war on yourself.");
@@ -445,6 +453,13 @@ public sealed class FactionWarSystem : EntitySystem
         if (targetSession.AttachedEntity is not { } targetEntity)
         {
             SendResult(player, false, "Target player is not yet in-game.");
+            return;
+        }
+
+        // #Misfits Fix - Cannot declare war on ghosts
+        if (HasComp<GhostComponent>(targetEntity))
+        {
+            SendResult(player, false, "Cannot declare war on ghosts.");
             return;
         }
 

--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -75,6 +75,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "NCRLT",
         "NCRRanger",
         "CaesarLegion", // Misfit: Legion Start
+        "CaesarLegionRecruit", // #Misfits Add - Cell door gate access for Legion IDs
         "CaesarLegionSlave",
         "CaesarLegionFrumentarii",
         "CaesarLegionVexillarius",

--- a/Content.Shared/_Misfits/RaidRequest/RaidRequestMessages.cs
+++ b/Content.Shared/_Misfits/RaidRequest/RaidRequestMessages.cs
@@ -26,6 +26,7 @@ public static class RaidRequestConfig
         "Townsfolk", "PlayerRaider",
         "Tribal", "Vault", "Followers",
         "Enclave", // #Misfits Add - Enclave remnant faction may submit faction-tier raid requests.
+        "Eighties", // #Misfits Add - 80s biker gang may submit faction-tier raid requests.
     };
 
     /// <summary>
@@ -66,6 +67,7 @@ public static class RaidRequestConfig
         "Vault"       => "Vault Dwellers",
         "Followers"   => "Followers of the Apocalypse",
         "Wastelander" => "Wastelander",
+        "Eighties"    => "80s",
         _             => canonicalFaction,
     };
 

--- a/Resources/Locale/en-US/_Goobstation/job-names.ftl
+++ b/Resources/Locale/en-US/_Goobstation/job-names.ftl
@@ -1,0 +1,2 @@
+job-name-radiohost = Radio Host
+job-description-radiohost = Keep the airwaves alive! Entertain the crew, report the news, and be the voice the station needs.

--- a/Resources/Locale/en-US/_Misfits/job-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/job-names.ftl
@@ -115,6 +115,10 @@ job-description-follower-guard = You protect the Followers' clinic, escort docto
 job-name-follower-volunteer = Followers Volunteer
 job-description-follower-volunteer = You are new to the Followers. You believe knowledge and compassion can outlast bullets and bombs. Prove it — learn from those above you and help anyone who needs it.
 
+# #Misfits Add - Supermutant Follower Doctor job locale.
+job-name-supermutant-follower-doctor = Supermutant Follower Doctor
+job-description-supermutant-follower-doctor = A SuperMutant trained in the ways of medicine.
+
 # #Misfits Add — Western BoS chapter command-tier jobs (Elder + Head Scribe).
 # These keys were commented out in the Corvax locale when the Corvax west-BoS chapter
 # was removed, but the Misfits bos_elder.yml and bos_headscribe.yml prototypes still reference them.

--- a/Resources/Locale/en-US/_Misfits/loadout-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/loadout-names.ftl
@@ -512,3 +512,128 @@ loadout-name-MisfitsLoadoutNeckCloakNCRSnow = NCR winter cloak
 loadout-name-MisfitsLoadoutNeckMantleNCR = NCR squad leader mantle
 loadout-name-MisfitsLoadoutNeckCloakNCRWoods = NCR woods cloak
 loadout-name-MisfitsLoadoutNeckCloakTribal = tribal cloak
+
+# N14 loadout names (universal item group)
+# Headwear
+loadout-name-N14LoadoutUniversalHeadHatCaravan = railwayman's cap
+loadout-name-N14LoadoutUniversalHeadHatCaravanSuit = Blue Line Caravan Co. boss' hat
+loadout-name-N14LoadoutUniversalHeadHatCaravanUniform = Blue Line Caravan Co. employee hat
+loadout-name-N14LoadoutUniversalHeadHatChinese = chinese hat
+loadout-name-N14LoadoutUniversalHeadHatHoodBlackRobe = black robe hood
+loadout-name-N14LoadoutUniversalHeadHatHoodGhillieCloak = ghillie cloak hood
+loadout-name-N14LoadoutUniversalHeadHatHoodLeatherCloak = leather cloak hood
+loadout-name-N14LoadoutUniversalHeadHatHoodLeatherRobe = leather robe hood
+loadout-name-N14LoadoutUniversalHeadHatHoodScribeTabard = Scribe Tabard hood
+loadout-name-N14LoadoutUniversalHeadHatMountie = mountie hat
+loadout-name-N14LoadoutUniversalHeadHatTownGuard = the Guard's hat
+loadout-name-N14LoadoutUniversalHeadHatVancouver = vancouver preventor cap
+loadout-name-N14LoadoutUniversalHeadTribalCloakHood = tribal cloak hood
+loadout-name-N14LoadoutUniversalHeadTribalCloakHoodBr = tribal cloak hood
+loadout-name-M14ClothingHeadHatVaultCap = vault-tec cap
+
+# Masks
+loadout-name-N14LoadoutUniversalMaskBlackBalaclava = black balaclava
+loadout-name-N14LoadoutUniversalMaskBlueMask = blue mask
+loadout-name-N14LoadoutUniversalMaskBrownMask = brown mask
+loadout-name-N14LoadoutUniversalMaskGreenMask = green mask
+loadout-name-N14LoadoutUniversalMaskOrangeMask = orange mask
+loadout-name-N14LoadoutUniversalMaskPatriotMask = patriot mask
+loadout-name-N14LoadoutUniversalMaskRedMask = red mask
+
+# Neck
+loadout-name-N14LoadoutUniversalNeckCloakBrotherhoodWashington = Brotherhood of Steel cloak
+loadout-name-N14LoadoutUniversalNeckCloakDarkCloak = dark cloak
+loadout-name-N14LoadoutUniversalNeckCloakLeather = leather cloak
+loadout-name-N14LoadoutUniversalNeckCloakYaoguai = Yao Guai cloak
+loadout-name-N14LoadoutUniversalNeckMantleBrotherhoodWashington = Brotherhood of Steel mantle
+loadout-name-N14LoadoutUniversalNeckMantleLeather = leather mantle
+loadout-name-N14LoadoutUniversalNeckShawl = shawl
+loadout-name-N14LoadoutUniversalNeckTownGuardCloak = old cloak
+loadout-name-N14LoadoutUniversalNeckTribalCloak = tribal cloak
+loadout-name-N14LoadoutUniversalNeckTribalCloakBr = tribal cloak
+loadout-name-MisfitsLoadoutNeckNCRmantleQM = Requisitions Officer's mantle
+
+# Outer
+loadout-name-N14LoadoutUniversalOuterBlackRobes = black robe
+loadout-name-N14LoadoutUniversalOuterGhostEchoes = Ghost Echoes
+loadout-name-N14LoadoutUniversalOuterLeatherRobes = leather robe
+loadout-name-N14LoadoutUniversalOuterRobeHubologist = hubologist robes
+loadout-name-N14LoadoutUniversalOuterNCRCorrectional = NCR CF uniform
+loadout-name-N14LoadoutUniversalOuterNCRDressJacket = NCR dress jacket
+loadout-name-N14LoadoutUniversalOuterNCRDressJacketCO = NCR CO dress jacket
+loadout-name-N14LoadoutUniversalOuterNCRQuartermaster = NCR QM uniform
+loadout-name-N14LoadoutOuterCoatLeatherCoat = leather coat
+
+# Boots
+loadout-name-N14LoadoutUniversalBootsFire = firefighter boots
+loadout-name-N14LoadoutUniversalBootsCombatMK2 = combat boots MK2
+loadout-name-N14LoadoutUniversalBootsMountie = mountie leather boots
+
+# Uniforms
+loadout-name-N14LoadoutUniversalUniformNCRDesert = NCR trooper uniform
+loadout-name-N14LoadoutUniversalUniformNCRSnow = NCR trooper uniform
+loadout-name-N14LoadoutUniversalUniformJumpskirtBOSBlack = Black Brotherhood of Steel uniform
+loadout-name-N14LoadoutUniversalUniformJumpskirtBOSGold = Brotherhood of Steel uniform
+loadout-name-N14LoadoutUniversalUniformJumpskirtBOSSilver = Brotherhood of Steel uniform
+loadout-name-N14LoadoutUniversalUniformJumpskirtRDFormal = research director's formal dress
+loadout-name-N14LoadoutUniversalUniformJumpsuitBOSBlack = Black Washington BoS uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitBOSGreen = Brotherhood of Steel uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitBOSRed = Washington BoS undersuit
+loadout-name-N14LoadoutUniversalUniformJumpsuitBOSScribe = BoS Scribe uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitBOSSilver = Washington BoS uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitBOSWashingtonFieldScribe = Washington BoS Scribe uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitCaravanOveralls = Blue Line Caravan Co. overalls
+loadout-name-N14LoadoutUniversalUniformJumpsuitCaravanShirt = Blue Line Caravan Co. uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitCaravanSuit = Blue Line Caravan Co. suit
+loadout-name-N14LoadoutUniversalUniformJumpsuitEnclave = enclave uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitFudd = fudd clothes
+loadout-name-N14LoadoutUniversalUniformJumpsuitMilUniform = prewar military uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitRCMP = RCMP uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitRDFormal = research director's formal suit
+loadout-name-N14LoadoutUniversalUniformJumpsuitTownGuard = the Guard's uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitTownGuardLight = the Guard's uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitVancouver = vancouver preventor uniform
+loadout-name-N14LoadoutUniversalUniformJumpsuitVault = vault jumpsuit
+loadout-name-N14LoadoutUniversalUniformBosRecon = BoS Paladin uniform
+loadout-name-N14LoadoutUniversalOfficerUniformNCRDesert = field NCR officer uniform
+loadout-name-N14LoadoutUniversalOfficerUniformNCRSnow = field NCR officer uniform
+loadout-name-N14LoadoutUniversalMPUniformNCRDesert = NCR military police uniform
+loadout-name-N14LoadoutUniversalMPUniformNCRSnow = NCR military police uniform
+loadout-name-N14LoadoutUniversalUniformRangerPatrol = patrol ranger uniform
+loadout-name-N14ClothingUniformJumpsuittribalpantsf = tribal clothing
+loadout-name-N14ClothingUniformJumpsuittribalpantsm = tribal clothing
+loadout-name-N14ClothingUniformJumpsuittribalpantsnecklace = tribal clothing
+loadout-name-N14ClothingUniformJumpsuitdrylanderTribal = tribal clothing
+
+# Ammo and magazines
+loadout-name-N14MagazinePistol45 = pistol magazine (.45 auto)
+loadout-name-N14MagazinePistol9mm = pistol magazine (9mm)
+loadout-name-N14MagazinePistol22lr = pistol magazine (.22lr)
+loadout-name-N14MagazinePistol10mm = pistol magazine (10mm)
+loadout-name-N14SpeedLoader44 = speed loader (.44 magnum)
+loadout-name-N14ReagentContainerOliveoil = olive oil
+
+# Melee weapons
+loadout-name-N14Gladius = gladius
+loadout-name-N14GladiusLegion = gladius
+loadout-name-N14ChineseSword = chinese officer sword
+loadout-name-N14LongSword = longsword
+loadout-name-N14LongSwordBoS = longsword
+loadout-name-N14CeremonialSwordCent = ceremonial sword
+loadout-name-N14GoliathFistLeader = goliath power fist
+loadout-name-N14TrenchClub = trench club
+loadout-name-N14PoliceBaton = police baton
+
+# Firearms
+loadout-name-N14WeaponPistol9mmChinese = chinese pistol
+loadout-name-N14WeaponPistol45Colt = .45 colt handgun
+loadout-name-N14WeaponPistolWebley = webley pistol
+loadout-name-N14WeaponRevolver44Magnun = magnum revolver
+
+# Other loadouts
+loadout-name-LoadoutLegionExplorerVeteranArmor = veteran legion explorer armor
+loadout-name-LoadoutLegionExplorerVeteranHelmet = veteran legion explorer helmet
+loadout-name-LoadoutNCRRangerEliteArmor = elite ranger combat armor
+loadout-name-LoadoutNCRRangerFoxArmor = fox ranger combat armor
+loadout-name-MisfitsLoadoutHeadAntlerSkull = antler skullcap
+loadout-name-MisfitsLoadoutBoSMidwestCommanderPowerArmor = BoS Commander Power Armor

--- a/Resources/Locale/en-US/_Misfits/supermutant/loadout-names.ftl
+++ b/Resources/Locale/en-US/_Misfits/supermutant/loadout-names.ftl
@@ -1,0 +1,17 @@
+loadout-name-MisfitsLoadoutSuperMutantGladiatorLoincloth = supermutant gladiator loincloth
+loadout-name-MisfitsLoadoutSuperMutantGladiatorArmor = supermutant gladiator armor
+loadout-name-MisfitsLoadoutSuperMutantGladiatorBoots = supermutant gladiator boots
+loadout-name-MisfitsLoadoutSuperMutantGladiatorHelmet = supermutant gladiator helmet
+loadout-name-MisfitsLoadoutSuperMutantRangerArmor = supermutant ranger duster
+loadout-name-MisfitsLoadoutSuperMutantTrooperArmor = supermutant trooper armor
+loadout-name-MisfitsLoadoutSuperMutantOutfitC = supermutant battle wrap
+loadout-name-MisfitsLoadoutSuperMutantVaultSuit = supermutant vault suit
+loadout-name-MisfitsLoadoutSuperMutantTribalLoincloth = supermutant tribal loincloth
+loadout-name-MisfitsLoadoutSuperMutantNeckGuard = supermutant neck guard
+loadout-name-MisfitsLoadoutSuperMutantNeckTrinket = supermutant skull necklace
+loadout-name-MisfitsLoadoutSuperMutantNeckCapeTribal = supermutant tribal neck cape
+loadout-name-ClothingSuperMutantSkullHelmetTribal = super mutant muffolo skull
+loadout-name-ClothingSuperMutantTribalGloves = supermutant tribal gloves
+loadout-name-ClothingSuperMutantZootSuit = supermutant zoot suit
+loadout-name-ClothingSuperMutantZootHat = super mutant zoot hat
+loadout-name-ClothingSuperMutantZootBoot = supermutant zoot boots

--- a/Resources/Prototypes/_Misfits/Access/all_access.yml
+++ b/Resources/Prototypes/_Misfits/Access/all_access.yml
@@ -1,0 +1,169 @@
+# #Misfits Add - Comprehensive all-access group for admin/debug use.
+# Includes every accessLevel defined across all prototype folders.
+# Excludes VaultControlsPanel (deliberately restricted to Overseer only).
+# Excludes syndicate/antag-only levels (NuclearOperative, SyndicateAgent) — admin card shouldn't flag as antag.
+
+- type: accessGroup
+  id: AllAccessN14
+  tags:
+  # ── Standard SS14 (mirrors upstream AllAccess) ──
+  - EmergencyShuttleRepealAll
+  - Captain
+  - HeadOfPersonnel
+  - ChiefEngineer
+  - ChiefMedicalOfficer
+  - HeadOfSecurity
+  - ResearchDirector
+  - Command
+  - Cryogenics
+  - Security
+  - Detective
+  - Armory
+  - Lawyer
+  - Engineering
+  - Medical
+  - Quartermaster
+  - Salvage
+  - Cargo
+  - Research
+  - Service
+  - Maintenance
+  - External
+  - Janitor
+  - Theatre
+  - Bar
+  - Chemistry
+  - Kitchen
+  - Chapel
+  - Hydroponics
+  - Atmospherics
+  # ── Nyanotrasen / DeltaV / Goobstation additions ──
+  - Mail
+  - Orders
+  - Mantis
+  - Paramedic
+  - Psychologist
+  - Boxer
+  - Clown
+  - Library
+  - Mime
+  - Musician
+  - Reporter
+  - Zookeeper
+  - Justice
+  - ChiefJustice
+  - Prosecutor
+  - Corpsman
+  - Journalism
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
+  - Magistrate
+  # ── N14: Townies & Wasteland ──
+  - TownieLaw
+  - TownieMayor
+  - TownieShopkeeper
+  - TownieDoctor
+  - TownieMechanic
+  - WastelandBartender
+  - WastelandReporter
+  - TownsPerson
+  - InnRoomOne
+  - InnRoomTwo
+  - InnRoomThree
+  - WastelandChaplain
+  - WastelandFarmer
+  # ── N14: Tribals ──
+  - TribeMember
+  - TribeChief
+  # ── N14: Followers of the Apocalypse ──
+  - FollowersApocalypse
+  - FotA
+  - FotADoctor
+  - FotAHead
+  # ── N14: Zetan ──
+  - ZetanCaptain
+  - Zetan
+  # ── N14: Enclave ──
+  - Enclave
+  - EnclaveNCO
+  - EnclaveOfficer
+  - EnclaveCommand
+  - EnclaveScience
+  # ── N14: NCR ──
+  - NCR
+  - NCRSGT
+  - NCRMedic
+  - NCRLT
+  - NCRRanger
+  - NCRCaptain
+  - NCRMajor
+  # ── N14: Vault ──
+  - VaultOverseer
+  - VaultGatekeeper
+  - VaultSecurity
+  - VaultMedical
+  - VaultChemistry
+  - VaultEngineer
+  - VaultDweller
+  # ── N14: Legion (Corvax) ──
+  - CaesarLegion
+  - CaesarLegionSlave
+  - CaesarLegionRecruit
+  - CaesarLegionHoundmaster
+  - CaesarLegionFrumentarii
+  - CaesarLegionVexillarius
+  - CaesarLegionExplorer
+  - CaesarLegionOptio
+  - CaesarLegionLegionnaireRecruit
+  - CaesarLegionLegionnaireWarrior
+  - CaesarLegionLegionnaireVeteran
+  - CaesarLegionDean
+  - CaesarLegionVeteranDecanus
+  - CaesarLegionCenturion
+  - CaesarLegionLegate
+  # ── N14: BoS Washington ──
+  - WashingtonCommander
+  - WashingtonPaladin
+  - WashingtonKnight
+  - WashingtonScribe
+  - WashingtonInitiate
+  - BOSWashington
+  # ── N14: BoS Midwest ──
+  - PaladinCommander
+  - Paladin
+  - Knight
+  - Scribe
+  - BoSMidwest
+  # ── N14: BoS (Misfits unified) ──
+  - BOS
+  - BOSInitiate
+  - BOSSquire
+  - BOSScribe
+  - BOSKnight
+  - BOSPaladin
+  - BOSSeniorScribe
+  - BOSSeniorKnight
+  - BOSSeniorPaladin
+  - BOSHeadScribe
+  - BOSHeadKnight
+  - BOSHeadPaladin
+  - BOSElder
+  # ── N14: 80s ──
+  - 80s
+  - 80sHead
+  - 80sSlave
+  # ── N14: Keys ──
+  - IronKey
+  - BronzeKey
+  - BrassKey
+  - LegionBrassKey
+  - SilverKey
+  # ── N14: Dungeons / Bunkers ──
+  - DungeonBunkerA1
+  - DungeonBunkerA2
+  - DungeonBunkerA3
+  - DungeonBlue
+  - DungeonYellow
+  - DungeonRed
+  - DungeonCommon
+  - AncientBunker

--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Species/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Species/supermutant.yml
@@ -74,6 +74,7 @@
   - type: Perishable
     rotAfter: 3600
   - type: Hunger
+    baseDecayRate: 0.024 # #Misfits Add - 3x human default (0.008) to reflect massive size / accelerated metabolism
     starvationDamage:
       types:
         Cold: 0.15 # Misfits Change - use Cold damage for Malnutrition instead of custom Starvation type (no brute/bleed from hunger)

--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Species/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Species/supermutant.yml
@@ -119,10 +119,10 @@
   - type: Oni
     modifiers:
       coefficients:
-        Blunt: 1.0
-        Slash: 1.0
-        Piercing: 1.0
-        Shock: 1.0
+        Blunt: 2.0
+        Slash: 2.0
+        Piercing: 2.0
+        Shock: 2.0
   - type: MeleeThrowOnHit
     speed: 15
     lifetime: 0.025

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Misc/identification.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Misc/identification.yml
@@ -1,0 +1,21 @@
+# #Misfits Add - Admin/Sysadmin ID cards for debugging and access terminal administration.
+
+- type: entity
+  parent: N14IDPassportBlank
+  id: N14IDCardAdmin
+  name: admin ID card
+  description: A debug ID card with universal access. Use with the access terminal to grant any access level.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: _Nuclear14/Objects/Misc/identification.rsi
+    state: passport_blank
+  - type: Access
+    groups:
+    - AllAccessN14
+  - type: Clothing
+    sprite: _Nuclear14/Objects/Misc/identification.rsi
+  - type: IdCard
+  - type: Tag
+    tags:
+    - DoorBumpOpener

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/SuperMutant/supermutant.yml
@@ -398,8 +398,8 @@
 - type: job
   id: SuperMutantFollowerDoctor
   jobWhitelistBypassesRoleTimers: true
-  name: Supermutant Follower Doctor
-  description: A SuperMutant trained in the ways of medicine.
+  name: job-name-supermutant-follower-doctor
+  description: job-description-supermutant-follower-doctor
   playTimeTracker: SuperMutantFollowerDoctor
   icon: JobIconPassenger
   supervisors: job-supervisors-follower-doctor


### PR DESCRIPTION
---

## About the PR

This PR addresses several items from the [MISFITS DEVELOPMENT TRACKER](https://github.com/orgs/Misfit-Sanctuary/projects/1/views/2)

**Commits included:**
- `1efae1c` - 80s Added to /raid + SM Hunger
- `2b1189e` - Ghost check for /war
- `1c8fbdc` - SM Melee Adjusts & Locale.ftl

## Why / Balance

- **#725 - ADD 80'S TO RAID REQUEST** - The 80s faction is now fully operational on the server, so they need to be a valid target for raid requests just like other factions.
- **#719 - Make Supermutants have 3x as fast hunger drain** - Super Mutants are massive, metabolically accelerated beings......`baseDecayRate: 0.024` (3x human default of 0.008) reflects their size and keeps hunger relevant for them.
- **#706 - Ghosts can declare war** - Ghosts shouldn't be able to interact with the war system at all...
- **#713 - ACCESS TERMINAL NOT APPLYING APPROPRIATE ACCESSES (related)** - `CaesarLegionRecruit` was entirely missing from the access levels list in `IdCardConsoleComponent.cs`, which broke trysettag for that role. Then AllAccess for Chance.
- **#678 - SM LOG DMG ONLY APPLIES TO WIELDED WEAPONS. OTHERWISE JUST FLAT x2 DAMAGE** - The Oni system was applying a flat 2x multiplier to all melee damage, in addition to SuperMutantMeleeSystem.cs from https://github.com/Misfit-Sanctuary/nuclear-14/pull/619, replaced the flat coefficient approach with proper log application capped at 200f total and commented out SuperMutantMeleeSystem.cs so it is not duplicating. It was a copy of Oni system.

## Technical details

### RaidRequestMessages.cs
Added 80s faction to the raid request whitelist (+2 lines).

### supermutant.yml
Added `Hunger` component with `baseDecayRate: 0.024` to `N14BaseMobSuperMutant`.

### FactionWarSystem.cs
Added ghost check - prevents ghosts from declaring war and adds a secondary guard so `/war` can't target ghosts either. Admin aghost can still force war via F7.

### IdCardConsoleComponent.cs
Added missing `CaesarLegionRecruit` access level to the access list that broke access edits.

### all_access.yml (new)
New `AllAccess` tag prototype - consolidates what would otherwise be 50+ individual access tags into a single tag for admin use.

### identification.yml
New `N14IDCardAdmin` prototype ("admin ID card") using the `AllAccess` tag.

### OniSystem.cs
Reworked the damage formula - removed flat 2x coefficient approach in favor of proper log application. Damage cap of 200f total. This effectively undoes Dan's earlier approach from [#619](https://github.com/Misfit-Sanctuary/nuclear-14/pull/619), which was applying twice. SMs now have 2.0 base, then log. 

I.E
Melee = 30
Super Sledge 1hand = 36
Super Sledge Wielded = 200 (200 is max cap)

### SuperMutantMeleeSystem.cs
Commented out - this was duplicating logic already handled by `OniSystem.cs`. Chose to keep the native system over the copy.

### Locale files (`.ftl`)
Updated various job-name strings and locale entries.

## Media

N/A

# Changelog

:cl:
- add: Added 80s faction to /raid request system
- add: Added admin ID card with AllAccess tag
- add: Added 3x hunger drain rate for Super Mutants
- fix: Ghosts can no longer declare or receive war declarations
- fix: CaesarLegionRecruit access level now properly applies to trysettag
- fix: Super Mutant melee damage now uses proper log scaling instead of flat 2x multiplier (capped at 200f)
- tweak: Removed redundant SuperMutantMeleeSystem (already handled by OniSystem)