### PR TITLE
Bazaar Trader Fishing Rods

### DIFF
--- a/Resources/Prototypes/Corvax/Trade/trade.yml
+++ b/Resources/Prototypes/Corvax/Trade/trade.yml
@@ -782,6 +782,10 @@
     price: 150
   - proto: BoxTapeRecorder
     price: 100
+  - proto: FishingRod
+    price: 50
+  - proto: FishingRodGolden
+    price: 250
 
 - type: storeCategoryStructured
   id: CaravanBuy2_Sprouts


### PR DESCRIPTION
## About the PR
What this PR does is allows the bazaar merchant to sell fishing rods and the GLORIOUS golden rod. Prices goes as followed: regular fishing rod is roughly 50 caps and the golden fishing rod 250 caps. With this people wont have to smash the Z key and or the mouse too hard awhile fishing Yeehaw partner.
<img width="1016" height="314" alt="image" src="https://github.com/user-attachments/assets/b15a45b2-b421-4453-bbda-f6044b507446" />


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Oli
- add: Fishing Rod to Bazaar

