### PR TITLE
Update PowerArmorIntegritySystem.cs

### DIFF
--- a/Content.Shared/_Misfits/PowerArmor/PowerArmorIntegritySystem.cs
+++ b/Content.Shared/_Misfits/PowerArmor/PowerArmorIntegritySystem.cs
@@ -35,8 +35,10 @@ namespace Content.Shared._Misfits.PowerArmor;
 /// </summary>
 public sealed class PowerArmorIntegritySystem : EntitySystem
 {
-    // #Misfits Fix - Tracks last processed hit to prevent Shitmed body system double-dip.
-    private (GameTick tick, EntityUid uid) _lastProcessed;
+    // Shitmed relays one hit through inventory twice: once from part damage and
+    // once from the body-level damage pass. Cache the wearer-facing split so the
+    // second relay keeps the same reduced damage without charging integrity again.
+    private (GameTick Tick, EntityUid Armor, EntityUid? Origin, FixedPoint2 OriginalTotal, DamageSpecifier WearerShare)? _lastSplit;
 
     // #Misfits Fix - Biological/internal damage types that bypass armor integrity entirely.
     private static readonly HashSet<string> BypassTypes = new()
@@ -140,12 +142,18 @@ public sealed class PowerArmorIntegritySystem : EntitySystem
     private void OnDamageModify(EntityUid uid, PowerArmorIntegrityComponent comp,
         InventoryRelayedEvent<DamageModifyEvent> args)
     {
-        // #Misfits Fix - Shitmed body system relays the same hit through inventory twice
-        // (once from body parts, once from the main event). Only process once per tick.
         var curTick = _timing.CurTick;
-        if (_lastProcessed.uid == uid && _lastProcessed.tick == curTick)
+        var originalTotal = args.Args.OriginalDamage.GetTotal();
+
+        if (_lastSplit is { } cached &&
+            cached.Tick == curTick &&
+            cached.Armor == uid &&
+            cached.Origin == args.Args.Origin &&
+            cached.OriginalTotal == originalTotal)
+        {
+            args.Args.Damage = new DamageSpecifier(cached.WearerShare);
             return;
-        _lastProcessed = (curTick, uid);
+        }
 
         // #Misfits Change - broken armor: ArmorComponent stays active (coefficients still apply).
         // Apply BrokenBleedthroughRatio (20%) so the wearer takes only 20% of post-coefficient damage.
@@ -164,6 +172,7 @@ public sealed class PowerArmorIntegritySystem : EntitySystem
                 // Pass healing (negative values) through unchanged; only cap incoming damage.
                 brokenShare.DamageDict[type] = amount <= 0 ? amount : amount * comp.BrokenBleedthroughRatio;
             }
+            _lastSplit = (curTick, uid, args.Args.Origin, originalTotal, new DamageSpecifier(brokenShare));
             args.Args.Damage = brokenShare;
             return;
         }
@@ -214,6 +223,8 @@ public sealed class PowerArmorIntegritySystem : EntitySystem
             armorShare.DamageDict[type] = toArmor;
             playerShare.DamageDict[type] = toPlayer;
         }
+
+        _lastSplit = (curTick, uid, args.Args.Origin, originalTotal, new DamageSpecifier(playerShare));
 
         // Only the 1.5% bleedthrough reaches the wearer.
         args.Args.Damage = playerShare;


### PR DESCRIPTION
## About the PR
Fixes old power armor integrity damage routing so worn power armor actually absorbs most incoming damage instead of letting most of it hit the wearer.

## Why / Balance
This restores the intended behavior of power armor.
Before this fix, the suit would lose a little integrity, but the person inside still took most of the hit.
After this fix, damage is split properly again, so the armor takes the absorbed portion and the wearer only takes the reduced bleedthrough amount.

## Technical details
Shitmed was relaying the same damage event through inventory twice.
The old guard in `PowerArmorIntegritySystem` blocked the second relay completely, which let the wearer still receive the later damage path unmodified.
This change caches the already-computed reduced wearer damage and reuses it on the duplicate relay, while only applying armor integrity damage once.

## Media
Not needed.

# Changelog

:cl:
- fix: Fixed old power armor integrity not properly absorbing damage for the wearer is all. GGs