### PR TITLE
Quick Legion Fix

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/chalkboardfloor.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Furniture/chalkboardfloor.yml
@@ -124,7 +124,7 @@
   - type: Sprite
     state: board_text2
   - type: AccessReader
-    access: [["CaesarLegionCenturion"]]
+    access: [["CaesarLegion"]]
   - type: ActivatableUIRequiresAccess
   - type: WastelandMap
     mapTexturePath: _Misfits/Maps/wendover_map.png


### PR DESCRIPTION
## About the PR

Updates the Legion tactical chalkboard access requirement from Centurion-only access to general Caesar's Legion access.

## Why / Balance

This lets all Legion members use the tactical chalkboard instead of restricting it to Centurions only.

## Technical details

Changed the `AccessReader` on `N14ChalkboardFloor11` from `CaesarLegionCenturion` to `CaesarLegion`.

# Changelog

:cl:
- fix: Changed the Legion tactical chalkboard to use general Legion access instead of Centurion-only access.