### PR TITLE
Fix Pet Pigrat Missing LanguageKnowledge Component

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/pets_organic.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/pets_organic.yml
@@ -589,6 +589,19 @@
       path: /Audio/Animals/small_dog_bark_happy.ogg
   - type: ReplacementAccent
     accent: xeno
+  - type: LanguageKnowledge # Misfits Fix - pigrat was missing language knowledge entirely; mirror other organic pets
+    speaks:
+    - N14Insect
+    understands:
+    - N14Dog
+    - N14Insect
+    - English
+    - Chinese
+    - Latin
+    - Tribal
+    - N14Robot
+    - N14BrotherBeep
+    - Sign
   - type: NpcFactionMember # Corvax-Change
     factions:
     - Passive


### PR DESCRIPTION
## About the PR
Adds the missing `LanguageKnowledge` to `N14MobPetPigrat` — the only organic pet without one, so it understood nothing.

## Why / Balance
Brings the Pigrat in line with the other pets (Dog/Roach/Ant). Oversight, not intent; no balance impact. Fixes #800.

## Technical details
`Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/pets_organic.yml` — `N14MobPetPigrat`:
- `speaks: [N14Insect]`, reusing the pest-line tongue as `N14MobPetAnt` does.
- `understands:` the standard pet set, identical to Dog/Roach.
- No new language prototype; all ids already exist.

## Media
N/A — component-only fix.

# Changelog

:cl:
- fix: The Pet Pigrat companion now understands languages like the other pets, instead of none.