### PR TITLE
Brahdo Need 1 Hand to Use + C27 Caustic Healing.

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Corvax/Entities/Mobs/NPCs/animals.yml
@@ -4,6 +4,7 @@
   name: brahdo
   description: "Neigh? That thing has too many legs... Think it bites? Might ride it. Might eat it."
   components:
+  - type: Vehicle # for some reason this is the only comp that forces it to take just one hand.
   - type: Sprite
     drawdepth: Mobs
     layers:

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -40,6 +40,7 @@
       types: # these are all split across multiple types
         Heat: -1.66
         Shock: -1.66
+        Caustic: -1.66
 
 - type: entity
   id: CableHVStack

--- a/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Mobs/Species/c27.yml
@@ -150,7 +150,7 @@
         Brute: -0.3
       types:
         Heat: -0.3
-        Shock: -0.3
+        Caustic: -0.3
   # #Misfits Add (Phase F) - Innate melee buff: chassis fist hits noticeably harder than a
   # human punch (spec calls for melee buff to make the slow speed worth it).
   - type: MeleeWeapon


### PR DESCRIPTION
🆑 



- tweak: Made riding brahdo NEED one open hand slot.
- tweak: Made C27's heal caustic + able to heal it from cable coils.
