### PR TITLE
More Smgs to Loadouts and Lowering Armor Cost in the Loadouts

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/head.yml
@@ -216,7 +216,7 @@
 - type: loadout
   id: N14ClothingHeadHatCombatHelmet
   category: Head
-  cost: 4
+  cost: 3 # Its 10% literally nothing
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -237,7 +237,7 @@
 - type: loadout
   id: N14ClothingHeadHatPressHelmet
   category: Head
-  cost: 4
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -258,7 +258,7 @@
 - type: loadout
   id: N14ClothingHeadHatLightBaseballHelmet
   category: Head
-  cost: 4
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -279,7 +279,7 @@
 - type: loadout
   id: N14ClothingHeadHatChineseHelmet
   category: Head
-  cost: 4
+  cost: 3
   exclusive: true
   requirements:
     - !type:CharacterTraitRequirement
@@ -300,3 +300,50 @@
        - Vault
   items:
     - N14ClothingHeadHatChineseHelmet
+
+- type: loadout
+  id: N14ClothingHeadHatPrewarMilitaryHelmet
+  category: Head
+  cost: 3
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
+  items:
+    - N14ClothingHeadHatPrewarMilitaryHelmet
+
+
+- type: loadout
+  id: N14ClothingHeadHatChineseHelmetMk2
+  category: Head
+  cost: 4 # Its actually not better than the normal helmet for some reason, but make it 4 since drip expensive I guess
+  exclusive: true
+  requirements:
+    - !type:CharacterTraitRequirement
+      traits:
+      - LanguageChinese
+      - LanguageNerd 
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutHead
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+       - Vault
+  items:
+    - N14ClothingHeadHatChineseHelmetMk2

--- a/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/outerClothing.yml
@@ -326,7 +326,7 @@
 - type: loadout
   id: N14LoadoutOuterMetalArmor
   category: Outer
-  cost: 6
+  cost: 5
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -346,7 +346,7 @@
 - type: loadout
   id: N14LoadoutOuterTribalArmor
   category: Outer
-  cost: 5
+  cost: 4
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -428,7 +428,7 @@
 - type: loadout
   id: N14LoadoutOuterScavengerHeavyArmor
   category: Outer
-  cost: 8
+  cost: 4
   requirements:
     - !type:CharacterPlaytimeRequirement
       tracker: Wastelander
@@ -478,7 +478,7 @@
 - type: loadout
   id: N14LoadoutOuterCoatCombatDuster
   category: Outer
-  cost: 7
+  cost: 6
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -499,7 +499,7 @@
 - type: loadout
   id: N14LoadoutOuterCoatFollowersArmoredCheap
   category: Outer
-  cost: 6
+  cost: 4
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -520,7 +520,7 @@
 - type: loadout
   id: N14LoadoutOuterCoatFollowersArmored
   category: Outer
-  cost: 10
+  cost: 7
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -540,7 +540,7 @@
 - type: loadout
   id: N14LoadoutOuterCombatArmorRaider 
   category: Outer
-  cost: 7 # Why cheap, it sucks its a 20% armor despite the name
+  cost: 5 # Why cheap, it sucks its a 20% armor despite the name
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -560,7 +560,7 @@
 - type: loadout
   id: N14LoadoutOuterPoliceCombat
   category: Outer
-  cost: 9
+  cost: 6
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -581,7 +581,7 @@
 - type: loadout
   id: N14LoadoutOuterPressArmor
   category: Outer
-  cost: 9
+  cost: 6
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -601,7 +601,7 @@
 - type: loadout
   id: N14LoadoutOuterCombatArmor
   category: Outer
-  cost: 18
+  cost: 12
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -621,7 +621,7 @@
 - type: loadout
   id: N14LoadoutOuterCombatArmorPainspike
   category: Outer
-  cost: 18
+  cost: 12
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -642,7 +642,7 @@
 - type: loadout
   id: N14LoadoutOuterRaiderCombat1
   category: Outer
-  cost: 18
+  cost: 12
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter
@@ -663,7 +663,7 @@
 - type: loadout
   id: N14ClothingOuterCombatArmorChinese
   category: Outer
-  cost: 18
+  cost: 12
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -687,7 +687,7 @@
 - type: loadout
   id: N14LoadoutOuterVestChinese
   category: Outer
-  cost: 17
+  cost: 11
   requirements:
     - !type:CharacterTraitRequirement
       traits:
@@ -719,7 +719,7 @@
 - type: loadout
   id: N14LoadoutOuterSoldierCoat
   category: Outer
-  cost: 2
+  cost: 3
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutOuter

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -422,6 +422,27 @@
     - N14WeaponSMG9mm
 
 - type: loadout
+  id: N14WeaponSMG9mmCanadian
+  category: Weapons
+  cost: 9
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGunsBig
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14WeaponSMG9mmCanadian
+
+
+- type: loadout
   id: N14WeaponSMG10mm
   category: Weapons
   cost: 9
@@ -484,6 +505,114 @@
       - NCRPrisoner
   items:
     - N14WeaponSMG10mmChinese
+
+
+- type: loadout
+  id: N14WeaponSMG10mmSuppressed
+  category: Weapons
+  cost: 12
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGunsBig
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14WeaponSMG10mmSuppressed
+
+- type: loadout
+  id: N14WeaponSMG45
+  category: Weapons
+  cost: 13
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGunsBig
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14WeaponSMG45
+
+
+
+- type: loadout
+  id: N14WeaponSMG12mm
+  category: Weapons
+  cost: 14
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGunsBig
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14WeaponSMG12mm
+
+
+- type: loadout
+  id: N14WeaponSMGPPSh41
+  category: Weapons
+  cost: 16
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGunsBig
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14WeaponSMGPPSh41
+
+- type: loadout
+  id: N14WeaponSMGAmerican180
+  category: Weapons
+  cost: 15
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGunsBig
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14WeaponSMGAmerican180
+
+
+
+
 
 ## Rifles
 
@@ -854,6 +983,27 @@
   items:
     - N14WeaponSMG10mmPipe
 
+
+- type: loadout
+  id: N14WeaponSMG12mmPipe
+  category: Weapons
+  cost: 7
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGunsBig
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14WeaponSMG12mmPipe
+
 ## Lasers
 
 
@@ -864,9 +1014,10 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutGuns
-    - !type:CharacterDepartmentRequirement
+    - !type:CharacterDepartmentRequirement 
+      inverted: true
       departments:
-      - BrotherhoodOfSteel
+      - Vault
   items:
     - N14WeaponLaserPistol
 
@@ -877,9 +1028,10 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutGuns
-    - !type:CharacterDepartmentRequirement
+    - !type:CharacterDepartmentRequirement 
+      inverted: true
       departments:
-      - BrotherhoodOfSteel
+      - Vault
   items:
     - N14WeaponLaserRevolver
 
@@ -1138,6 +1290,69 @@
   items:
     - N14MagazineSMG10mm
 
+- type: loadout
+  id: N14MagazineSMG12mm
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmoBig
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14MagazineSMG12mm
+
+- type: loadout
+  id: Magazine45SubMachineGun
+  category: Weapons
+  cost: 2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmoBig
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - Magazine45SubMachineGun
+
+- type: loadout
+  id: N14MagazineSMG9mmDrum
+  category: Weapons
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmoBig
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14MagazineSMG9mmDrum
+    
+- type: loadout
+  id: N14MagazineAmerican180Drum
+  category: Weapons
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmoBig
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14MagazineAmerican180Drum
 # ARs
 
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -590,25 +590,25 @@
   items:
     - N14WeaponSMGPPSh41
 
-- type: loadout
-  id: N14WeaponSMGAmerican180
-  category: Weapons
-  cost: 15
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: N14LoadoutGunsBig
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-      - Vault
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-      - BoSMidSerf
-      - CaesarLegionSlave
-      - NCRPrisoner
-  items:
-    - N14WeaponSMGAmerican180
+#- type: loadout
+#  id: N14WeaponSMGAmerican180
+#  category: Weapons
+#  cost: 15
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#      group: N14LoadoutGunsBig
+#    - !type:CharacterDepartmentRequirement
+#      inverted: true
+#      departments:
+#      - Vault
+#    - !type:CharacterJobRequirement
+#      inverted: true
+#      jobs:
+#      - BoSMidSerf
+#      - CaesarLegionSlave
+#      - NCRPrisoner
+#  items:
+#    - N14WeaponSMGAmerican180
 
 
 
@@ -1338,21 +1338,21 @@
   items:
     - N14MagazineSMG9mmDrum
     
-- type: loadout
-  id: N14MagazineAmerican180Drum
-  category: Weapons
-  cost: 3
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: N14LoadoutAmmoBig
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-      - BoSMidSerf
-      - CaesarLegionSlave
-      - NCRPrisoner
-  items:
-    - N14MagazineAmerican180Drum
+#- type: loadout
+#  id: N14MagazineAmerican180Drum
+#  category: Weapons
+#  cost: 3
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#      group: N14LoadoutAmmoBig
+#    - !type:CharacterJobRequirement
+#      inverted: true
+#      jobs:
+#      - BoSMidSerf
+#      - CaesarLegionSlave
+#      - NCRPrisoner
+#  items:
+#    - N14MagazineAmerican180Drum
 # ARs
 
 

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -508,29 +508,9 @@
 
 
 - type: loadout
-  id: N14WeaponSMG10mmSuppressed
-  category: Weapons
-  cost: 12
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: N14LoadoutGunsBig
-    - !type:CharacterDepartmentRequirement
-      inverted: true
-      departments:
-      - Vault
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-      - BoSMidSerf
-      - CaesarLegionSlave
-      - NCRPrisoner
-  items:
-    - N14WeaponSMG10mmSuppressed
-
-- type: loadout
   id: N14WeaponSMG45
   category: Weapons
-  cost: 13
+  cost: 12
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutGunsBig
@@ -552,7 +532,7 @@
 - type: loadout
   id: N14WeaponSMG12mm
   category: Weapons
-  cost: 14
+  cost: 13
   requirements:
     - !type:CharacterItemGroupRequirement
       group: N14LoadoutGunsBig


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Added some smgs to loadouts, they aren't the strongest things and made lasers be able to be taken by everyone
Cause all bos can just get an aer-7 from their kits and the makeshift laser revolver is makeshift I made them be able to be taken by everyone again
Added two new helms
Lower armor and helmet cost

Combat armor is still 12 tho
https://discord.com/channels/1471565853534322715/1471970834825482355/threads/1517000770669776996

I made this after realizing the smgs had no expensive alternatives
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: 45, 12.7 and the PPsh41 Smgs to Loadout
- tweak: Makeshift Laser Revolver and aer-7 being bos only
- tweak: Armor is Slightly cheaper
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
