### PR TITLE
Eighties Can Craft Motorcycles Now

### DIFF
--- a/Resources/Locale/en-US/_Misfits/lathe-blueprints.ftl
+++ b/Resources/Locale/en-US/_Misfits/lathe-blueprints.ftl
@@ -93,3 +93,5 @@ lathe-category-blueprint-c27-armor-ncr = C-27 Armor (NCR)
 lathe-category-blueprint-c27-armor-bos = C-27 Armor (Brotherhood)
 lathe-category-blueprint-c27-combat = C-27 Combat Armor
 
+lathe-category-blueprint-eighties-motorbikes = Eighties Motorbike Flatpacks
+

--- a/Resources/Prototypes/_Misfits/Catalog/Fills/Blueprints/minor_factions.yml
+++ b/Resources/Prototypes/_Misfits/Catalog/Fills/Blueprints/minor_factions.yml
@@ -30,7 +30,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: BoxFolderGrey
+    - id: MisfitsBlueprintMotorbikeAssemblyManual
 
 
 - type: entity

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/eighties_motorbike_blueprint.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/eighties_motorbike_blueprint.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: N14BlueprintBase
+  id: MisfitsBlueprintMotorbikeAssemblyManual
+  name: Motorbike Assembly And Maintenance Manual
+  description: A grease-stained Eighties manual covering motorbike assembly, teardown, and field maintenance. Insert it into a workbench to unlock motorbike flatpack fabrication.
+  components:
+  - type: Blueprint
+    recipes:
+    - MisfitsBPEightiesGreenMotorbikeFlatpack
+    - MisfitsBPEightiesFlameyMotorbikeFlatpack
+    - MisfitsBPEightiesRustyMotorbikeFlatpack
+    - MisfitsBPEightiesScramblerMotorbikeFlatpack
+    - MisfitsBPEightiesClassicMotorbikeFlatpack
+

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Devices/eighties_flatpacks.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Devices/eighties_flatpacks.yml
@@ -1,0 +1,89 @@
+- type: entity
+  parent: BaseFlatpack
+  id: MisfitsEightiesGreenMotorbikeFlatpack
+  name: green motorbike flatpack
+  description: A flatpack used by the Eighties to unpack a green motorbike.
+  components:
+  - type: Flatpack
+    entity: N14VehicleBikeGreen
+  - type: Sprite
+    layers:
+    - state: base
+    - state: overlay
+      color: "#8a5a2b"
+      map: ["enum.FlatpackVisualLayers.Overlay"]
+    - state: icon-default
+  - type: StaticPrice
+    price: 1500
+
+- type: entity
+  parent: BaseFlatpack
+  id: MisfitsEightiesFlameyMotorbikeFlatpack
+  name: flamey motorbike flatpack
+  description: A flatpack used by the Eighties to unpack a flamey motorbike.
+  components:
+  - type: Flatpack
+    entity: N14VehicleBikeFlamey
+  - type: Sprite
+    layers:
+    - state: base
+    - state: overlay
+      color: "#8a5a2b"
+      map: ["enum.FlatpackVisualLayers.Overlay"]
+    - state: icon-default
+  - type: StaticPrice
+    price: 1500
+
+- type: entity
+  parent: BaseFlatpack
+  id: MisfitsEightiesRustyMotorbikeFlatpack
+  name: rusty motorbike flatpack
+  description: A flatpack used by the Eighties to unpack a rusty motorbike.
+  components:
+  - type: Flatpack
+    entity: N14VehicleBikeRustLight
+  - type: Sprite
+    layers:
+    - state: base
+    - state: overlay
+      color: "#8a5a2b"
+      map: ["enum.FlatpackVisualLayers.Overlay"]
+    - state: icon-default
+  - type: StaticPrice
+    price: 1500
+
+- type: entity
+  parent: BaseFlatpack
+  id: MisfitsEightiesScramblerMotorbikeFlatpack
+  name: scrambler motorbike flatpack
+  description: A flatpack used by the Eighties to unpack a scrambler motorbike.
+  components:
+  - type: Flatpack
+    entity: N14VehicleBikeScrambler
+  - type: Sprite
+    layers:
+    - state: base
+    - state: overlay
+      color: "#8a5a2b"
+      map: ["enum.FlatpackVisualLayers.Overlay"]
+    - state: icon-default
+  - type: StaticPrice
+    price: 1500
+
+- type: entity
+  parent: BaseFlatpack
+  id: MisfitsEightiesClassicMotorbikeFlatpack
+  name: classic motorbike flatpack
+  description: A flatpack used by the Eighties to unpack a classic motorbike.
+  components:
+  - type: Flatpack
+    entity: N14VehicleBikeClassic
+  - type: Sprite
+    layers:
+    - state: base
+    - state: overlay
+      color: "#8a5a2b"
+      map: ["enum.FlatpackVisualLayers.Overlay"]
+    - state: icon-default
+  - type: StaticPrice
+    price: 1500

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_eighties_motorbikes.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_eighties_motorbikes.yml
@@ -1,0 +1,41 @@
+- type: latheRecipe
+  id: MisfitsBPEightiesMotorbikeFlatpackBase
+  abstract: true
+  category: MisfitsBlueprintEightiesMotorbikes
+  completetime: 15
+  requiresBlueprint: true
+  applyMaterialDiscount: false
+  availableFaction:
+  - Eighties
+  materials:
+    Steel: 15000
+    Circuitry: 300
+    Plastic: 1500
+    N14Copper: 500
+    N14Gold: 100
+
+- type: latheRecipe
+  parent: MisfitsBPEightiesMotorbikeFlatpackBase
+  id: MisfitsBPEightiesGreenMotorbikeFlatpack
+  result: MisfitsEightiesGreenMotorbikeFlatpack
+
+- type: latheRecipe
+  parent: MisfitsBPEightiesMotorbikeFlatpackBase
+  id: MisfitsBPEightiesFlameyMotorbikeFlatpack
+  result: MisfitsEightiesFlameyMotorbikeFlatpack
+
+- type: latheRecipe
+  parent: MisfitsBPEightiesMotorbikeFlatpackBase
+  id: MisfitsBPEightiesRustyMotorbikeFlatpack
+  result: MisfitsEightiesRustyMotorbikeFlatpack
+
+- type: latheRecipe
+  parent: MisfitsBPEightiesMotorbikeFlatpackBase
+  id: MisfitsBPEightiesScramblerMotorbikeFlatpack
+  result: MisfitsEightiesScramblerMotorbikeFlatpack
+
+- type: latheRecipe
+  parent: MisfitsBPEightiesMotorbikeFlatpackBase
+  id: MisfitsBPEightiesClassicMotorbikeFlatpack
+  result: MisfitsEightiesClassicMotorbikeFlatpack
+

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/categories_blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/categories_blueprints.yml
@@ -339,3 +339,8 @@
   id: N14BlueprintC27CombatGeneric
   name: lathe-category-blueprint-c27-combat
 
+# === EIGHTIES MOTORBIKES ===
+- type: latheCategory
+  id: MisfitsBlueprintEightiesMotorbikes
+  name: lathe-category-blueprint-eighties-motorbikes
+


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Added motorbike flatpacks for each motorbike, added a relevant BP for them, gave it to the 80s.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Roadrashes can now build bikes, and do not have to be given them. They have somethiing to work towards. The eighties can now also replace lost bikes.
## Technical details
<!-- Summary of code changes for easier review. -->
Added prototypes for motorbike flatpacks
Added BP prototype for motorbike flatpacks
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="2620" height="1518" alt="image" src="https://github.com/user-attachments/assets/fecbb14c-9b99-4f49-9d15-4092469c42db" />
<img width="2683" height="1495" alt="image" src="https://github.com/user-attachments/assets/bb27203f-3e60-48c6-a73b-cfd5378ad9da" />
<img width="1081" height="673" alt="image" src="https://github.com/user-attachments/assets/adf7aacf-dd74-4c6f-b7a1-88fc152c2550" />

# Changelog

:cl: Operator
- Added motorbike flatpacks for each motorbike
- Added a BP for the flatpacks
- The gang finally grabbed their blueprints [Eighties base now has the above BP]
