### PR TITLE
Project Tracker | Bike HP, Dog Force-Down, Forge, Walls, Stipends

### DIFF
--- a/Content.Client/_Misfits/FactionWar/AllyTagOverlay.cs
+++ b/Content.Client/_Misfits/FactionWar/AllyTagOverlay.cs
@@ -186,9 +186,20 @@ internal sealed class AllyTagOverlay : Overlay
             if (!cacheEntry.Visible)
                 continue;
 
-            var isAlly = info.Side == effectiveSide.Value;
-            var tag = isAlly ? "[ALLY]" : "[ENEMY]";
-            var color = isAlly ? Color.LimeGreen : new Color(1f, 0.3f, 0.3f);
+            string tag;
+            Color color;
+
+            if (info.Surrendered)
+            {
+                tag = "[SURRENDERED]";
+                color = Color.White;
+            }
+            else
+            {
+                var isAlly = info.Side == effectiveSide.Value;
+                tag = isAlly ? "[ALLY]" : "[ENEMY]";
+                color = isAlly ? Color.LimeGreen : new Color(1f, 0.3f, 0.3f);
+            }
 
             var screenCoords = _eyeManager.WorldToScreen(
                 aabb.Center + new Angle(-_eyeManager.CurrentEye.Rotation)

--- a/Content.Client/_Misfits/FactionWar/FactionWarClientSystem.cs
+++ b/Content.Client/_Misfits/FactionWar/FactionWarClientSystem.cs
@@ -74,6 +74,12 @@ public sealed class FactionWarClientSystem : EntitySystem
             "Open the admin Force War panel.",
             "forcewar",
             OpenForceWarPanel);
+
+        _conHost.RegisterCommand(
+            "surrender",
+            "Surrender in an active war. You will be forced down, incapacitated, and marked as [SURRENDERED].",
+            "surrender",
+            OpenSurrender);
     }
 
     public override void Shutdown()
@@ -208,6 +214,13 @@ public sealed class FactionWarClientSystem : EntitySystem
 
         // Populate the admin panel with the latest online players and active wars.
         RaiseNetworkEvent(new FactionWarOpenPanelRequestEvent());
+    }
+
+    // ── /surrender client command ──────────────────────────────────────────
+
+    private void OpenSurrender(IConsoleShell shell, string argStr, string[] args)
+    {
+        RaiseNetworkEvent(new PlayerWarSurrenderRequestEvent());
     }
 
     // ── Window lifecycle ───────────────────────────────────────────────────

--- a/Content.Server/_Misfits/FactionWar/FactionWarSystem.cs
+++ b/Content.Server/_Misfits/FactionWar/FactionWarSystem.cs
@@ -20,6 +20,9 @@ using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.NPC.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Standing;
+using Content.Shared.Stunnable;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;
@@ -50,9 +53,11 @@ public sealed class FactionWarSystem : EntitySystem
     [Dependency] private readonly IConsoleHost     _conHost       = default!;
     [Dependency] private readonly IPlayerManager   _playerManager = default!;
     [Dependency] private readonly IGameTiming      _gameTiming    = default!;
-    [Dependency] private readonly JobSystem        _jobs          = default!;
-    [Dependency] private readonly MindSystem       _minds         = default!;
-    [Dependency] private readonly NpcFactionSystem _npcFaction    = default!;
+    [Dependency] private readonly JobSystem         _jobs          = default!;
+    [Dependency] private readonly MindSystem        _minds         = default!;
+    [Dependency] private readonly NpcFactionSystem  _npcFaction    = default!;
+    [Dependency] private readonly SharedPopupSystem _popup         = default!;
+    [Dependency] private readonly SharedStunSystem  _stun          = default!;
 
     // ── Constants ──────────────────────────────────────────────────────────
 
@@ -128,6 +133,9 @@ public sealed class FactionWarSystem : EntitySystem
     /// </summary>
     private readonly HashSet<ICommonSession> _panelOpenSessions = new();
 
+    /// <summary>Participants who have surrendered, keyed by character entity.</summary>
+    private readonly HashSet<NetEntity> _surrenderedParticipants = new();
+
     // ── Performance gates ──────────────────────────────────────────────────
 
     private float _participantResyncAccumulator;
@@ -174,6 +182,9 @@ public sealed class FactionWarSystem : EntitySystem
         // Warjoin panel & enlistment.
         SubscribeNetworkEvent<FactionWarJoinPanelRequestEvent>(OnWarJoinPanelRequest);
         SubscribeNetworkEvent<PlayerWarJoinRequestEvent>(OnWarJoinRequest);
+
+        // Surrender.
+        SubscribeNetworkEvent<PlayerWarSurrenderRequestEvent>(OnSurrenderRequest);
 
         // Admin force-war GUI.
         SubscribeNetworkEvent<PlayerWarForceRequestEvent>(OnForceWarRequest);
@@ -942,6 +953,73 @@ public sealed class FactionWarSystem : EntitySystem
         SendJoinResult(player, true, $"You have joined the war on the side of {sideName}.");
     }
 
+    // ── Surrender ───────────────────────────────────────────────────────────
+
+    private void OnSurrenderRequest(PlayerWarSurrenderRequestEvent msg, EntitySessionEventArgs args)
+    {
+        var player = args.SenderSession;
+
+        if (player.Status != SessionStatus.InGame || player.AttachedEntity is not { } surrEntity)
+        {
+            _chat.DispatchServerMessage(player, "You must be in-game to surrender.");
+            return;
+        }
+
+        var surrNetEntity = GetNetEntity(surrEntity);
+
+        // Check if this entity is a war participant in an active war
+        if (!_warParticipants.TryGetValue(surrNetEntity, out var participantEntry))
+        {
+            _chat.DispatchServerMessage(player, "You are not in a war.");
+            return;
+        }
+
+        if (!_activeWars.TryGetValue(participantEntry.WarKey, out var war) || war.Phase != WarPhase.Active)
+        {
+            _chat.DispatchServerMessage(player, "The war is not active.");
+            return;
+        }
+
+        // Already surrendered
+        if (_surrenderedParticipants.Contains(surrNetEntity))
+        {
+            _chat.DispatchServerMessage(player, "You have already surrendered.");
+            return;
+        }
+
+        // Mark as surrendered
+        _surrenderedParticipants.Add(surrNetEntity);
+
+        // Drop all held weapons
+        RaiseLocalEvent(surrEntity, new DropHandItemsEvent());
+
+        // Paralyze them (stun only) — they can still see, hear, and type in chat
+        _stun.TryStun(surrEntity, TimeSpan.FromHours(1), true);
+
+        // Broadcast updated participant info so overlays update
+        BroadcastParticipants();
+
+        // Local flavortext popup only — no server-wide announcement
+        _popup.PopupEntity("You have surrendered. You are now at your enemy's mercy.", surrEntity, surrEntity);
+
+        // Send a direct server message to the surrendering player's chatbox
+        _chat.DispatchServerMessage(player, "You have surrendered. You are now at your enemy's mercy.");
+
+        // Notify all other participants in the same war that this player surrendered
+        var surrName = Name(surrEntity);
+        foreach (var (otherNetEntity, _) in war.Participants)
+        {
+            if (otherNetEntity == surrNetEntity)
+                continue;
+
+            var otherUid = GetEntity(otherNetEntity);
+            if (!TryComp<ActorComponent>(otherUid, out var actor))
+                continue;
+
+            _chat.DispatchServerMessage(actor.PlayerSession, $"{surrName} has surrendered. They are now at your mercy.");
+        }
+    }
+
     // ── Admin commands ─────────────────────────────────────────────────────
 
     private void WarEndCommand(IConsoleShell shell, string argStr, string[] args)
@@ -1145,6 +1223,7 @@ public sealed class FactionWarSystem : EntitySystem
         _activeWars.Clear();
         _warActivationTimes.Clear();
         _warParticipants.Clear();
+        _surrenderedParticipants.Clear();
         _playerWarCooldowns.Clear();
         _ceasefireCooldowns.Clear();
         _pendingCeasefireProposals.Clear();
@@ -1250,7 +1329,10 @@ public sealed class FactionWarSystem : EntitySystem
             .Select(kvp => kvp.Key)
             .ToList();
         foreach (var entity in toRemove)
+        {
             _warParticipants.Remove(entity);
+            _surrenderedParticipants.Remove(entity);
+        }
 
         war.History.Add(new WarHistoryEvent
         {
@@ -1318,6 +1400,7 @@ public sealed class FactionWarSystem : EntitySystem
                 {
                     Side = side,
                     WarKey = war.WarKey,
+                    Surrendered = _surrenderedParticipants.Contains(netEntity),
                 };
             }
         }

--- a/Content.Shared/_Misfits/FactionWar/FactionWarMessages.cs
+++ b/Content.Shared/_Misfits/FactionWar/FactionWarMessages.cs
@@ -296,6 +296,7 @@ public sealed class FactionWarParticipantInfo
 {
     public byte Side;
     public string WarKey = string.Empty;
+    public bool Surrendered;
 }
 
 /// <summary>
@@ -343,4 +344,23 @@ public sealed class PlayerWarForceCeasefireRequestEvent : EntityEventArgs
 {
     public NetUserId Player1;
     public NetUserId Player2;
+}
+
+// ── /surrender network messages ──────────────────────────────────────────
+
+/// <summary>
+/// Client → server. Player surrenders in an active war.
+/// Server will force them down, paralyze them, and mark them as surrendered.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class PlayerWarSurrenderRequestEvent : EntityEventArgs { }
+
+/// <summary>
+/// Server → client. Result of a surrender attempt.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class FactionWarSurrenderResultEvent : EntityEventArgs
+{
+    public bool   Success = false;
+    public string Message = string.Empty;
 }

--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -6762,3 +6762,22 @@ Entries:
   id: 6046
   time: '2026-06-11T01:32:51.0000000+00:00'
   url: https://github.com/Misfit-Sanctuary/nuclear-14/pull/746
+- author: cythisiax
+  changes:
+    - type: Add
+      message: >-
+        Added cross-compatible bun + meat burger recipes (upstream bun now works
+        with N14 meats and vice versa)
+    - type: Add
+      message: >-
+        Added microwave cooking recipes for radhog, pigrat, fire gecko, golden
+        gecko, iguana, squirrel, and radchicken etc.
+    - type: Add
+      message: >-
+        Added craftable duck burger recipe just because it was there. Not sure
+        there are even ducks on tile lol.
+    - type: Fix
+      message: Fixed FoodBreadBun and N14CookedFoodBreadBun not being cross-compatible.
+  id: 6047
+  time: '2026-06-11T02:45:50.0000000+00:00'
+  url: https://github.com/Misfit-Sanctuary/nuclear-14/pull/747


### PR DESCRIPTION
## About the PR
Batch of fixes and features from the development priority board.

## Why / Balance
- Motorbike HP - 80's faction bikes were too fragile, 3x durability makes them usable in combat.
- Dog Force Down - player-controlled pets had no way to force targets down. They now have the right-click Force Down verb like any MobHuman.
- Forge discoverability - forge construction was hidden in the Machines category; now also appears in Structures so it is findable.
- Cobblebrick walls - two new wall types for base building variety (cobblestone brick and basalt brick).
- Faction stipends - gives faction members a reason to engage with the persistent currency system outside of ... Yeah. Rank-based pay incentivizes climbing the ladder I guess, and technically also contributes to **#92**

## Technical details
#724  - Increase 80's motorbike HP
- Added Destructible override to N14VehicleBikeGreen with 150/300 thresholds (was 50/100 from BaseVehicle).

#695  - Let dogs force people down
- Added OwnInteractionVerbs to N14MobPetBasic with ForceDown in allowed verbs list (dogs already had Hands component, just needed the verb).

#696  - Make industrial forges craftable
- Added duplicate construction entry MisfitsForge in the Structures category referencing the existing N14WorkbenchForge construction graph (was only in Machines category. Pretty sure someone already did this as it is a duplicate, but it is now in two sections..... Just someone forgot to close tracker? Didn't test prior as I didn't find it.).

#727 - Add more blocks/tiles/carpet to crafting
- New construction graph MisfitsCobblebrickWall for cobblestone brick (WallCobblebrick) and basalt brick (WallBasaltCobblebrick) walls.  More to come eventually. So, maybe not close #727 

#728 - Faction stipend payments
- Configurable via YAML entities with MisfitsFactionStipend component. Currently configured: NCR, CaesarLegion, BrotherhoodOfSteel, Enclave, Rangers.
- Rank-based pay scale: CO (index 0) = 600 caps, lowest enlisted = 40 caps, linear interpolation between.
- 30-minute payout interval. Green chat message on payment.

((NOTES I DID NOT CHECK EVERY FACTION AS I HAVE TO WAIT 30 MINUTES. TRIED ON NCR WORKER, IT WORKED. HAHA. WORKER AND WORKED. Do we want admin verb to force pay?))


## Media
N/A

## Changelog

:cl: Cythisiax
- add: Increased 80's motorbike HP (3x tougher).
- tweak: Player-controlled dogs now have the Force Down verb in their right-click menu.
- add: Forge is now craftable from the Structures construction tab. (Duplicate, lol, moved from machines only to structures.)
- add: Cobblestone brick and basalt brick walls are now buildable via construction menu. (More to add)
- add: Faction members now receive rank-based cap payments every 30 minutes (direct deposit to wallet).
- fix: 80's motorbikes no longer die if an SM sneezes on it.