### PR TITLE
RE: C-27 WASTER NOT SPAWNING WITH THEIR LIGHT ARMOR VARIANT

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/C27/c27.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/C27/c27.yml
@@ -149,9 +149,12 @@
 - type: startingGear
   id: C27GearGeneric
   equipment:
+    head: ClothingC27HelmetLightGeneric    
     jumpsuit: ClothingC27Chassis
+    pocket1: N14Welder #they're C-27s they cant use bandages l0l -pierow
     ears: MisfitsClothingHeadsetWastelandScrap
     id: N14ClothingNeckDogtags
+    outerClothing: ClothingC27ArmorLightGeneric
 
 # NCR: chassis jumpsuit + Light NCR kit + NCR headset + NCR soldier dogtag.
 - type: startingGear


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Solves #764 and gives the C-27 a welder too.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->Don't question me. Don't @ me. Don't even 🫃 me.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1556" height="797" alt="image" src="https://github.com/user-attachments/assets/b1526b5b-2f46-44e0-97d4-1745db2e7da2" />


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:pierow
- tweak: C-27 Wastelander now spawns in with Light Armor, Light Helmet and a basic welder.
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
