### PR TITLE
RO + Ranger Loadout Fixes

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/loadouts_cosmetics.yml
+++ b/Resources/Prototypes/_Misfits/Roles/loadouts_cosmetics.yml
@@ -340,6 +340,7 @@
         - NCRCommander
         - NCRMajor
         - NCRDoctor
+        - NCRRO
   items:
     - N14ClothingHandsGlovesNCR
 
@@ -532,6 +533,7 @@
         - NCRCommander
         - NCRMajor
         - NCRDoctor
+        - NCRRO
   items:
     - N14ClothingHeadHatNCRSidecap
 
@@ -614,6 +616,7 @@
         - NCRVeteranRanger
         - NCRCitizen
         - NCRTrader
+        - NCRRO
   items:
     - N14ClothingHeadHatNCRSlouch
 
@@ -936,6 +939,7 @@
         - NCRCommander
         - NCRMajor
         - NCRDoctor
+        - NCRRO
   items:
     - N14ClothingNeckCloakNCR
 
@@ -963,6 +967,7 @@
         - NCRCommander
         - NCRMajor
         - NCRDoctor
+        - NCRRO
   items:
     - N14ClothingNeckCloakNCRSnow
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ncr.yml
@@ -24,6 +24,7 @@
         - NCRWS
         - NCRHeavyTrooper
         - NCRCadet
+        - NCRRO
 
         - NCRRangerRecruit
         - NCRFieldRanger
@@ -50,6 +51,7 @@
         - NCRWS
         - NCRHeavyTrooper
         - NCRCadet
+        - NCRRO
 
         - NCRRangerRecruit
         - NCRFieldRanger
@@ -76,6 +78,7 @@
         - NCRWS
         - NCRHeavyTrooper
         - NCRCadet
+        - NCRRO
 
         - NCRRangerRecruit
         - NCRFieldRanger
@@ -102,6 +105,7 @@
         - NCRWS
         - NCRHeavyTrooper
         - NCRCadet
+        - NCRRO
 
         - NCRRangerRecruit
         - NCRFieldRanger
@@ -128,6 +132,7 @@
         - NCRWS
         - NCRHeavyTrooper
         - NCRCadet
+        - NCRRO
 
         - NCRRangerRecruit
         - NCRFieldRanger
@@ -294,6 +299,7 @@
         - NCRVeteranRanger
         - NCRCitizen
         - NCRTrader
+        - NCRRO
   items:
     - N14ClothingUniformDesertPants
 
@@ -325,6 +331,7 @@
         - NCRVeteranRanger
         - NCRCitizen
         - NCRTrader
+        - NCRRO
   items:
     - N14ClothingUniformDesertPantsFull
 
@@ -354,6 +361,7 @@
         - NCRFieldRanger
         - NCRPatrolRanger
         - NCRVeteranRanger
+        - NCRRO
   items:
     - ClothingBeltNCRHarness
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/Roles/loadouts_ranger.yml
@@ -99,7 +99,9 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRFieldRanger # #Misfits Fix - renamed from NCRRanger
+        - NCRRangerRecruit
+        - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingHeadHatRangerB
@@ -112,7 +114,9 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRFieldRanger # #Misfits Fix - renamed from NCRRanger
+        - NCRRangerRecruit
+        - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingHeadHatNCRBeretRecon
@@ -137,7 +141,9 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRFieldRanger # #Misfits Fix - renamed from NCRRanger
+        - NCRRangerRecruit
+        - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingUniformRangerV1
@@ -150,7 +156,9 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRFieldRanger # #Misfits Fix - renamed from NCRRanger
+        - NCRRangerRecruit
+        - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingUniformRangerV2
@@ -163,7 +171,9 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRFieldRanger # #Misfits Fix - renamed from NCRRanger
+        - NCRRangerRecruit
+        - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingUniformRangerV3
@@ -176,7 +186,9 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRFieldRanger # #Misfits Fix - renamed from NCRRanger
+        - NCRRangerRecruit
+        - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingHandsGlovesNCR
@@ -243,7 +255,9 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRFieldRanger # #Misfits Fix - renamed from NCRRanger
+        - NCRRangerRecruit
+        - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingUniformRangerBlue
@@ -256,7 +270,9 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRFieldRanger # #Misfits Fix - renamed from NCRRanger
+        - NCRRangerRecruit
+        - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - N14ClothingUniformRangerModif
@@ -269,7 +285,8 @@
   requirements:
     - !type:CharacterJobRequirement
       jobs:
-        - NCRFieldRanger # #Misfits Fix - renamed from NCRRanger
+        - NCRFieldRanger
+        - NCRPatrolRanger
         - NCRVeteranRanger
   items:
     - ClothingNeckOldMantle


### PR DESCRIPTION
## About the PR
What this PR does is fixes most of the NCR stuff to allow the RO is use them. Im assuming this was a oversight same goes with the other rangers not getting the drip the loadout menu can get.

## Media
N/A


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Oli
- tweak: Loadout Items to RO + Other Rangers
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
