### PR TITLE
Hotfix BodyPart Damages

### DIFF
--- a/Resources/Prototypes/_Misfits/Body/Parts/supermutant.yml
+++ b/Resources/Prototypes/_Misfits/Body/Parts/supermutant.yml
@@ -8,7 +8,7 @@
   abstract: true
   components:
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: OrganicPart
     damageModifierSet: SuperMutant
   - type: BodyPart
     # Integrity thresholds scaled ×2.22 vs default human (90→200 CriticallyWounded).

--- a/Resources/Prototypes/_Nuclear14/Body/Parts/ghoul.yml
+++ b/Resources/Prototypes/_Nuclear14/Body/Parts/ghoul.yml
@@ -5,7 +5,8 @@
   abstract: true
   components:
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: OrganicPart  # Misfits Change - no more poison/rad/malnutrition limb damage
+    damageModifierSet: Ghoul      # Misfits Change - ghoul limbs should have ghoul resistances
   - type: BodyPart
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/_Nuclear14/Body/Parts/ghoulglowing.yml
+++ b/Resources/Prototypes/_Nuclear14/Body/Parts/ghoulglowing.yml
@@ -5,8 +5,8 @@
   abstract: true
   components:
   - type: Damageable
-    damageContainer: Biological
-    damageModifierSet: FullRadiationProtection # Forge-Change
+    damageContainer: OrganicPart    # Misfits Change - no more poison/rad/malnutrition limb damage
+    damageModifierSet: GhoulGlowing # Misfits Change - ghoul limbs should have ghoul resistances
   - type: BodyPart
   - type: ContainerContainer
     containers:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Ghouls, Glowing Ghouls, and Supermutants have been taking limb damage from poisons and rads (okay well maybe not rads for glowing ghouls), and Ghoul damage resistances haven't been applying to their body parts.

I noticed this because they began taking Malnutrition damage on their limbs with the Malnutrition update.

They will now only take brute and burn damages on their limbs, like humans do.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Humans take don't take part damage from poison, so why should supermutants and ghouls?

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the damage containers for the aforementioned body parts from `Biological` to `OrganicPart`, the same one that humans use.

Also applied the proper damage modifiers to each.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Ghouls, Glowing Ghouls, and Supermutants will no longer take limb damage from things that don't hurt limbs.

<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
