### PR TITLE
Thirst And Hunger

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -108,10 +108,17 @@ public sealed partial class HungerComponent : Component
     public float DeadHungerSlowdownModifier = 0.40f;
 
     /// <summary>
-    /// Damage dealt when your current threshold is at HungerThreshold.Dead
+    /// Damage dealt when your current threshold is at or below HungerThreshold.Starving
     /// </summary>
     [DataField("starvationDamage")]
     public DamageSpecifier? StarvationDamage;
+
+    // Misfits Add
+    /// <summary>
+    /// Damage recovered when your current threshold is at or above HungerThreshold.Peckish
+    /// </summary>
+    [DataField("recoveryDamage")]
+    public DamageSpecifier? RecoveryDamage;
 
     /// <summary>
     /// The time when the hunger will update next.

--- a/Content.Shared/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Shared/Nutrition/Components/ThirstComponent.cs
@@ -63,10 +63,17 @@ public sealed partial class ThirstComponent : Component
 
     // Misfits Add - Damage applied each second at ThirstThreshold.Dead, mirroring HungerComponent.StarvationDamage.
     /// <summary>
-    /// Damage dealt each update tick when at ThirstThreshold.Dead.
+    /// Damage dealt each update tick when at ThirstThreshold.Parched.
     /// </summary>
     [DataField("dehydrationDamage")]
     public DamageSpecifier? DehydrationDamage;
+
+    // Misfits Add
+    /// <summary>
+    /// Damage recovered when your current threshold is at or above ThirstThreshold.Okay
+    /// </summary>
+    [DataField("recoveryDamage")]
+    public DamageSpecifier? RecoveryDamage;
 
     // Misfits Add - Separate, harsher slowdown at Dead threshold so the player crawls rather than outright dies.
     /// <summary>

--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -173,13 +173,24 @@ public sealed class HungerSystem : EntitySystem
         if (!Resolve(uid, ref component))
             return;
 
-        // #Misfits Tweak - Starvation damage removed; only movement speed reduction remains.
-         if (component.CurrentThreshold <= HungerThreshold.Starving &&
-             component.StarvationDamage is { } damage &&
-             _mobState.IsAlive(uid))
-         {
-             _damageable.TryChangeDamage(uid, damage, true, false);
-         }
+        // Misfits: deal starvation damage at or below Starving, no damage at Peckish, and recover damage at Okay.
+        switch (component.CurrentThreshold)
+        {
+            case <= HungerThreshold.Starving:
+            {
+                if (component.StarvationDamage is { } damage &&
+                    _mobState.IsAlive(uid))
+                    _damageable.TryChangeDamage(uid, damage, true, false);
+                break;
+            }
+            case >= HungerThreshold.Okay:
+            {
+                if (component.RecoveryDamage is { } damage &&
+                    !_mobState.IsDead(uid))
+                    _damageable.TryChangeDamage(uid, damage, true, false);
+                break;
+            }
+        }
     }
 
     /// <summary>

--- a/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
@@ -245,16 +245,26 @@ public sealed class ThirstSystem : EntitySystem
         }
     }
 
-    // Misfits Add - Applies dehydration damage each tick when at ThirstThreshold.Dead,
-    // mirroring the starvation damage pattern in HungerSystem.
+    // Misfits Add - Applies dehydration damage each tick, mirroring the starvation damage pattern in HungerSystem.
     private void DoContinuousThirstEffects(EntityUid uid, ThirstComponent component)
     {
-        // #Misfits Tweak - Dehydration damage removed; only movement speed reduction remains.
-         if (component.CurrentThirstThreshold <= ThirstThreshold.Dead &&
-             component.DehydrationDamage is { } damage &&
-             _mobState.IsAlive(uid))
-         {
-             _damageable.TryChangeDamage(uid, damage, true, false);
-         }
+        // Misfits: deal dehydration damage at or below Parched, no damage at Thirsty, and recover damage at Okay
+        switch (component.CurrentThirstThreshold)
+        {
+            case <= ThirstThreshold.Parched:
+            {
+                if (component.DehydrationDamage is { } damage &&
+                    _mobState.IsAlive(uid))
+                    _damageable.TryChangeDamage(uid, damage, true, false);
+                break;
+            }
+            case >= ThirstThreshold.Okay:
+            {
+                if (component.RecoveryDamage is { } damage &&
+                    !_mobState.IsDead(uid))
+                    _damageable.TryChangeDamage(uid, damage, true, false);
+                break;
+            }
+        }
     }
 }

--- a/Resources/Locale/en-US/_Misfits/health-examinable/health-examinable-carbon.ftl
+++ b/Resources/Locale/en-US/_Misfits/health-examinable/health-examinable-carbon.ftl
@@ -1,0 +1,9 @@
+health-examinable-carbon-Starvation-25 = [color=bisque]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BASIC($target, "look", "looks")} thin.[/color]
+health-examinable-carbon-Starvation-50 = [color=khaki]{ CAPITALIZE(SUBJECT($target)) } {CONJUGATE-BE($target)} very thin and { POSS-ADJ($target) } cheeks are hollow.[/color]
+health-examinable-carbon-Starvation-75 = [color=darkgoldenrod]{ CAPITALIZE(POSS-ADJ($target)) } eyes are sunken, and { POSS-ADJ($target) } skin sags loose on { POSS-ADJ($target) } bones![/color]
+
+health-examinable-carbon-Dehydration-25 = [color=bisque]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } cracked, chapped lips.[/color]
+health-examinable-carbon-Dehydration-50 = [color=lightblue]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } cracked lips and dry, blotchy skin.[/color]
+health-examinable-carbon-Dehydration-75 = [color=deepskyblue]{ CAPITALIZE(POSS-ADJ($target)) } eyes are sunken, and { POSS-ADJ($target) } skin is sallow and wrinkled![/color]
+
+health-examinable-carbon-Caustic-50 = [color=greenyellow]{ CAPITALIZE(POSS-ADJ($target)) } skin cracks and peels from severe chemical burns![/color]

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -249,6 +249,8 @@
     Bloodloss: 0.0 # no double dipping
     Cellular: 0.0
     Caustic: 0.0
+    Starvation: 0.0 # Misfits Add
+    Dehydration: 0.0 # Misfits Add
 
 - type: damageModifierSet
   id: SlimePet # Very survivable slimes

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -358,7 +358,20 @@
   - type: PersistentCurrency # Misfits - Currency wallet
   - type: PersistentPlayerData # Misfits Add - SPECIAL stats, kill/death/round tracking, character history
   - type: Ungibbable  # Misfits Add - No more gibbing
-
+  - type: Hunger # Misfits Change - admeme species like felinids and vulps will starve
+    starvationDamage:
+      types:
+        Starvation: 0.15
+    recoveryDamage:
+      types:
+        Starvation: -0.30
+  - type: Thirst    # Misfits Change - admeme species will dehydrate
+    dehydrationDamage:
+      types:
+        Dehydration: 0.25
+    recoveryDamage:
+      types:
+        Dehydration: -0.35
 - type: entity
   save: false
   id: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -22,18 +22,24 @@
       Peckish: 0.5
       Starving: 0.4
       Dead: 0
-    starvationDamage:
+    starvationDamage:      # Misfits Change - use custom Starvation type
       types:
-        Cold: 0.15 # Misfits Change - use Cold damage for Malnutrition instead of custom Starvation type (no brute/bleed from hunger)
+        Starvation: 0.15
+    recoveryDamage:        # Misfits Add
+      types:
+        Starvation: -0.30
     starvingSlowdownModifier: 0.5
   - type: Icon # It will not have an icon in the adminspawn menu without this. Body parts seem fine for whatever reason.
     sprite: Mobs/Species/Human/parts.rsi
     state: full
   - type: Thirst
     baseDecayRate: 0.02 # Misfits Tweak - reduced from 0.1 (5x slower); first "Thirsty" ~1hr from typical start vs ~13min vanilla; not Parched until ~2hrs
-    dehydrationDamage:
+    dehydrationDamage:  # Misfits Add - Dehydration damage
       types:
-        Cold: 0.15 # Misfits Change - use Cold damage for Dehydration instead of custom Dehydration type (no brute/bleed from thirst)
+        Dehydration: 0.15
+    recoveryDamage:     # Misfits Add - Dehydration damage
+      types:
+        Dehydration: -0.30
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Butcherable
     butcheringType: Spike

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -111,6 +111,9 @@
     - Piercing
     - Heat
     - Shock
+    - Caustic       # Misfits Add
+    - Starvation    # Misfits Add
+    - Dehydration   # Misfits Add
   - type: DamageOnHighSpeedImpact
     damage:
       types:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
@@ -8,6 +8,10 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+      - !type:HealthChange # Misfits Add
+        damage:
+          types:
+            Dehydration: -0.3
   reactiveEffects:
     Extinguish:
       methods: [ Touch ]
@@ -54,6 +58,11 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.06
+      - !type:HealthChange # Misfits Add
+        probability: 0.5
+        damage:
+          types:
+            Dehydration: -0.2
   reactiveEffects:
     Flammable:
       methods: [ Touch ]

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -466,6 +466,10 @@
       effects:
       - !type:SatiateThirst
         factor: 4
+      - !type:HealthChange # Misfits Add
+        damage:
+          types:
+            Dehydration: -0.5
 
 - type: reagent
   id: Ice

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -11,6 +11,10 @@
     Food:
       effects:
       - !type:SatiateHunger
+      - !type:HealthChange # Misfits Add
+        damage:
+          types:
+            Starvation: -0.3
   plantMetabolism:
   - !type:PlantAdjustNutrition
     amount: 1.5
@@ -35,6 +39,8 @@
           groups:
             Brute: -0.5
             Burn: -0.5
+          types:             # Misfits Add
+            Starvation: -0.5
       # Helps you stop bleeding to an extent.
       - !type:ModifyBleedAmount
         amount: -0.25
@@ -63,6 +69,8 @@
         damage:
           groups:
             Brute: -0.4
+          types:              # Misfits Add
+            Starvation: -0.5
       - !type:ModifyBloodLevel
         amount: 1 # weaker than iron but pretty good all things considered
       - !type:SatiateHunger

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -670,6 +670,10 @@
           factor: 6
         - !type:ModifyBloodLevel
           amount: 6
+        - !type:HealthChange # Misfits Add
+          damage:
+            types:
+              Dehydration: -1
 
 - type: reagent
   id: Siderlac

--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Species/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Species/supermutant.yml
@@ -75,14 +75,20 @@
     rotAfter: 3600
   - type: Hunger
     baseDecayRate: 0.024 # #Misfits Add - 3x human default (0.008) to reflect massive size / accelerated metabolism
-    starvationDamage:
+    starvationDamage:    # Misfits Change - use custom Starvation type
       types:
-        Cold: 0.15 # Misfits Change - use Cold damage for Malnutrition instead of custom Starvation type (no brute/bleed from hunger)
+        Starvation: 0.15
+    recoveryDamage:      # Misfits Add
+      types:
+        Starvation: -0.30
     starvingSlowdownModifier: 0.5
   - type: Thirst
-    dehydrationDamage:
+    dehydrationDamage:   # Misfits Add - Dehydration damage
       types:
-        Cold: 0.15 # Misfits Change - use Cold damage for Dehydration instead of custom Dehydration type (no brute/bleed from thirst)
+        Dehydration: 0.15
+    recoveryDamage:      # Misfits Add - Dehydration damage
+      types:
+        Dehydration: -0.30
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: SuperMutant

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/Species/ghouls.yml
@@ -66,14 +66,20 @@
   - type: Perishable
     rotAfter: 3600 # An entire in-game day.
   - type: Hunger
-    starvationDamage:
+    starvationDamage:   # Misfits Change - use custom Starvation type
       types:
-        Cold: 0.15 # Misfits Change - use Cold damage for Malnutrition instead of custom Starvation type (no brute/bleed from hunger)
+        Starvation: 0.15
+    recoveryDamage:     # Misfits Add
+      types:
+        Starvation: -0.30
     starvingSlowdownModifier: 0.5
   - type: Thirst
-    dehydrationDamage:
+    dehydrationDamage:  # Misfits Add - Dehydration damage
       types:
-        Cold: 0.15 # Misfits Change - use Cold damage for Dehydration instead of custom Dehydration type (no brute/bleed from thirst)
+        Dehydration: 0.15
+    recoveryDamage:     # Misfits Add - Dehydration damage
+      types:
+        Dehydration: -0.30
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Ghoul
@@ -166,13 +172,20 @@
   - type: Perishable
     rotAfter: 3600 # An entire in-game day.
   - type: Hunger
-    starvationDamage:
+    starvationDamage:    # Misfits Change - use custom Starvation type
       types:
-        Cold: 0.5 # Misfits Change - use Cold damage instead of Starvation+Bloodloss (no brute/bleed from hunger)
+        Starvation: 0.5
+    recoveryDamage:      # Misfits Add
+      types:
+        Starvation: -0.5
+    starvingSlowdownModifier: 0.5
   - type: Thirst
-    dehydrationDamage:
+    dehydrationDamage:   # Misfits Add - Dehydration damage
       types:
-        Cold: 0.25 # Misfits Change - use Cold damage for Dehydration instead of custom Dehydration type (glowing ghouls dehydrate faster)
+        Dehydration: 0.25
+    recoveryDamage:      # Misfits Add - Dehydration damage
+      types:
+        Dehydration: -0.35
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: GhoulGlowing


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
This changes the damage from starvation and dehydration from Cold back to their custom damage types. It had been changed to cold in the first place because these damage types didn't work properly, but I've fixed them.

Malnutrition damage types don't cause bleeding anymore, they have examinable health states, and they are recovered gradually by eating, drinking, and maintaining good hydration and nutrition. Dehydration in particular can be treated very effectively with saline.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Freezing to death from hunger was weird, and needing to treat starvation victims with ointment was weird.

Dehydration and Starvation damage won't accrue while you are Crit or Dead, but importantly can be restored while Crit. This should effectively remove any risk of being RRed by AFKing, but it can still crit you and cause you to die from asphyxiation.

## Technical details
<!-- Summary of code changes for easier review. -->
I had hoped to map hunger/thirst thresholds to `DamageSpecifiers` to allow for a smooth sliding scale of damage accrual and recovery and avoid if/switch hell in the Hunger and Thirst systems, but I couldn't make that mapping work out in the yaml. A more experienced SS14 developer may be able to succeed where I failed, but for now this is what we've got.

### C#
`HungerComponent` and `ThirstComponent` added a RecoveryDamage field for recovering damage when well fed and watered. `HungerSystem` and `ThirstSystem` logic was updated to use these fields

### YAML
Hunger and Thirst components were added or modified for humans, ghouls, supermutants, and `BaseMobSpeciesOrganic` to ensure that all playable species--including admeme ones like vulps--will experience hunger and thirst.

`MobDamageable` got an update to the HealthExaminable component to add Caustic, Starvation, and Dehydration examination.

`BloodlossHuman` damage modifier set was updated to prevent Malnutrition damage types from causing bleeding.

Several food and drink reagents were updated to heal Malnutrition damages are varying levels of effectiveness. (This is separate from the recovery you get just for being well fed and well watered.)

### Localization
Added new examinable health text for Caustic damage, Starvation damage, and Dehydration damage


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="760" height="399" alt="2026-06-14 15_06_12-Misfits_ Nuclear Wasteland" src="https://github.com/user-attachments/assets/1c1205ac-b2df-47b1-8042-bef757040d2d" />
<img width="784" height="357" alt="2026-06-14 15_08_45-Misfits_ Nuclear Wasteland" src="https://github.com/user-attachments/assets/a2ea2dc8-24f5-4505-b089-9390722e89dc" />
<img width="780" height="411" alt="2026-06-14 15_06_53-Misfits_ Nuclear Wasteland" src="https://github.com/user-attachments/assets/ce7911af-051d-4ded-9d6f-b430990edc6f" />
<img width="752" height="437" alt="2026-06-14 15_11_52-Misfits_ Nuclear Wasteland" src="https://github.com/user-attachments/assets/24be6892-92ab-4f1b-a9e5-ce7a30191884" />
<img width="739" height="374" alt="2026-06-14 15_11_23-Misfits_ Nuclear Wasteland" src="https://github.com/user-attachments/assets/d5a0aa1e-3f86-4b5e-8fae-3b7957382e57" />
<img width="779" height="506" alt="2026-06-14 15_27_53-Misfits_ Nuclear Wasteland" src="https://github.com/user-attachments/assets/279fd3dd-36c9-4d60-b561-cd4bb05b46da" />


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed several problems with the custom Malnutrition damage group for its reintroduction.
- tweak: Changed the Cold damage from starving and dehydrating back to the custom Malnutrition damage types. These damages heal gradually on their own by maintaining good nutrition and hydration. These damages can lead to death, but not RR.
- add: Added small amounts of Malnutrition damage healing to several food and drink reagents.
- add: Added examinable health states for Malnutrition damage types and for Caustic damage.
