### PR TITLE
Rank Pin Update

### DIFF
--- a/Content.Client/_Misfits/Clothing/Pins/ClothingPinVisualsSystem.cs
+++ b/Content.Client/_Misfits/Clothing/Pins/ClothingPinVisualsSystem.cs
@@ -1,0 +1,97 @@
+using Content.Client.Clothing;
+using Content.Shared._Misfits.Clothing.Pins;
+using Content.Shared.Clothing;
+using Content.Shared.Clothing.Components;
+using Content.Shared.Item;
+using Robust.Client.GameObjects;
+using Robust.Shared.Containers;
+using Robust.Shared.Serialization.Manager;
+
+namespace Content.Client._Misfits.Clothing.Pins;
+
+/// <summary>
+/// Adds attached pin clothing visuals to the worn clothing item.
+/// </summary>
+public sealed class ClothingPinVisualsSystem : EntitySystem
+{
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly SharedItemSystem _item = default!;
+    [Dependency] private readonly ISerializationManager _serialization = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ClothingPinHolderComponent, GetEquipmentVisualsEvent>(OnGetEquipmentVisuals, after: [typeof(ClientClothingSystem)]);
+        SubscribeLocalEvent<ClothingPinHolderComponent, EntInsertedIntoContainerMessage>(OnContainerChanged);
+        SubscribeLocalEvent<ClothingPinHolderComponent, EntRemovedFromContainerMessage>(OnContainerChanged);
+        SubscribeLocalEvent<ClothingPinHolderComponent, AfterAutoHandleStateEvent>(OnAfterState);
+    }
+
+    private void OnGetEquipmentVisuals(Entity<ClothingPinHolderComponent> ent, ref GetEquipmentVisualsEvent args)
+    {
+        if (!_containers.TryGetContainer(ent, ent.Comp.ContainerId, out var container))
+            return;
+
+        var index = 0;
+        foreach (var pin in container.ContainedEntities)
+        {
+            if (!TryComp<ClothingComponent>(pin, out var clothing))
+                continue;
+
+            if (!clothing.ClothingVisuals.TryGetValue("neck", out var layers))
+                continue;
+
+            foreach (var layer in layers)
+            {
+                var attachedLayer = _serialization.CreateCopy(layer, notNullableOverride: true);
+
+                // Explicitly use the pin RSI. Otherwise the layer falls back to the
+                // uniform/armor RSI and missing pin states render as error textures.
+                if (string.IsNullOrWhiteSpace(attachedLayer.RsiPath))
+                {
+                    attachedLayer.RsiPath = GetPinRsiPath(pin, clothing);
+
+                    if (attachedLayer.RsiPath == null)
+                        continue;
+                }
+
+                args.Layers.Add(($"misfits-clothing-pin-{pin.Id}-{index}", attachedLayer));
+                index++;
+            }
+        }
+    }
+
+    private string? GetPinRsiPath(EntityUid pin, ClothingComponent clothing)
+    {
+        if (!string.IsNullOrWhiteSpace(clothing.Sprite))
+            return NormalizeRelativeRsiPath(clothing.Sprite);
+
+        return TryComp<SpriteComponent>(pin, out var sprite)
+            ? sprite.BaseRSI?.Path.CanonPath
+            : null;
+    }
+
+    private static string NormalizeRelativeRsiPath(string path)
+    {
+        path = path.TrimStart('/');
+
+        const string textureRoot = "Textures/";
+        return path.StartsWith(textureRoot, StringComparison.Ordinal)
+            ? path[textureRoot.Length..]
+            : path;
+    }
+
+    private void OnContainerChanged(Entity<ClothingPinHolderComponent> ent, ref EntInsertedIntoContainerMessage args)
+    {
+        _item.VisualsChanged(ent.Owner);
+    }
+
+    private void OnContainerChanged(Entity<ClothingPinHolderComponent> ent, ref EntRemovedFromContainerMessage args)
+    {
+        _item.VisualsChanged(ent.Owner);
+    }
+
+    private void OnAfterState(Entity<ClothingPinHolderComponent> ent, ref AfterAutoHandleStateEvent args)
+    {
+        _item.VisualsChanged(ent.Owner);
+    }
+}

--- a/Content.Server/_Misfits/Clothing/Pins/ClothingPinSystem.cs
+++ b/Content.Server/_Misfits/Clothing/Pins/ClothingPinSystem.cs
@@ -1,0 +1,131 @@
+using Content.Shared._Misfits.Clothing.Pins;
+using Content.Shared.Clothing.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Item;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Robust.Shared.Containers;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Misfits.Clothing.Pins;
+
+/// <summary>
+/// Lets pin items be attached to inner or outer clothing, mirroring RMC's
+/// uniform accessory interaction model without requiring every clothing proto
+/// to define a holder component up front.
+/// </summary>
+public sealed class ClothingPinSystem : EntitySystem
+{
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedItemSystem _item = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    private static readonly SlotFlags PinSlots = SlotFlags.INNERCLOTHING | SlotFlags.OUTERCLOTHING;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ClothingComponent, InteractUsingEvent>(OnClothingInteractUsing);
+        SubscribeLocalEvent<ClothingPinHolderComponent, GetVerbsEvent<EquipmentVerb>>(OnGetEquipmentVerbs);
+        SubscribeLocalEvent<ClothingPinHolderComponent, ComponentInit>(OnHolderInit);
+    }
+
+    private void OnHolderInit(Entity<ClothingPinHolderComponent> ent, ref ComponentInit args)
+    {
+        _containers.EnsureContainer<Container>(ent, ent.Comp.ContainerId);
+    }
+
+    private void OnClothingInteractUsing(Entity<ClothingComponent> ent, ref InteractUsingEvent args)
+    {
+        if (args.Handled || !TryComp<ClothingPinComponent>(args.Used, out var pin))
+            return;
+
+        args.Handled = TryAttachPin(args.Used, pin, ent, args.User);
+    }
+
+    private void OnGetEquipmentVerbs(Entity<ClothingPinHolderComponent> ent, ref GetVerbsEvent<EquipmentVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (!_containers.TryGetContainer(ent, ent.Comp.ContainerId, out var container) ||
+            container.ContainedEntities.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var pin in container.ContainedEntities)
+        {
+            var user = args.User;
+            args.Verbs.Add(new EquipmentVerb
+            {
+                Text = Loc.GetString("clothing-pin-remove-verb", ("pin", Name(pin))),
+                IconEntity = GetNetEntity(pin),
+                Act = () => TryRemovePin(ent, pin, user),
+            });
+        }
+    }
+
+    public bool TryAttachPin(EntityUid pinUid, ClothingPinComponent pin, Entity<ClothingComponent> clothingEnt, EntityUid user)
+    {
+        if (!TryComp<ClothingComponent>(pinUid, out _))
+            return false;
+
+        if ((clothingEnt.Comp.Slots & PinSlots) == SlotFlags.NONE)
+        {
+            _popup.PopupEntity(Loc.GetString("clothing-pin-attach-fail-slot"), user, user, PopupType.SmallCaution);
+            return false;
+        }
+
+        var holder = EnsureComp<ClothingPinHolderComponent>(clothingEnt.Owner);
+        var container = _containers.EnsureContainer<Container>(clothingEnt.Owner, holder.ContainerId);
+
+        if (!holder.AllowedCategories.Contains(pin.Category))
+        {
+            _popup.PopupEntity(Loc.GetString("clothing-pin-attach-fail-category"), user, user, PopupType.SmallCaution);
+            return false;
+        }
+
+        var sameCategory = 0;
+        foreach (var contained in container.ContainedEntities)
+        {
+            if (TryComp<ClothingPinComponent>(contained, out var containedPin) &&
+                containedPin.Category == pin.Category)
+            {
+                sameCategory++;
+            }
+        }
+
+        if (sameCategory >= pin.Limit)
+        {
+            _popup.PopupEntity(Loc.GetString("clothing-pin-attach-fail-limit"), user, user, PopupType.SmallCaution);
+            return false;
+        }
+
+        if (!_containers.Insert(pinUid, container))
+            return false;
+
+        _item.VisualsChanged(clothingEnt.Owner);
+        _popup.PopupEntity(Loc.GetString("clothing-pin-attached",
+            ("pin", Name(pinUid)),
+            ("clothing", Name(clothingEnt.Owner))), user, user);
+
+        return true;
+    }
+
+    private void TryRemovePin(Entity<ClothingPinHolderComponent> holder, EntityUid pin, EntityUid user)
+    {
+        if (!_containers.TryGetContainer(holder, holder.Comp.ContainerId, out var container) ||
+            !container.Contains(pin) ||
+            !_containers.Remove(pin, container))
+        {
+            return;
+        }
+
+        _hands.PickupOrDrop(user, pin);
+        _item.VisualsChanged(holder.Owner);
+    }
+}

--- a/Content.Server/_Misfits/RankTitle/RankTitleSystem.cs
+++ b/Content.Server/_Misfits/RankTitle/RankTitleSystem.cs
@@ -1,36 +1,71 @@
 using Content.Server.Access.Systems;
+using Content.Shared._Misfits.Clothing.Pins;
 using Content.Shared._Misfits.RankTitle;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
+using Robust.Shared.Containers;
 using Robust.Shared.Utility;
 
 namespace Content.Server._Misfits.RankTitle;
 
 /// <summary>
-/// When a <see cref="RankTitleComponent"/> item is worn in the neck slot:
-/// — writes the rank title onto the wearer's ID card so the identity system
-///   can display it in the "young private woman" description line.
-/// — adds "She is wearing a private pin." to the character examine text.
+/// Applies the visible rank title from a neck-worn rank pin, or from a rank pin
+/// attached to equipped inner/outer clothing.
 /// </summary>
 public sealed class RankTitleSystem : EntitySystem
 {
     [Dependency] private readonly IdCardSystem _idCard = default!;
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
 
     public override void Initialize()
     {
         SubscribeLocalEvent<RankTitleComponent, GotEquippedEvent>(OnEquip);
         SubscribeLocalEvent<RankTitleComponent, GotUnequippedEvent>(OnUnequip);
+        SubscribeLocalEvent<ClothingPinHolderComponent, GotEquippedEvent>(OnPinHolderEquip);
+        SubscribeLocalEvent<ClothingPinHolderComponent, GotUnequippedEvent>(OnPinHolderUnequip);
+        SubscribeLocalEvent<ClothingPinHolderComponent, EntInsertedIntoContainerMessage>(OnPinHolderContainerChanged);
+        SubscribeLocalEvent<ClothingPinHolderComponent, EntRemovedFromContainerMessage>(OnPinHolderContainerChanged);
         SubscribeLocalEvent<InventoryComponent, ExaminedEvent>(OnExamined);
     }
 
     private void OnEquip(EntityUid uid, RankTitleComponent comp, GotEquippedEvent args)
-        => SetRankTitle(args.Equipee, comp.RankTitle);
+        => RefreshRankTitle(args.Equipee);
 
     private void OnUnequip(EntityUid uid, RankTitleComponent comp, GotUnequippedEvent args)
-        => SetRankTitle(args.Equipee, null);
+        => RefreshRankTitle(args.Equipee);
+
+    private void OnPinHolderEquip(EntityUid uid, ClothingPinHolderComponent comp, GotEquippedEvent args)
+        => RefreshRankTitle(args.Equipee);
+
+    private void OnPinHolderUnequip(EntityUid uid, ClothingPinHolderComponent comp, GotUnequippedEvent args)
+        => RefreshRankTitle(args.Equipee);
+
+    private void OnPinHolderContainerChanged(EntityUid uid, ClothingPinHolderComponent comp, EntInsertedIntoContainerMessage args)
+    {
+        if (TryGetWearer(uid, out var wearer))
+            RefreshRankTitle(wearer);
+    }
+
+    private void OnPinHolderContainerChanged(EntityUid uid, ClothingPinHolderComponent comp, EntRemovedFromContainerMessage args)
+    {
+        if (TryGetWearer(uid, out var wearer))
+            RefreshRankTitle(wearer);
+    }
+
+    private void RefreshRankTitle(EntityUid wearer)
+    {
+        if (TryGetRankPin(wearer, out var rankPin) &&
+            TryComp<RankTitleComponent>(rankPin, out var rankComp))
+        {
+            SetRankTitle(wearer, rankComp.RankTitle);
+            return;
+        }
+
+        SetRankTitle(wearer, null);
+    }
 
     private void SetRankTitle(EntityUid wearer, string? rankTitle)
     {
@@ -42,18 +77,66 @@ public sealed class RankTitleSystem : EntitySystem
 
     private void OnExamined(EntityUid uid, InventoryComponent _, ExaminedEvent args)
     {
-        if (!_inventory.TryGetSlotEntity(uid, "neck", out var neckItem) || neckItem == null)
+        if (!TryGetRankPin(uid, out var rankPin) ||
+            !TryComp<RankTitleComponent>(rankPin, out var rankComp))
             return;
 
-        if (!TryComp<RankTitleComponent>(neckItem.Value, out var rankComp) || rankComp == null)
-            return;
-
-        var itemName = FormattedMessage.EscapeText(Name(neckItem.Value));
+        var rankTitle = FormattedMessage.EscapeText(rankComp.RankTitle);
         using (args.PushGroup(nameof(RankTitleComponent)))
         {
             args.PushMarkup(Loc.GetString("rank-pin-examine",
                 ("user", Identity.Entity(uid, EntityManager)),
-                ("item", itemName)));
+                ("rank", rankTitle)));
         }
+    }
+
+    private bool TryGetRankPin(EntityUid wearer, out EntityUid rankPin)
+    {
+        rankPin = default;
+
+        if (_inventory.TryGetSlotEntity(wearer, "neck", out var neckItem) &&
+            neckItem != null &&
+            HasComp<RankTitleComponent>(neckItem.Value))
+        {
+            rankPin = neckItem.Value;
+            return true;
+        }
+
+        var slots = _inventory.GetSlotEnumerator(wearer, SlotFlags.INNERCLOTHING | SlotFlags.OUTERCLOTHING);
+        while (slots.MoveNext(out var slot))
+        {
+            if (slot.ContainedEntity == null ||
+                !TryComp<ClothingPinHolderComponent>(slot.ContainedEntity.Value, out var holder) ||
+                !_containers.TryGetContainer(slot.ContainedEntity.Value, holder.ContainerId, out var container))
+            {
+                continue;
+            }
+
+            foreach (var pin in container.ContainedEntities)
+            {
+                if (!HasComp<RankTitleComponent>(pin))
+                    continue;
+
+                rankPin = pin;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryGetWearer(EntityUid clothing, out EntityUid wearer)
+    {
+        wearer = default;
+
+        if (!_inventory.TryGetContainingSlot(clothing, out _) ||
+            !_containers.TryGetContainingContainer((clothing, (TransformComponent?) null, (MetaDataComponent?) null), out var container) ||
+            !HasComp<InventoryComponent>(container.Owner))
+        {
+            return false;
+        }
+
+        wearer = container.Owner;
+        return true;
     }
 }

--- a/Content.Shared/_Misfits/Clothing/Pins/ClothingPinComponent.cs
+++ b/Content.Shared/_Misfits/Clothing/Pins/ClothingPinComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Misfits.Clothing.Pins;
+
+/// <summary>
+/// Allows this item to be attached to compatible clothing.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ClothingPinComponent : Component
+{
+    /// <summary>
+    /// Pins with the same category share a per-clothing limit.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string Category = "pin";
+
+    /// <summary>
+    /// Maximum number of pins in this category that can be attached to one clothing item.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int Limit = 1;
+}

--- a/Content.Shared/_Misfits/Clothing/Pins/ClothingPinHolderComponent.cs
+++ b/Content.Shared/_Misfits/Clothing/Pins/ClothingPinHolderComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Misfits.Clothing.Pins;
+
+/// <summary>
+/// Runtime holder for clothing pins attached to a clothing item.
+/// Added lazily when a pin is attached, so clothing prototypes do not need to opt in individually.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+public sealed partial class ClothingPinHolderComponent : Component
+{
+    public const string DefaultContainerId = "misfits_clothing_pins";
+
+    [DataField, AutoNetworkedField]
+    public string ContainerId = DefaultContainerId;
+
+    [DataField, AutoNetworkedField]
+    public List<string> AllowedCategories = new() { "pin" };
+}

--- a/Resources/Locale/en-US/_Misfits/rank-pin.ftl
+++ b/Resources/Locale/en-US/_Misfits/rank-pin.ftl
@@ -1,1 +1,6 @@
-rank-pin-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } wearing a { $item }.
+rank-pin-examine = { CAPITALIZE(POSS-ADJ($user)) } rank is { $rank }.
+clothing-pin-attached = You attach the { $pin } to the { $clothing }.
+clothing-pin-remove-verb = Remove { $pin }
+clothing-pin-attach-fail-slot = You can only attach pins to uniforms or outer clothing.
+clothing-pin-attach-fail-category = That pin cannot be attached to this clothing.
+clothing-pin-attach-fail-limit = There is already a pin attached to this clothing.

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -7,6 +7,7 @@
   components:
   - type: Item
     size: Tiny
+  - type: ClothingPin
   - type: DamageOtherOnHit
     damage:
       types:


### PR DESCRIPTION
## About the PR
Adds a clothing pin attachment system. Pins can now be attached to uniforms and outer clothing instead of only being worn in the neck slot.

Rank pins still apply rank titles when worn on the neck, and now also apply rank titles when attached to worn clothing.

## Why / Balance
This makes rank pins less restrictive by allowing players to display them on clothing while keeping the neck slot free for other items.

## Technical details
Added shared `ClothingPin` and `ClothingPinHolder` components, plus server-side attach/remove behavior.

Attached pins are stored inside a clothing container and can be removed through an equipment verb. Client visuals reuse the pin’s existing neck-equipped sprite so attached pins match how they look when worn normally.

Updated rank title logic to detect rank pins attached to equipped inner or outer clothing. Examine text now shows the wearer’s rank directly instead of saying they are wearing a pin.

# Changelog

:cl:
- add: Pins can now be attached to uniforms and outer clothing.
- tweak: Rank pins attached to clothing now apply rank titles.
- tweak: Examining someone with a rank pin now shows their rank directly.