### PR TITLE
NCR Explorer Parity

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/OuterClothing/falloutarmor.yml
@@ -796,6 +796,9 @@
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutNCRvestcoatblack.rsi
   - type: Clothing
     sprite: _Nuclear14/Clothing/OuterClothing/Armor/falloutNCRvestcoatblack.rsi
+  - type: ClothingSpeedModifier
+    walkModifier: 1.10
+    sprintModifier: 1.10
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
## About the PR

Adds a movement speed bonus to the NCR infiltrator coat used in the specialist infiltrator kit to be in line with the Veteran Explorer gear.

## Why / Balance

The NCR infiltrator kit is intended for stealth/scout-style play, similar to Legion explorer gear. Giving the infiltrator coat a `1.10` walk and sprint modifier makes it better fit that role without changing its armor values or kit contents.

## Technical details

Updated `N14ClothingOuterNCRVestCoatBlack` with:

```yaml
- type: ClothingSpeedModifier
  walkModifier: 1.10
  sprintModifier: 1.10
```

# Changelog

:cl:
- tweak: NCR infiltrator armor now grants a 10% movement speed bonus.