### PR TITLE
Legion Kit Variants, Brotherhood Rippersword BP, Small Other Changes

### DIFF
--- a/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Misfits/undecidedloadout.ftl
@@ -314,7 +314,7 @@ undecided-loadout-category-misfits-centurion-armor-unbroken-description =
 undecided-loadout-category-corvax-venator-marksman-name = Venator Marksman
 undecided-loadout-category-corvax-venator-marksman-description =
     Includes a .308 sniper rifle, a rope belt,
-    2 mags of .308, night vision goggles,
+    4 mags of .308, night vision goggles,
     2 healing powder, 2 K rations,
     a ceramic flask, and mustard.
 
@@ -337,19 +337,19 @@ undecided-loadout-category-corvax-vexillarius-standard-name = Vexillarius Standa
 undecided-loadout-category-corvax-vexillarius-standard-description =
     Includes base armor, a hunting rifle, a box of .308 ammo,
     a .45 Colt pistol, 2 .45 magazines, a Legion shield,
-    a rope belt, 2 pilum spears, a bola, a healing poultice,
+    a rope belt, 3 pilum spears, a bola, a healing poultice,
     a healing powder, 2 K rations, and a ceramic flask.
 
 undecided-loadout-category-corvax-vexillarius-herald-name = Vexillarius Herald
 undecided-loadout-category-corvax-vexillarius-herald-description =
-    Includes base armor, a hunting rifle, a box of .308 ammo,
+    Includes base armor, a legion SKS, 3 .308 SKS clips,
     a .45 Colt pistol, 2 .45 magazines, a rope belt,
     a smoke grenade, 2 bandages, 2 healing poultices,
     a healing powder, 2 K rations, and a ceramic flask.
 
 undecided-loadout-category-corvax-vexillarius-skirmisher-name = Vexillarius Skirmisher
 undecided-loadout-category-corvax-vexillarius-skirmisher-description =
-    Includes base armor, a hunting rifle, a box of .308 ammo,
+    Includes base armor, a 10mm SMG, 3 10mm SMG mags,
     a .45 Colt pistol, 2 .45 magazines, a rope belt,
     a buckler, a pilum spear, a healing poultice,
     2 K rations, and a ceramic flask.
@@ -420,7 +420,7 @@ undecided-loadout-category-corvax-auxilia-medic-description =
 
 undecided-loadout-category-corvax-veteran-decanus-command-name = Veteran Decanus Command
 undecided-loadout-category-corvax-veteran-decanus-command-description =
-    Includes a Legion shield, a Riot shotgun, 2 20 gauge drums, a 20 gauge box,
+    Includes a Legion shield, a blowback shotgun, 3 boxes of 12 gauge,
     a rope belt, a .45 Colt pistol, 2 .45 magazines,
     a box of .45 ammo, a handcuff box, a bola,
     2 healing poultice, 2 K rations, and a ceramic flask.
@@ -456,7 +456,7 @@ undecided-loadout-category-corvax-decanus-sagitaria-description =
 
 undecided-loadout-category-corvax-decanus-berserker-name = Decanus Berserker
 undecided-loadout-category-corvax-decanus-berserker-description =
-    Includes a Legion SKS with 4 clips,
+    Includes a 12mm SMG with 4 magazines,
     a .45 revolver with 2 spare magazines, a pair of power fists,
     a rope belt, 3 throwing knives, 2 healing poultice,
     2 K rations, a ceramic flask, and mustard.
@@ -470,7 +470,7 @@ undecided-loadout-category-corvax-veteran-rifleman-description =
 
 undecided-loadout-category-corvax-veteran-berserker-name = Veteran Berserker
 undecided-loadout-category-corvax-veteran-berserker-description =
-    Includes veteran armor, a Legion SKS with 4 clips,
+    Includes veteran armor, a grease gun with 4 mags,
     a .45 Colt pistol, 2 .45 magazines, a rope belt,
     a gladius, a fire axe, 3 throwing knives,
     2 healing poultice, 2 K rations,
@@ -486,29 +486,27 @@ undecided-loadout-category-corvax-veteran-goliath-description =
 
 undecided-loadout-category-corvax-veteran-shieldbearer-name = Veteran Shieldbearer
 undecided-loadout-category-corvax-veteran-shieldbearer-description =
-    Includes veteran armor, a Legion SKS with 4 clips,
+    Includes veteran armor, a grease gun with 4 mags,
     a .45 Colt pistol, 2 .45 magazines, a rope belt,
     a Legion shield, 2 healing poultice,
     2 K rations, and a ceramic flask.
 
 undecided-loadout-category-corvax-warrior-skirmisher-name = Warrior Skirmisher
 undecided-loadout-category-corvax-warrior-skirmisher-description =
-    Includes base armor, a hunting rifle, a box of .308 ammo,
-    a .45 Colt pistol, 2 .45 magazines, a rope belt,
-    a gladius, a Legion buckler, 2 healing powder,
+    Includes base armor, a .45 Colt pistol, 4 .45 magazines, 
+    a rope belt, a gladius, a Legion buckler, 2 healing powder,
     2 K rations, a ceramic flask, and mustard.
 
 undecided-loadout-category-corvax-warrior-slaver-name = Warrior Slaver
 undecided-loadout-category-corvax-warrior-slaver-description =
     Includes base armor, a hunting rifle, a box of .308 ammo,
     a .45 Colt pistol, 2 .45 magazines, a rope belt,
-    a whip, a stunprod, 2 zipties,
+    a whip, a stunprod, 2 zipties, 2 smoke grenades, 
     2 K rations, a ceramic flask, and mustard.
 
 undecided-loadout-category-corvax-warrior-medic-name = Warrior Medic
 undecided-loadout-category-corvax-warrior-medic-description =
-    Includes base armor, a hunting rifle, a box of .308 ammo,
-    a .45 Colt pistol, 2 .45 magazines, a rope belt,
+    Includes base armor, a grease gun and 2 mags, a rope belt,
     a tribal machete, 2 healing powder, 2 healing poultices,
     2 bandages, ointment, 2 K rations, and a ceramic flask.
 
@@ -517,20 +515,19 @@ undecided-loadout-category-corvax-warrior-gunman-description =
     Includes base armor, a hunting rifle, a box of .308 ammo,
     a .45 Colt pistol, 2 .45 magazines, a rope belt,
     a tribal machete, a healing powder,
-    2 K rations, a ceramic flask, and mustard.
+    2 K rations, a ceramic flask, and mustard. 
 
-undecided-loadout-category-corvax-warrior-shieldbearer-name = Warrior Shieldbearer
+undecided-loadout-category-corvax-warrior-shieldbearer-name = Warrior Charger
 undecided-loadout-category-corvax-warrior-shieldbearer-description =
-    Includes base armor, a hunting rifle, a box of .308 ammo,
-    a .45 Colt pistol, 2 .45 magazines, a rope belt,
-    a trench club, a Legion shield, a healing powder,
+    Includes base armor, a .45 Colt pistol, 4 .45 magazines, 
+    a rope belt, a tribal big club, a healing powder,
     a healing poultice, 2 K rations,
-    a ceramic flask, and mustard.
+    a ceramic flask, and mustard. Sweet sweet mustard.
 
 undecided-loadout-category-corvax-recruit-skirmisher-name = Legionnaire Recruit Skirmisher
 undecided-loadout-category-corvax-recruit-skirmisher-description =
-    Includes recruit armor, a spear quiver belt, 1 M3A1 grease gun,
-    2 .45 SMG magazines, a tribal machete, a Legion buckler,
+    Includes recruit armor, a 9mm SMG and 2 mags for it,
+    a tribal machete, a Legion buckler,
     a healing powder, 2 K rations, and a ceramic flask.
 
 undecided-loadout-category-corvax-recruit-spearman-name = Legionnaire Recruit Spearman
@@ -780,14 +777,14 @@ undecided-loadout-category-misfits-priestess-order-desc =
 undecided-loadout-category-misfits-eighties-block-road-captain-name = Road Captain Kit
 undecided-loadout-category-misfits-eighties-block-road-captain-description =
     A kit filled with everything a block needs to rip them apart.
-    Comes with a 12.7 SMG, a ripper, and some meds with various other 
-    looted equipment. 
+    Comes with a 12.7 SMG, a heavy ripper sword, and some meds with various other 
+    looted equipment. Includes a 45-70 hunter and a shitload of meds.
 
 undecided-loadout-category-misfits-eighties-block-boss-brawler-name = Boss Brawler Kit
 undecided-loadout-category-misfits-eighties-block-boss-brawler-description =
     A homemade stash filled with what the block needs to brawl with armor.
-    Comes with a .50 pipe, a 45-70 hunter, and some assorted meds and food.
-    A smoke and a frag are included.
+    Comes with a .50 pipe, a 45-70 hunter, and assorted meds and food.
+    A smoke and a frag are included. Also comes with a massive club.
 
 undecided-loadout-category-misfits-eighties-block-lead-foot-name = Lead Foot Kit
 undecided-loadout-category-misfits-eighties-block-lead-foot-description =

--- a/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/undecidedloadout.ftl
@@ -305,11 +305,11 @@ undecided-loadout-category-mbos-scribe-engineer-description =
 
 # Misfits Change /Tweak/: Paladin laser kit replaced with auto shotgun + laser pistol sidearm.
 # Misfits Tweak: Removed rank prefix so the kit name is role-neutral.
-undecided-loadout-category-mbos-pal-las-name = Shotgun Kit
+undecided-loadout-category-mbos-pal-las-name = Ripper Kit
 undecided-loadout-category-mbos-pal-las-description =
     A cache containing belongings of a Brotherhood chapter member.
-    Includes 1 auto shotgun, 3 shotgun magazines, 1 AEP-7,
-    2 energy cells, 1 roll of gauze, 1 stimpak,
+    Includes a Ripper sword, 1 AEP-7,
+    4 energy cells, 1 roll of gauze, 2 stimpaks,
     and 1 K ration MRE.
 
 # Misfits Tweak: Removed rank prefix so the kit name is role-neutral.

--- a/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Specific/Kits/kits.yml
@@ -185,7 +185,7 @@
       - id: ClothingBeltRope
       # #Misfits Change - AMR magazines removed; bolt-action uses single cartridges from ammo boxes
       - id: MagazineOver308RifleSniper
-        amount: 2
+        amount: 4
       - id: ClothingEyesNightVisionGoggles
       - id: N14HealingPoultice #Misfits Change /Tweak/: replaces dirty stimpak, Legion uses tribal medicine
         amount: 2
@@ -275,7 +275,7 @@
       - id: N14LegionnaireShield
       - id: ClothingBeltRope
       - id: N14PilumSpear
-        amount: 2
+        amount: 3
       - id: Bola
       - id: N14HealingPoultice #Misfits Change /Tweak/: replaces dirty stimpak, Legion uses tribal medicine
       - id: N14HealingPowder
@@ -298,8 +298,9 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
-      - id: N14AmmoBox308
+      - id: N14WeaponRifleSKS # #Misfits Change: hunting rifle as Legion baseline primary
+      - id: SKSEnbloc308
+        amount: 3
       - id: ClothingBeltRope
       - id: N14WeaponPistol45Colt # existing .45 sidearm kept
       - id: N14MagazinePistol45
@@ -329,8 +330,9 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary (replaces SMG)
-      - id: N14AmmoBox308
+      - id: N14WeaponSMG10mm # #Misfits Change: hunting rifle as Legion baseline primary (replaces SMG)
+      - id: N14MagazineSMG10mm
+        amount: 3
       - id: ClothingBeltRope
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
       - id: N14MagazinePistol45
@@ -514,7 +516,6 @@
         amount: 2
       - id: N14HealingPoultice
         amount: 2
-      - id: N14Hydra
       - id: N14HealingPowder
         amount: 2
       - id: N14TribalMachete
@@ -538,10 +539,9 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14LegionnaireShield
-      - id: N14WeaponShotgunRiot 
-      - id: N14MagazineShotgun20 
-        amount: 2
-      - id: MagazineBox20gauge
+      - id: N14WeaponBlowback
+      - id: MagazineBox12gauge
+        amount: 3
       - id: ClothingBeltRope
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
       - id: N14MagazinePistol45
@@ -699,8 +699,8 @@
   - type: SpawnItemsOnUse
     items:
       - id: N14ClothingHandsPowerFistGoliath
-      - id: N14WeaponRifleSKS # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
-      - id: SKSEnbloc308 # #Misfits Change - replaced GarandEnbloc308
+      - id: N14WeaponSMG12mm # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
+      - id: N14MagazineSMG12mm #Misfits Change - replaced GarandEnbloc308
         amount: 4
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
       - id: N14MagazinePistol45
@@ -762,14 +762,10 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponRifleSKS # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
-      - id: SKSEnbloc308
+      - id: N14WeaponSMGGreaseGun # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
+      - id: Magazine45SubMachineGun
         amount: 4
       - id: ClothingBeltRope
-      - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
-      - id: N14MagazinePistol45
-        amount: 2
-      - id: N14Gladius
       - id: N14FireAxe
       - id: ThrowingKnife
         amount: 3
@@ -827,8 +823,8 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponRifleSKS # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
-      - id: SKSEnbloc308
+      - id: N14WeaponSMGGreaseGun # #Misfits Change by BILL CLINTON!: Small number role made to be paired with the NCR sarge or basic ranger kits.
+      - id: Magazine45SubMachineGun
         amount: 4
       - id: ClothingBeltRope
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
@@ -856,12 +852,10 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
-      - id: N14AmmoBox308
       - id: ClothingBeltRope
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
       - id: N14MagazinePistol45
-        amount: 2
+        amount: 4
       - id: N14Gladius
       - id: N14LegionnaireBuckler
       - id: N14HealingPowder #Misfits Change /Tweak/: replaces dirty stimpak, Legion uses tribal medicine
@@ -889,8 +883,7 @@
       - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
       - id: N14AmmoBox308
       - id: ClothingBeltRope
-      - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
-      - id: N14MagazinePistol45
+      - id: SmokeGrenade
         amount: 2
       - id: N14Whip
       - id: Stunprod
@@ -916,11 +909,8 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
-      - id: N14AmmoBox308
-      - id: ClothingBeltRope
-      - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
-      - id: N14MagazinePistol45
+      - id: N14WeaponSMGGreaseGun # #Misfits Change: .45 revolver Legion sidearm
+      - id: Magazine45SubMachineGun
         amount: 2
       - id: N14TribalMachete
       #- id: N14ClothingBeltMedicalFilled #Misfits Change /Remove/: Legion does not use stimpak medical belts
@@ -931,8 +921,6 @@
       - id: N14Bandage
         amount: 2
       - id: Ointment
-      - id: N14WeaponPistol45Colt
-      - id: N14MagazinePistol45
       - id: MagazineBox45
       - id: N14FoodTinK
         amount: 2
@@ -981,14 +969,11 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponSniperHunting # #Misfits Change: hunting rifle as Legion baseline primary
-      - id: N14AmmoBox308
       - id: ClothingBeltRope
       - id: N14WeaponPistol45Colt # #Misfits Change: .45 revolver Legion sidearm
       - id: N14MagazinePistol45
-        amount: 2
-      - id: N14TrenchClub
-      - id: N14LegionnaireShield
+        amount: 4
+      - id: N14TribalBigClub
       - id: N14HealingPowder
       - id: N14HealingPoultice #Misfits Change /Tweak/: replaces dirty stimpak, Legion uses tribal medicine
       - id: N14FoodTinK
@@ -1011,9 +996,8 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: ClothingBeltQuiverSpear
-      - id: N14WeaponSMGGreaseGun
-      - id: Magazine45SubMachineGun
+      - id: N14WeaponSMG9mm
+      - id: N14MagazineSMG9mm
         amount: 2
       - id: N14TribalMachete
       - id: N14LegionnaireBuckler

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
@@ -494,6 +494,7 @@
     - N14BPBoSWeaponPlasmaRifleUrban
     - N14BPBoSWeaponPlasmaMultiplas
     - N14BPBoSWeaponLaserRCW # #Misfits Change - moved from T5 to T3; RCW is now red-beam mid-tier
+    - N14BPBoSWeaponRipperSword
 
 - type: entity
   parent: N14BlueprintBase

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/eighties_rank_loadoutkits.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Specific/Kits/eighties_rank_loadoutkits.yml
@@ -232,7 +232,7 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-    - id: N14ripper
+    - id: N14rippersword
     - id: N14WeaponSMG12mm
     - id: N14MagazineSMG12mm
       amount: 2

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Weapons/Melee/Rippersword.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Weapons/Melee/Rippersword.yml
@@ -1,0 +1,49 @@
+- type: entity
+  name: Ripper Sword
+  parent: N14Machete
+  id: N14rippersword
+  description: A moderately rare model of ripper, dating to pre-war shocktroops. Significantly longer and heavier, it rends horrible, gaping wounds while tearing metal and flesh alike. A horrible weapon of the deranged and brutal.
+  components:
+  - type: Clothing
+    sprite: _Misfits/Objects/Weapons/Melee/rippersword.rsi
+    quickEquip: false
+    slots:
+    - Belt
+    - suitStorage
+  - type: Sprite
+    sprite: _Misfits/Objects/Weapons/Melee/rippersword.rsi
+    state: icon
+  - type: MeleeWeapon
+    autoAttack: true
+    angle: 0
+    wideAnimationRotation: -135
+    attackRate: 0.85
+    damage:
+      types:
+        Slash: 40
+        Piercing: 15
+        Structural: 40
+        Shock: 10
+    soundHit:
+      path: /Audio/_Nuclear14/Weapons/Melee/Swing/ripper.ogg
+  - type: Item
+    size: Large
+    sprite: _Misfits/Objects/Weapons/Melee/rippersword.rsi
+  - type: DisarmMalus
+  - type: RefillableSolution
+    solution: Welder
+  - type: SolutionContainerManager
+    solutions:
+      Welder:
+        reagents:
+        - ReagentId: WeldingFuel
+          Quantity: 350
+        maxVol: 350
+  - type: UseDelay
+    delay: 1
+  - type: Tool
+    qualities:
+      - Sawing
+    speedModifier: 3.0
+  - type: StaticPrice
+    price: 350

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_bos_town.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_bos_town.yml
@@ -208,6 +208,23 @@
 
     Plastic: 1200
 
+- type: latheRecipe
+  id: N14BPBoSWeaponRipperSword
+  result: N14rippersword
+  category: N14BlueprintBoSWeaponsT3
+  completetime: 15
+  requiresBlueprint: true
+  availableFaction:
+  - BrotherhoodOfSteel
+  materials:
+    Steel: 4500
+
+    Circuitry: 100
+
+    ScrapElectronic: 300
+
+    Plastic: 500
+
 
 - type: latheRecipe
   id: N14BPBoSWeaponPlasmaRifleUrban

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Specific/Kits/kits.yml
@@ -1182,7 +1182,7 @@
 # MBoS Paladin Kits
 #Misfits Change /Tweak/: Replaced auto laser rifle with auto shotgun + laser pistol sidearm.
 - type: entity
-  name: BoS Paladin Shotgun Kit
+  name: BoS Paladin Ripper Kit
   parent: KitBase
   id: KitMBoS_PalLas
   description: A crate containing everything a member of the Brotherhood might need.
@@ -1193,14 +1193,13 @@
     size: Huge
   - type: SpawnItemsOnUse
     items:
-      - id: N14WeaponShotgunAuto
-      - id: N14MagazineShotgun12
-        amount: 3
+      - id: N14rippersword
       - id: N14WeaponLaserPistol
       - id: N14PowerCellSmall
-        amount: 2
+        amount: 4
       - id: N14CleanGauze10
       - id: N14Stimpak
+        amount: 2
       - id: N14BoxCardboardMREBoxKFilled
 
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/_Misfits/drums.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/_Misfits/drums.yml
@@ -41,7 +41,7 @@
     whitelist:
       tags:
         - N14CartridgePistol22
-    capacity: 35
+    capacity: 177
     proto: N14CartridgePistol22
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -972,8 +972,8 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
     fireRate: 12
-    minAngle: 4
-    maxAngle: 16
+    minAngle: 2
+    maxAngle: 10
     angleIncrease: 2
     angleDecay: 14
     selectedMode: Fullauto


### PR DESCRIPTION
## About the PR
Gave a good number of legion loadouts a variant set, giving more sidegrade options without actually taking anything away.
Tooled up the RipperSword. Gave brotherhood kits a choice of rippersword (took away their never-used combat shotgun for it)
Gave brotherhood a rippersword BP. So yummy.
Gave the 80s big block a rippersword in his kit instead of ripper.
Made the american 180 drum IRL accurate. 177 rounds of 22lr GO MY BEES.

We can finally be bees, this is great news mark. We will live for 30 years.

## Why / Balance
Rippasword is the brotherhood melee since its a pre-war item. It is a very strong close in weapon that is primarily balanced by the brotherhood's lacking strength and close combat skills. gave them the BP so they could make it.
american 180 had 35 rounds of 22lr ima vomit this is HORRIBLE dogshit.
Legion loadouts were cookiecutter and had no soul, I needed to fix it.

## Technical details
Yaml and ftl what more could it be?

## Media

Uploading guyboss.mp4…

# Changelog

:cl: Bill
- add: Added fun new melee weapon, THE RIPPER SWORD!
- add: Added said fun new melee weapon to the big block kit, and to a paladin-grade kit. 
- remove: Removed auto-shotgun from paladin kit, replaced with said rippersword.
- tweak: Gave multiple legion variant sets for several kits.
- fix: Fixed the american 180 drum has been given its RL accurate capacity of 177 rounds
- tweak: made american 180 more accurate, off of feedback from cylinders.