### PR TITLE
Fixes NCR Weapon Spec Pins

### DIFF
--- a/Resources/Prototypes/_Misfits/NCR/ncr_rank_pin_progressions.yml
+++ b/Resources/Prototypes/_Misfits/NCR/ncr_rank_pin_progressions.yml
@@ -106,7 +106,7 @@
   id: NCRSpecialistPins
   jobs:
     - NCRWS
-  tracker: NCRWeaponsSpecialist
+  tracker: NCRWeaponSpecialist
   departmentTracker: false
   thresholds:
     - min: 0


### PR DESCRIPTION
## About the PR
Fixes NCR Weapon Specialist rank pin progression.

## Why / Balance
Weapon Specialists were earning playtime under `NCRWeaponSpecialist`, but the rank pin progression checked `NCRWeaponsSpecialist`, so earned hours did not apply and they stayed at Private. This restores the intended PV2 -> PFC -> Specialist progression.

## Technical details
Changed the `NCRSpecialistPins` tracker in `ncr_rank_pin_progressions.yml` to match the `NCRWS` job's actual playtime tracker.

# Changelog

:cl:
- fix: Fixed NCR Weapon Specialist rank pins not progressing with playtime.