### PR TITLE
Ungibbable Robots

### DIFF
--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Player/synthetics.yml
@@ -54,31 +54,32 @@
       - !type:PlaySoundBehavior
         sound:
           path: /Audio/Machines/AI/borg_death.ogg
-    - trigger:
-        !type:DamageTrigger
-        damage: 1000
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          PowerCellHyper:
-            min: 1
-            max: 1
-          N14Scrap1:
-            min: 2
-            max: 4
-          N14ScrapElectronic1:
-            min: 1
-            max: 3
-      - !type:EmptyContainersBehaviour
-        containers:
-        - borg_module
-        - cell_slot
-        # borg_brain intentionally omitted — player mind is destroyed with the chassis
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
+      # Commented out to remove player bot gibbing.
+#    - trigger:
+#        !type:DamageTrigger
+#        damage: 1000
+#      behaviors:
+#      - !type:PlaySoundBehavior
+#        sound:
+#          collection: MetalBreak
+#      - !type:SpawnEntitiesBehavior
+#        spawn:
+#          PowerCellHyper:
+#            min: 1
+#            max: 1
+#          N14Scrap1:
+#            min: 2
+#            max: 4
+#          N14ScrapElectronic1:
+#            min: 1
+#            max: 3
+#      - !type:EmptyContainersBehaviour
+#        containers:
+#        - borg_module
+#        - cell_slot
+#        # borg_brain intentionally omitted — player mind is destroyed with the chassis
+#      - !type:DoActsBehavior
+#        acts: [ "Destruction" ]
 
 - type: entity
   parent: N14BasePlayerSynthetic


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Player synthetics can no longer be gibbed

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Orders from Big Boss

## Technical details
<!-- Summary of code changes for easier review. -->
Literally just commenting out the part of the destructible component that gibs the player synthetics.

I'd initially wanted to use the UngibbableComponent I made for this, but it would disable the satisfying sound effects bots make when you smash them up.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Player robots are no longer gibbable.
