### PR TITLE
Bugfix for Humanoid NPCs Starving to Death

### DIFF
--- a/Resources/Prototypes/_Misfits/Damage/containers.yml
+++ b/Resources/Prototypes/_Misfits/Damage/containers.yml
@@ -1,0 +1,8 @@
+- type: damageContainer
+  id: MisfitsNPCBiological
+  supportedGroups:
+  - Brute
+  - Burn
+  - Toxin
+  - Airloss
+  - Genetic

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/baseRaidersMobs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/baseRaidersMobs.yml
@@ -4,6 +4,8 @@
   abstract: true
   suffix: AI
   components:
+    - type: Damageable    # Misfits Add - Override from BaseMobSpeciesOrganic to prevent hunger/thirst damage
+      damageContainer: MisfitsNPCBiological
     - type: NpcFactionMember
       factions:
       - Raider
@@ -56,7 +58,7 @@
     - type: Carriable
     - type: Perishable
       rotAfter: 1800 # Rots after half of an in-game day
-    - type: RotInto 
+    - type: RotInto
       entity: N14FoodMeatRadRaw # and becomes a single chunk of meat.
     - type: Butcherable
       butcheringType: Spike

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/basemob.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/basemob.yml
@@ -217,7 +217,7 @@
   parent: N14MobBaseHostile
   components:
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: MisfitsNPCBiological # Misfits Change
   - type: NoSlip
   - type: NpcFactionMember
     factions:
@@ -247,7 +247,7 @@
   description: A mean looking ghoul.
   components:
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: MisfitsNPCBiological  # Misfits Change - no hunger/thirst damage for feral ghouls
     damageModifierSet: GhoulNPC
   # - type: NoSlip
   - type: NpcFactionMember
@@ -314,7 +314,7 @@
   description: A hulking post-human mutation, product of the FEV virus. Radiation resistant and brutally strong.
   components:
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: MisfitsNPCBiological  # Misfits Change
     damageModifierSet: N14SuperMutant
   - type: NpcFactionMember
     factions:

--- a/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/ghouls.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Mobs/NPCs/ghouls.yml
@@ -127,7 +127,7 @@
   description: A special looking ghoul towering over most everything.
   components:
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: MisfitsNPCBiological  # Misfits Change - no starvation for feral ghouls
     damageModifierSet: N14ToughAnimal
   - type: MeleeWeapon
     hidden: true


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Adjusted damage containers on humanoid NPCs (raiders, feral ghouls, hostile SMs) to no longer accept Malnutrition group damages.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Raider NPCs were dying to starvation and dehydration before players even arrived.

## Technical details
<!-- Summary of code changes for easier review. -->
New DamageContainer added, `MisfitsNPCBiological`, which excludes the Malnutrition group. NPCs were updated to use it so that they will be immune to the starvation and thirst damages incurred by the Hunger and Thirst components they're inheriting from `BaseMobSpeciesOrganic`.

Simpler to update Damageable components than to override the Hunger and Thirst components, by a lot.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Nutritional assistance programs for raiders have resulted in a 100% reduction in NPC raider deaths to starvation and dehydration.
  
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
