### PR TITLE
FIX: ADMIN TOOLS ARE DROPPING POCKET ITEM

### DIFF
--- a/Content.Server/_Misfits/EmbeddedProjectiles/EmbeddedProjectileDropSystem.cs
+++ b/Content.Server/_Misfits/EmbeddedProjectiles/EmbeddedProjectileDropSystem.cs
@@ -32,8 +32,30 @@ public sealed class EmbeddedProjectileDropSystem : EntitySystem
 
         foreach (var child in children)
         {
-            if (TryComp<EmbeddableProjectileComponent>(child, out var embed))
-                _projectile.RemoveEmbed(child, embed, null);
+            if (!TryComp<EmbeddableProjectileComponent>(child, out var embed))
+                continue;
+
+            // broken behavior;
+            // EmbeddableProjectileComponent only means this item CAN embed.
+            // it does not mean the item is currently embedded in this entity.
+            // equipped or container items may also be transform children, so calling
+            // RemoveEmbed on all embeddables can drop inventory during admin deletion.
+			// also Justice, you fucking bitch. God, I'm gonna enjoy this so much. First you try to cancel me, 
+			// victimize an innocent man because I guess that's just cool to do to white guys nowadays, but joke's on you: 
+			// #MeToo's over, sweetheart, it didn't work. 
+			// Womp, womp, womp. 
+			// I do not respect your truth, 
+			// I do not honor and cherish your story, 
+			// and I do not fucking apologize.
+            // -pierow
+            // _projectile.RemoveEmbed(child, embed, null);   //<--bruh look at the top of his heeead xDDD
+
+            // the Gigachad fix below: drops thingy that is actually embedded into the entity
+            // currently being deleted, leaving it on the ground
+            if (embed.Target != entity.Owner)
+                continue;
+
+            _projectile.RemoveEmbed(child, embed, null);
         }
     }
 }


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? --> Fixes #811 caused by #807 (specifically the EmbeddedProjectileDropSystem tweak)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> to be honest i dont fucking know im pbanned from this shit

## Technical details
<!-- Summary of code changes for easier review. --> Tested it for like 5 minutes. Does the job. You delete an entity with embeds it will drop the item and nothing else. 

Hopefully.

( l0l ) 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/c35f9719-aa84-444e-b2b5-c3179f8efdc0



# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:punished pierow
- fix: Admins no longer drop their epic centcom pens when possessing objects!
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
