### PR TITLE
Caustic for Robots Selfheal/Wireheal

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
@@ -138,6 +138,7 @@
       types:
         Heat: -0.5
         Shock: -0.5
+        Caustic: -0.5
   - type: RobotSelfRepairAnnouncer # #Misfits Change: hull integrity warnings + self-repair popups
   - type: Sanitized # #Misfits Change: makes mr handy not do damage in surgery
 
@@ -245,6 +246,7 @@
       types:
         Heat: -0.5
         Shock: -0.5
+        Caustic: -0.5
   - type: RobotSelfRepairAnnouncer # #Misfits Change: hull integrity warnings + self-repair popups
 
   - type: Tag # #Misfits Change: Protectron walks, so it should have footstep sounds
@@ -328,6 +330,7 @@
       types:
         Heat: -0.5
         Shock: -0.5
+        Caustic: -0.5
   - type: RobotSelfRepairAnnouncer # #Misfits Change: hull integrity warnings + self-repair popups
 
   - type: Gun # #Misfits Add: built-in plasma caster — right-click in combat mode to fire
@@ -663,6 +666,7 @@
       types:
         Heat: -0.5
         Shock: -0.5
+        Caustic: -0.5
   - type: RobotSelfRepairAnnouncer # #Misfits Change: hull integrity warnings + self-repair popups
 
   - type: Tag # #Misfits Change: Assaultron walks, so it should have footstep sounds
@@ -839,6 +843,7 @@
       types:
         Heat: -0.5
         Shock: -0.5
+        Caustic: -0.5
   - type: RobotSelfRepairAnnouncer
   - type: Tag
     tags:
@@ -1013,6 +1018,7 @@
       types:
         Heat: -0.5
         Shock: -0.5
+        Caustic: -0.5
   - type: RobotSelfRepairAnnouncer
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Robots/base_borg_chassis.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Robots/base_borg_chassis.yml
@@ -71,6 +71,7 @@
       - Piercing
       - Heat
       - Shock
+      - Caustic
     locPrefix: silicon
   - type: UserInterface
     interfaces:


### PR DESCRIPTION

## About the PR

Title. Caustic is now healable for robots via wire & selfheals.

## Why / Balance

Because it is unhealable.

## Technical details

Just added Caustic group.

## Media
N/A

# Changelog

:cl:
- add: Added Caustic to synthetics to be healable.

