### PR TITLE
Projects Tracker | /Surrender

### DIFF
--- a/Content.Client/_Misfits/FactionWar/AllyTagOverlay.cs
+++ b/Content.Client/_Misfits/FactionWar/AllyTagOverlay.cs
@@ -186,9 +186,20 @@ internal sealed class AllyTagOverlay : Overlay
             if (!cacheEntry.Visible)
                 continue;
 
-            var isAlly = info.Side == effectiveSide.Value;
-            var tag = isAlly ? "[ALLY]" : "[ENEMY]";
-            var color = isAlly ? Color.LimeGreen : new Color(1f, 0.3f, 0.3f);
+            string tag;
+            Color color;
+
+            if (info.Surrendered)
+            {
+                tag = "[SURRENDERED]";
+                color = Color.White;
+            }
+            else
+            {
+                var isAlly = info.Side == effectiveSide.Value;
+                tag = isAlly ? "[ALLY]" : "[ENEMY]";
+                color = isAlly ? Color.LimeGreen : new Color(1f, 0.3f, 0.3f);
+            }
 
             var screenCoords = _eyeManager.WorldToScreen(
                 aabb.Center + new Angle(-_eyeManager.CurrentEye.Rotation)

--- a/Content.Client/_Misfits/FactionWar/FactionWarClientSystem.cs
+++ b/Content.Client/_Misfits/FactionWar/FactionWarClientSystem.cs
@@ -74,6 +74,12 @@ public sealed class FactionWarClientSystem : EntitySystem
             "Open the admin Force War panel.",
             "forcewar",
             OpenForceWarPanel);
+
+        _conHost.RegisterCommand(
+            "surrender",
+            "Surrender in an active war. You will be forced down, incapacitated, and marked as [SURRENDERED].",
+            "surrender",
+            OpenSurrender);
     }
 
     public override void Shutdown()
@@ -208,6 +214,13 @@ public sealed class FactionWarClientSystem : EntitySystem
 
         // Populate the admin panel with the latest online players and active wars.
         RaiseNetworkEvent(new FactionWarOpenPanelRequestEvent());
+    }
+
+    // ── /surrender client command ──────────────────────────────────────────
+
+    private void OpenSurrender(IConsoleShell shell, string argStr, string[] args)
+    {
+        RaiseNetworkEvent(new PlayerWarSurrenderRequestEvent());
     }
 
     // ── Window lifecycle ───────────────────────────────────────────────────

--- a/Content.Server/_Misfits/FactionWar/FactionWarSystem.cs
+++ b/Content.Server/_Misfits/FactionWar/FactionWarSystem.cs
@@ -20,6 +20,9 @@ using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.NPC.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;
@@ -50,9 +53,11 @@ public sealed class FactionWarSystem : EntitySystem
     [Dependency] private readonly IConsoleHost     _conHost       = default!;
     [Dependency] private readonly IPlayerManager   _playerManager = default!;
     [Dependency] private readonly IGameTiming      _gameTiming    = default!;
-    [Dependency] private readonly JobSystem        _jobs          = default!;
-    [Dependency] private readonly MindSystem       _minds         = default!;
-    [Dependency] private readonly NpcFactionSystem _npcFaction    = default!;
+    [Dependency] private readonly JobSystem         _jobs          = default!;
+    [Dependency] private readonly MindSystem        _minds         = default!;
+    [Dependency] private readonly NpcFactionSystem  _npcFaction    = default!;
+    [Dependency] private readonly SharedPopupSystem _popup         = default!;
+    [Dependency] private readonly SharedStunSystem  _stun          = default!;
 
     // ── Constants ──────────────────────────────────────────────────────────
 
@@ -128,6 +133,9 @@ public sealed class FactionWarSystem : EntitySystem
     /// </summary>
     private readonly HashSet<ICommonSession> _panelOpenSessions = new();
 
+    /// <summary>Participants who have surrendered, keyed by character entity.</summary>
+    private readonly HashSet<NetEntity> _surrenderedParticipants = new();
+
     // ── Performance gates ──────────────────────────────────────────────────
 
     private float _participantResyncAccumulator;
@@ -174,6 +182,9 @@ public sealed class FactionWarSystem : EntitySystem
         // Warjoin panel & enlistment.
         SubscribeNetworkEvent<FactionWarJoinPanelRequestEvent>(OnWarJoinPanelRequest);
         SubscribeNetworkEvent<PlayerWarJoinRequestEvent>(OnWarJoinRequest);
+
+        // Surrender.
+        SubscribeNetworkEvent<PlayerWarSurrenderRequestEvent>(OnSurrenderRequest);
 
         // Admin force-war GUI.
         SubscribeNetworkEvent<PlayerWarForceRequestEvent>(OnForceWarRequest);
@@ -942,6 +953,73 @@ public sealed class FactionWarSystem : EntitySystem
         SendJoinResult(player, true, $"You have joined the war on the side of {sideName}.");
     }
 
+    // ── Surrender ───────────────────────────────────────────────────────────
+
+    private void OnSurrenderRequest(PlayerWarSurrenderRequestEvent msg, EntitySessionEventArgs args)
+    {
+        var player = args.SenderSession;
+
+        if (player.Status != SessionStatus.InGame || player.AttachedEntity is not { } surrEntity)
+        {
+            _chat.DispatchServerMessage(player, "You must be in-game to surrender.");
+            return;
+        }
+
+        var surrNetEntity = GetNetEntity(surrEntity);
+
+        // Check if this entity is a war participant in an active war
+        if (!_warParticipants.TryGetValue(surrNetEntity, out var participantEntry))
+        {
+            _chat.DispatchServerMessage(player, "You are not in a war.");
+            return;
+        }
+
+        if (!_activeWars.TryGetValue(participantEntry.WarKey, out var war) || war.Phase != WarPhase.Active)
+        {
+            _chat.DispatchServerMessage(player, "The war is not active.");
+            return;
+        }
+
+        // Already surrendered
+        if (_surrenderedParticipants.Contains(surrNetEntity))
+        {
+            _chat.DispatchServerMessage(player, "You have already surrendered.");
+            return;
+        }
+
+        // Mark as surrendered
+        _surrenderedParticipants.Add(surrNetEntity);
+
+        // Drop all held weapons
+        RaiseLocalEvent(surrEntity, new DropHandItemsEvent());
+
+        // Paralyze them (stun only) — they can still see, hear, and type in chat
+        _stun.TryStun(surrEntity, TimeSpan.FromHours(1), true);
+
+        // Broadcast updated participant info so overlays update
+        BroadcastParticipants();
+
+        // Local flavortext popup only — no server-wide announcement
+        _popup.PopupEntity("You have surrendered. You are now at your enemy's mercy.", surrEntity, surrEntity);
+
+        // Send a direct server message to the surrendering player's chatbox
+        _chat.DispatchServerMessage(player, "You have surrendered. You are now at your enemy's mercy.");
+
+        // Notify all other participants in the same war that this player surrendered
+        var surrName = Name(surrEntity);
+        foreach (var (otherNetEntity, _) in war.Participants)
+        {
+            if (otherNetEntity == surrNetEntity)
+                continue;
+
+            var otherUid = GetEntity(otherNetEntity);
+            if (!TryComp<ActorComponent>(otherUid, out var actor))
+                continue;
+
+            _chat.DispatchServerMessage(actor.PlayerSession, $"{surrName} has surrendered. They are now at your mercy.");
+        }
+    }
+
     // ── Admin commands ─────────────────────────────────────────────────────
 
     private void WarEndCommand(IConsoleShell shell, string argStr, string[] args)
@@ -1145,6 +1223,7 @@ public sealed class FactionWarSystem : EntitySystem
         _activeWars.Clear();
         _warActivationTimes.Clear();
         _warParticipants.Clear();
+        _surrenderedParticipants.Clear();
         _playerWarCooldowns.Clear();
         _ceasefireCooldowns.Clear();
         _pendingCeasefireProposals.Clear();
@@ -1250,7 +1329,10 @@ public sealed class FactionWarSystem : EntitySystem
             .Select(kvp => kvp.Key)
             .ToList();
         foreach (var entity in toRemove)
+        {
             _warParticipants.Remove(entity);
+            _surrenderedParticipants.Remove(entity);
+        }
 
         war.History.Add(new WarHistoryEvent
         {
@@ -1318,6 +1400,7 @@ public sealed class FactionWarSystem : EntitySystem
                 {
                     Side = side,
                     WarKey = war.WarKey,
+                    Surrendered = _surrenderedParticipants.Contains(netEntity),
                 };
             }
         }

--- a/Content.Shared/_Misfits/FactionWar/FactionWarMessages.cs
+++ b/Content.Shared/_Misfits/FactionWar/FactionWarMessages.cs
@@ -296,6 +296,7 @@ public sealed class FactionWarParticipantInfo
 {
     public byte Side;
     public string WarKey = string.Empty;
+    public bool Surrendered;
 }
 
 /// <summary>
@@ -343,4 +344,23 @@ public sealed class PlayerWarForceCeasefireRequestEvent : EntityEventArgs
 {
     public NetUserId Player1;
     public NetUserId Player2;
+}
+
+// ── /surrender network messages ──────────────────────────────────────────
+
+/// <summary>
+/// Client → server. Player surrenders in an active war.
+/// Server will force them down, paralyze them, and mark them as surrendered.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class PlayerWarSurrenderRequestEvent : EntityEventArgs { }
+
+/// <summary>
+/// Server → client. Result of a surrender attempt.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class FactionWarSurrenderResultEvent : EntityEventArgs
+{
+    public bool   Success = false;
+    public string Message = string.Empty;
 }


### PR DESCRIPTION

## About the PR
<!-- What did you change? -->

Adds a `/surrender` command for players engaged in an active `/war`. Surrendering marks the player as `[SURRENDERED]` (white tag replacing `[ENEMY]` in the war overlay), drops their held weapons, paralyzes them so they can be captured or whatever, and notifies all war participants.

Closes **#673**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Gives players an alternative. Surrendering players become captives, or whichever their enemies decide. They can still see, hear, and type in chat, but cannot move or act. Their tag changes from `[ENEMY]` to `[SURRENDERED]` (white text) so the opposing side can visually identify them.

- Only available to war participants in an **active** war
- Weapons are dropped on surrender
- Surrender state automatically clears when the war ends, they die, or a round restart.
- War participants are notified of surrenders. Applies to enemies and allies...


## Technical details

**Shared** - Told the network that each war participant now carries a `Surrendered` flag, and added two new network message. One for the client to request surrender, one for the server to reply with the result.

**Server** - Hooks into the stun and popup systems. When a surrender comes in, it checks the player is actually in an active war, then stuns them (prevents movement/actions), fires the event that drops whatever they're holding, sends a chat message to them and everyone else in the war, and marks them surrendered so the overlay updates. The surrendered flag gets wiped automatically when the war ends, if they're 2tapped or the round restarts.

**Tag** - When drawing the floating `[ALLY]`/`[ENEMY]` tags above players, if the participant has surrendered, the overlay draws `[SURRENDERED]` in white text instead. Applies to both sides.

## Media
<!-- Attach media if the PR makes ingame changes -->

N/A

# Changelog

:cl: cythisiax
- add: Added /surrender command for active faction wars. Surrendering drops your weapons, paralyzes you, and marks you as [SURRENDERED] in the war overlay so the enemy can take you captive. That's it.
