### PR TITLE
Fix "Wasteland Announcement Announcement"

### DIFF
--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -1,7 +1,7 @@
 ## RoundEndSystem
 
 # Misfits Change - renamed "shuttle" to "train" for wasteland theme
-round-end-system-shuttle-announcement-sender = Wasteland Announcement
+round-end-system-shuttle-announcement-sender = Wasteland
 # round-end-system-shuttle-called-announcement = An emergency shuttle has been sent. ETA: {$time} {$units}.
 round-end-system-shuttle-called-announcement = A train has been dispatched. ETA: {$duration}. Board it or fall back to your bunkers.
 round-end-system-shuttle-countdown-announcement = The train is due in {$duration}. Board it or fall back to your bunkers.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR

**FIXES "Wasteland Announcement Announcement"!!!!!**

This ONE line has pissed me off so much I needed to spend an hour of my time digging through the code, and eventually through old PRs to do this One-Liner. GONE are the days where Wasteland Announcement Announcement tells us when the non-existent train is arriving!

### Explaination

The way Space Station 14 titles announcements is fairly simple. Most LocalHosts get a grasp of this when messing around with the "Announce" command: The game considers the "Announcer" to be the phrase or phrases at the start of the Announcement, and calls for "Announcement" to be tacked on to every title. So, if your Announcer is "Central Command", your announcement will come up as Central Command Announcement. 

round-end-system.ftl INSTEAD has the announcer named as "Wasteland Announcement", causing every single call related to the Train/Shuttle to come up as "Wasteland Announcement Announcement", as the game doesn't check who the announcer is, it simply adds "Announcement" to the end of their announcement.

or at least that's my understanding of it. regardless we've finally killed Announcement Announcement guys

new drinking game. take a shot every time I typed "Announce" in this PR.

+



# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:

- fix: The automatic Wasteland Announcement is now less redundant.
