### PR TITLE
Hotfix: Tribal Protectron Profile Editing + Adamantium Skeleton Description

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -106,6 +106,7 @@ namespace Content.Client.Lobby.UI
                 ("RobotProtectronPolice", "humanoid-profile-editor-robot-model-protectron-police"),
                 ("RobotProtectronBuilder", "humanoid-profile-editor-robot-model-protectron-builder"),
                 ("RobotProtectronFire", "humanoid-profile-editor-robot-model-protectron-fire"),
+                ("RobotProtectronTribal", "humanoid-profile-editor-robot-model-protectron-tribal"),
             },
             ["RobotAssaultron"] = new[]
             {
@@ -1799,7 +1800,8 @@ namespace Content.Client.Lobby.UI
                 || speciesId == "RobotSentryBot"
                 || speciesId == "RobotSentryBotLaser"
                 || speciesId == "RobotRobobrain"
-                || speciesId == "RobotRobobrainLaser";
+                || speciesId == "RobotRobobrainLaser"
+                || speciesId == "RobotProtectronTribal";
         }
 
         // #Misfits Add: variant species are hidden from the main Species dropdown and driven by Robot Model selector.
@@ -1812,7 +1814,8 @@ namespace Content.Client.Lobby.UI
                 || speciesId == "RobotSentryBotLaser"
                 || speciesId == "RobotRobobrainLaser"
                 || speciesId == "C27NCR" // #Misfits Add - C-27 NCR variant picked via Robot Model dropdown
-                || speciesId == "C27BoS"; // #Misfits Add - C-27 Brotherhood variant picked via Robot Model dropdown
+                || speciesId == "C27BoS" // #Misfits Add - C-27 Brotherhood variant picked via Robot Model dropdown
+                || speciesId == "RobotProtectronTribal"; // Misfits Add - Protectron Spirit-Tender
         }
 
         // #Misfits Add: normalize hidden variants to base Protectron in main species selector.

--- a/Resources/Locale/en-US/_Misfits/character-editor.ftl
+++ b/Resources/Locale/en-US/_Misfits/character-editor.ftl
@@ -40,6 +40,7 @@ humanoid-profile-editor-robot-model-protectron-standard = Standard
 humanoid-profile-editor-robot-model-protectron-police = Police
 humanoid-profile-editor-robot-model-protectron-builder = Builder
 humanoid-profile-editor-robot-model-protectron-fire = Firefighter
+humanoid-profile-editor-robot-model-protectron-tribal = Tribal Spirit-Tender
 
 # Robot model selector labels for Assaultron variants.
 humanoid-profile-editor-robot-model-assaultron-beam = Beam

--- a/Resources/Locale/en-US/_Misfits/traits/physical.ftl
+++ b/Resources/Locale/en-US/_Misfits/traits/physical.ftl
@@ -4,6 +4,6 @@ trait-description-MisfitsBloodyMess =
     Hope you know a good doctor...
 
 trait-name-MisfitsAdamantiumSkeleton = Adamantium Skeleton
-trait-description-MisfitsBloodyMess =
+trait-description-MisfitsAdamantiumSkeleton =
     Whether though augmentation or mutation, your bones are especially resistant to trauma.
     Your limbs are impossible to sever from your body through any means but surgery.

--- a/Resources/Prototypes/_Misfits/Species/robot.yml
+++ b/Resources/Prototypes/_Misfits/Species/robot.yml
@@ -106,7 +106,7 @@
   order: 21 # hidden from main selector, used by Robot Model picker
   whitelistRequired: true
   restrictedCustomization: true
-  jobWhitelistUnlock: SyntheticProtectron
+  jobWhitelistUnlock: SyntheticProtectronTribal
   restrictedJobs:
   - SyntheticProtectronTribal
   sprites: RobotSprites


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Tribal Protectron wasn't selected the same way as other protectron models, and had sex and height/width selectors that other robots don't have. I fixed these things.

Also noticed Adamantium Skeleton description was colliding with Bloody Mess description, so I'm just fixing that in here too.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Client shitcode needed appeasement.

## Technical details
<!-- Summary of code changes for easier review. -->
Works the tribal protectron into hardcoded client stuff surrounding profile editing

This might result in the existing whitelists for the Protectron Spirit-Tender needing adjustment, but I _think_ it's gonna be fine. Works on my machine.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Tribal Protectron is now properly a protectron.
- fix: Fixed descriptions colliding between the Bloody Mess and Adamantium Skeleton perks.
