### PR TITLE
The Changes.

### DIFF
--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -32,6 +32,7 @@
   supportedTypes:
     - Heat
     - Shock
+    - Caustic
 
 - type: damageContainer
   id: Shield

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/legionpa.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/legionpa.yml
@@ -14,7 +14,7 @@
   # Repair with a welder to restore the pool and re-enable absorption.
   - type: Damageable
   - type: PowerArmorIntegrity
-    maxIntegrity: 200        # #Misfits Add - FAR lighter salvaged plating
+    maxIntegrity: 300        # #Misfits Add - FAR lighter salvaged plating
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply (35% mitigation from plates alone)
     disableServosLock: true       # #Misfits Add - no servo-lock speed debuff when armor breaks
   - type: Repairable
@@ -63,7 +63,7 @@
     reflects:
       - SmallCaliber
       - MediumCaliber
-    reflectProb: 0.3
+    reflectProb: 0.35
     reflectProbByType:
       MediumCaliber: 0.10 #less armor. less reflect.
     innate: true

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
@@ -507,6 +507,7 @@
     - N14BPBoSWeaponLaserRifleWattz2000 # #Misfits Change - moved from T3 to T4
     - N14BPBoSWeaponLaserRifleWattz3000
     - N14BPBoSWeaponLaserRifleAER12 # #Misfits Add - AER-12 amber beam at T4
+    - N14BPBoSWeaponBozarGRA
 
 # #Misfits Change - RCW moved to T3; AER-15 added to T5
 - type: entity

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Clothing/OuterClothing/ncr_salvaged_pa.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Clothing/OuterClothing/ncr_salvaged_pa.yml
@@ -18,11 +18,11 @@
     requiresProficiency: false # #Misfits Add - waive training gate for this salvaged variant
   # 250 HP integrity pool (lower than standard NCR T45 at 325).
   - type: PowerArmorIntegrity
-    maxIntegrity: 285          # #Misfits Add - lighter salvaged plating
+    maxIntegrity: 385          # #Misfits Add - lighter salvaged plating
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply (35% mitigation from plates alone)
     disableServosLock: true       # #Misfits Add - no servo-lock speed debuff when armor breaks
   # 50% passive damage reduction post-integrity (nerfed from 35% salvaged plate). # #Misfits Tweak - coefficients raised from 0.65 → 0.50 (half damage on all main types)
-  - type: Armor # #Misfits Add - weaker than stock NCR T45 (0.80 coeff) to reflect stripped-down state
+  - type: Armor # #Misfits Add - weaker than stock NCR T45 (0.70 coeff) to reflect stripped-down state
     modifiers:
       coefficients:
         Blunt: 0.50

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/bos_rank_loadoutkits.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/bos_rank_loadoutkits.yml
@@ -72,7 +72,7 @@
     - MBoS_PalSni_Set  #Misfits Remove: Bozar removed from all Paladin ranks
     #- MBoS_PalPla_Set  #Misfits readd by bill: full auto AER-9 for paladins
     #Misfits Tweak: Paladin-tier ranks use Bozar again instead of the Wattz 2000 option.
-    - Misfits_PalWattz_Set
+    #- Misfits_PalWattz_Set
 
 - type: entity
   id: BoSBrotherhoodSeniorKnightKits
@@ -84,8 +84,8 @@
     state: rifleman
   - type: UndecidedLoadoutBackpack
     possibleSets:
-    - MBoS_KniLas_Set
-    - MBoS_KniBal_Set
+    - MBoS_PalBal_Set
+    - MBoS_PalSni_Set
 
 - type: entity
   id: BoSBrotherhoodSeniorScribeKits
@@ -203,10 +203,11 @@
     possibleSets:
     #- MBoS_KniLas_Set  #Misfits Tweak: AER-9 (was AER-14 PalPla)
     - MBoS_PalLas_Set
+    #- MBoS_PalPla_Set
     - MBoS_PalBal_Set
     - MBoS_PalSni_Set  #Misfits readd by Bill: AER-9 for elites.
     #Misfits Tweak: Paladin-tier ranks use Bozar again instead of the Wattz 2000 option.
-    - Misfits_PalWattz_Set
+    #- Misfits_PalWattz_Set
 
 - type: entity
   id: BoSBrotherhoodHeadKnightKits

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_bos_town.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_bos_town.yml
@@ -166,9 +166,9 @@
 
     ScrapElectronic: 500
 
-    Plastic: 750
+    Plastic: 1000
 
-    N14Gold: 150
+    N14Gold: 350
 
 
 - type: latheRecipe
@@ -334,13 +334,15 @@
   availableFaction:
   - BrotherhoodOfSteel
   materials:
-    Steel: 9000
+    Steel: 11500
 
-    N14Gunpowder: 80
+    N14Gold: 100
 
-    Circuitry: 20
+    N14Brass: 2000
 
-    ScrapElectronic: 15
+    ScrapElectronic: 150
+
+    Glass: 300 #scope
 
 
 - type: latheRecipe

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -1864,9 +1864,9 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 12000
+    Steel: 17500
 
-    N14Iron: 3000
+    N14Iron: 5000
 
     Circuitry: 100
 
@@ -1882,7 +1882,7 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Wood: 3000
+    Wood: 4000
 
     N14Iron: 950
 

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -207,7 +207,7 @@
   availableFaction:
   - NCR
   materials:
-    Steel: 4000
+    Steel: 5000
 
     Wood: 1500
 
@@ -301,13 +301,15 @@
   availableFaction:
   - NCR
   materials:
-    Steel: 4000
+    Steel: 6500
 
     Wood: 1500
 
     Glass: 1000
 
-    N14Iron: 500
+    N14Iron: 800
+
+    N14Brass: 300
 
 
 # --- NCR Tier 3 Weapons (Ranger/Veteran grade) ---

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_vault_tribe.yml
@@ -646,7 +646,7 @@
   availableFaction:
   - Tribe
   materials:
-    Wood: 1800
+    Wood: 3800
     N14Iron: 1200
     Leather: 500
     N14Gold: 250
@@ -688,7 +688,7 @@
   availableFaction:
   - Tribe
   materials:
-    Steel: 25000
+    Steel: 30000
     N14Iron: 3500
     Wood: 900
     Scrap: 5000

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/powerarmor.yml
@@ -12,7 +12,7 @@
   # Repair with a welder to restore the pool and re-enable absorption.
   - type: Damageable
   - type: PowerArmorIntegrity
-    maxIntegrity: 400 # #Misfits Tweak: By Bill, 400 durability for a little more standing power.
+    maxIntegrity: 500 # #Misfits Tweak: By Bill, 500 durability for a little more standing power.
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
   - type: Repairable
     fuelCost: 10
@@ -39,11 +39,11 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
-        Caustic: 0.75
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.7
+        Caustic: 0.7
         Radiation: 0.6
   - type: UserInterface
     interfaces:
@@ -73,7 +73,7 @@
     reflects:
       - SmallCaliber
       - MediumCaliber
-    reflectProb: 0.3
+    reflectProb: 0.4
     reflectProbByType:
       MediumCaliber: 0.15
     innate: true
@@ -102,7 +102,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 480 # #Misfits Tweak: By Bill, 480 durability.
+    maxIntegrity: 580 # #Misfits Tweak: By Bill, 580 durability.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t51.rsi
   - type: Clothing
@@ -110,11 +110,11 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.70
-        Caustic: 0.75
+        Blunt: 0.60
+        Slash: 0.60
+        Piercing: 0.60
+        Heat: 0.60
+        Caustic: 0.65
         Radiation: 0.6
   - type: UserInterface
     interfaces:
@@ -137,7 +137,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 480 # #Misfits Tweak: By Bill, 480 durability.
+    maxIntegrity: 500 # #Misfits Tweak: By Bill, 500 durability.
   - type: Sprite
     sprite: _Misfits/Clothing/OuterClothing/PowerArmor/Mutant_PA.rsi
   - type: Clothing
@@ -178,7 +178,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 445 # #Misfits Tweak: By Bill, 445 durability.
+    maxIntegrity: 545 # #Misfits Tweak: By Bill, 545 durability.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t60.rsi
   - type: Clothing
@@ -186,11 +186,11 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.725
-        Slash: 0.725
-        Piercing: 0.725
-        Heat: 0.725
-        Caustic: 0.75
+        Blunt: 0.65
+        Slash: 0.65
+        Piercing: 0.65
+        Heat: 0.65
+        Caustic: 0.65
         Radiation: 0.6
   - type: UserInterface
     interfaces:
@@ -233,7 +233,7 @@
     reflects:
       - SmallCaliber
       - Energy
-    reflectProb: 0.3
+    reflectProb: 0.40
     innate: true
     spread: 90
   - type: UserInterface
@@ -255,7 +255,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 460 # #Misfits Tweak: By Bill, 460 a little better than T60 but not T51.
+    maxIntegrity: 560 # #Misfits Tweak: By Bill, 460 a little better than T60 but not T51.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/advanced1.rsi
   - type: Clothing
@@ -267,7 +267,7 @@
         Slash: 0.65
         Piercing: 0.65
         Heat: 0.65
-        Caustic: 0.75
+        Caustic: 0.6
         Radiation: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.08 # #Misfits Tweak: X-01 advanced plating — ~10 HP at ground zero
@@ -284,7 +284,7 @@
   - type: Reflect # #Misfits Change Tweak: X-01 advanced armor ricochets small-caliber rounds at 30% (innate).
     reflects:
       - SmallCaliber
-    reflectProb: 0.3
+    reflectProb: 0.55
     innate: true
     spread: 90
 
@@ -296,7 +296,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 485 # #Misfits Tweak: X-02 durability.
+    maxIntegrity: 585 # #Misfits Tweak: X-02 durability.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/advanced2.rsi
   - type: Clothing
@@ -341,7 +341,7 @@
   - type: Reflect # #Misfits Change Tweak: X-02 armor ricochets small-caliber rounds at 30% (innate).
     reflects:
       - SmallCaliber
-    reflectProb: 0.3
+    reflectProb: 0.55
     innate: true
     spread: 90
 
@@ -352,7 +352,7 @@
   description: A deep black suit of Enclave-manufactured heavy power armor based on pre-war designs such as the T-51 and improving off of data gathered by post-war designs such as the X-01. Most commonly fielded on the East Coast, no suit rivals its strength.
   components:
   - type: PowerArmorIntegrity
-    maxIntegrity: 500 # #Misfits Tweak: Hellfire durability.
+    maxIntegrity: 600 # #Misfits Tweak: Hellfire durability.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/hellfire.rsi
   - type: Clothing
@@ -360,11 +360,11 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.70
-        Caustic: 0.75
+        Blunt: 0.60
+        Slash: 0.60
+        Piercing: 0.60
+        Heat: 0.60
+        Caustic: 0.55
         Radiation: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.06 # #Misfits Tweak: Hellfire designed for combat — best blast resistance, ~7 HP at ground zero
@@ -387,7 +387,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 300 # #Misfits Tweak: +150 flat integrity buff
+    maxIntegrity: 400 # #Misfits Tweak: +150 flat integrity buff
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/raider.rsi
   - type: Clothing
@@ -395,10 +395,10 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.80
-        Heat: 0.80
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.75
+        Heat: 0.75
         Caustic: 0.75
         Radiation: 0.65
   - type: ExplosionResistance
@@ -416,7 +416,7 @@
   - type: Reflect # #Misfits Change Tweak: Raider power armor ricochets small-caliber rounds at 30% (innate).
     reflects:
       - SmallCaliber
-    reflectProb: 0.3
+    reflectProb: 0.35
     innate: true
     spread: 90
   - type: ClothingSpeedModifier # Forge-Change
@@ -431,7 +431,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 400 # #Misfits Tweak: +150 flat integrity buff
+    maxIntegrity: 500 # #Misfits Tweak: +150 flat integrity buff
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/midwest.rsi
   - type: Clothing
@@ -439,11 +439,11 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.725
-        Slash: 0.725
-        Piercing: 0.725
-        Heat: 0.725
-        Caustic: 0.75
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.7
+        Caustic: 0.7
         Radiation: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.12 # #Misfits Tweak: Midwest BoS blast resistance — ~14 HP at ground zero
@@ -478,7 +478,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 485 # #Misfits Tweak: Very slightly above standard T-51.
+    maxIntegrity: 585 # #Misfits Tweak: Very slightly above standard T-51.
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/midwestcommander.rsi
   - type: Clothing
@@ -486,11 +486,11 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.695
-        Slash: 0.695
-        Piercing: 0.695
-        Heat: 0.695
-        Caustic: 0.745
+        Blunt: 0.645
+        Slash: 0.645
+        Piercing: 0.645
+        Heat: 0.645
+        Caustic: 0.7
         Radiation: 0.595
   - type: ExplosionResistance
     damageCoefficient: 0.118 # #Misfits Tweak: Very slightly above standard T-51 blast resistance.
@@ -509,7 +509,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 490 # #Misfits Tweak: By Bill, little more durability than normal T-51
+    maxIntegrity: 590 # #Misfits Tweak: By Bill, little more durability than normal T-51
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t51bc.rsi
   - type: Clothing
@@ -517,11 +517,11 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.675
-        Slash: 0.675
-        Piercing: 0.675
-        Heat: 0.675
-        Caustic: 0.75
+        Blunt: 0.575
+        Slash: 0.575
+        Piercing: 0.575
+        Heat: 0.575
+        Caustic: 0.675
         Radiation: 0.6
   - type: TemperatureProtection
     coefficient: 0.5
@@ -552,7 +552,7 @@
   - type: Reflect # #Misfits Change Tweak: T-51BC ricochets small-caliber rounds at 30% (innate).
     reflects:
       - SmallCaliber
-    reflectProb: 0.3
+    reflectProb: 0.55
     innate: true
     spread: 90
 
@@ -595,7 +595,7 @@
   - type: Reflect # #Misfits Change Tweak: Salvaged NCR T-45 ricochets small-caliber rounds at 30% (innate).
     reflects:
       - SmallCaliber
-    reflectProb: 0.3
+    reflectProb: 0.4
     innate: true
     spread: 90
 
@@ -688,7 +688,7 @@
   components:
   - type: PowerArmorIntegrity
     brokenBleedthroughRatio: 1.0  # #Misfits Add - when broken, only armor coefficients apply
-    maxIntegrity: 485 # #Misfits Tweak: By Bill, a little better than T51 but not as good as T51BC
+    maxIntegrity: 585 # #Misfits Tweak: By Bill, a little better than T51 but not as good as T51BC
   - type: Sprite
     sprite: _Nuclear14/Clothing/OuterClothing/PowerArmor/t51washelite.rsi
   - type: Clothing
@@ -696,11 +696,11 @@
   - type: Armor # #Misfits Tweak: Added Heat and Piercing coefficients — pre-reduces damage before integrity absorption so PA stays above Centurion/Vet.Ranger at all integrity levels.
     modifiers:
       coefficients:
-        Blunt: 0.675
-        Slash: 0.675
-        Piercing: 0.675
-        Heat: 0.675
-        Caustic: 0.75
+        Blunt: 0.575
+        Slash: 0.575
+        Piercing: 0.575
+        Heat: 0.575
+        Caustic: 0.575
         Radiation: 0.6
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -1241,7 +1241,7 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14WeaponLaserRifleAuto # misfits change by bill; makes it easier to balance paladin kits, AER14 too much roundstart.
-      - id: N14MicrofusionCellBlue
+      - id: N14MicrofusionCell
         amount: 1
       - id: N14WeaponPistol12mm
       - id: N14MagazinePistol12mm

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
@@ -39,7 +39,7 @@
     impactEffect: BulletPlasmaImpactEffect
     damage:
       types:
-        Shock: 18
+        Caustic: 18
         Radiation: 2
         Structural: 50
     soundHit:
@@ -57,7 +57,7 @@
     impactEffect: BulletPlasmaImpactEffect
     damage:
       types:
-        Shock: 15
+        Caustic: 15
         Structural: 25
     soundHit:
       path: "/Audio/Weapons/Guns/Hits/energy_meat1.ogg"
@@ -74,7 +74,7 @@
     impactEffect: BulletPlasmaImpactEffect
     damage:
       types:
-        Shock: 35
+        Caustic: 35
         Radiation: 5
         Structural: 100
     soundHit:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -109,7 +109,7 @@
     maxAngle: 105
     angleIncrease: 4
     angleDecay: 16
-    fireRate: 1.2
+    fireRate: 0.9
     soundGunshot:
       collection: N14AntiMaterielGunshot
     selectedMode: SemiAuto

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -230,7 +230,6 @@
         messageKeys:
         - drug-ambience-robust-healing-mixture-1
         - drug-ambience-robust-healing-mixture-2
-        refresh: true
       - !type:HealthChange
         damage:
           groups:

--- a/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Nuclear14/Reagents/medicine.yml
@@ -17,12 +17,6 @@
           messageKeys:
           - drug-ambience-healing-mixture-1
           - drug-ambience-healing-mixture-2
-        - !type:GenericStatusEffect # Misfits Add: mark entity as having an active recovery drug — enables 2s crit stand-up
-          key: RecoveryDrugActive
-          component: RecoveryDrugActiveComponent
-          type: Add
-          time: 3
-          refresh: true
         - !type:HealthChange
           damage:
             groups:
@@ -70,7 +64,7 @@
             Brute: -2.0
             Airloss: -2.0
           types:
-            Radiation: 0.5
+            Radiation: 0.25
             Poison: 0.25
       - !type:ModifyBleedAmount
         amount: -1
@@ -236,11 +230,6 @@
         messageKeys:
         - drug-ambience-robust-healing-mixture-1
         - drug-ambience-robust-healing-mixture-2
-      - !type:GenericStatusEffect # Misfits Add: mark entity as having an active recovery drug — enables 2s crit stand-up
-        key: RecoveryDrugActive
-        component: RecoveryDrugActiveComponent
-        type: Add
-        time: 3
         refresh: true
       - !type:HealthChange
         damage:


### PR DESCRIPTION
## About the PR
PA buff across the board. More reflect, more integrity, more DR, I don't care that cyth is reworking them and will steamroll all these changes in less than a week. Such is nature for something better to replace it.
Made plasma do caustic again. robots now take caustic damage.
Gave brotherhood bozar kit. Also flatlined half their kits. Brotherhood senior knight to the head fucking paladin run the same shit. top to bottom. AER-9, assault carbine, assault shotgun. This is what you get. Brotherchuds seem content with this change. they can still make their yummy shit.
Increased some BPs to reasonable prices for their relative effectiveness (like AER-9auto for BOS and marksman carbine for NCR)
GUTTED the prices for super sledge on legion and yuma. just fucking exorbitant. Make one at your own peril.
Removed recovery component from super stim and stim, made you immortal effectively. that sucks.
Toned down rad damage on dirty stim. made it more acceptable (0.25)
Tweaked AMR rof a little, requested nerf by a min.

## Why / Balance
Every other NCR private had a fucking marksman carbine. wayyyyy too cheap.
Super sledge spam is getting old.
BOS got better kits for their grunts in exchange for more standardized shit across the board. (Larp this off as frum hitting their supply line or somethin)
PA was and is bugged beyond my ability. this simply buffs it some while keeping it acceptable within the current abilities of SPECIAL.
Plasma was shock, sucks. Now its caustic, soul.
Fighting a vet ranger without 50+ DPS weapons was impossible due to the dreaded 2-3 tap of the .50 AMR. also requested change by one of the jannies.

## Technical details
Yaml. its all yaml? always has been yaml.

## Media

https://github.com/user-attachments/assets/f0a23eda-85f7-45dd-9e58-3d5f30d71c84

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Billus Clintius.
- add: Added Bozar to BOS BPs. rejoice.
- add: Added caustic instead of shock to plasma weapons.
- remove: Removed recovery component from super stims you are no longer immortal while on them.
- tweak: Buffed all PAs. if i missed one ping me in disc.
- tweak: brotherhood kits massively standardized. Big paladins lost some fun shit so the little knights could have better kits.
- tweak: BP costs for certain items tweaked. Such as NCR marksman carbine and BOS AER-9 auto.
- remove: Super sledge is removed from the game 
- tweak: the above is a lie. the super sledge is not removed. the prices to make it for legion and yuma were massively increased.
- tweak: dirty stim does less rads now
- tweak: decreased ROF on vet ranger AMR by 0.3 RPS. from 1.2 to 0.9.