### PR TITLE
Forcewarjoin Perm Fix

### DIFF
--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -94,3 +94,4 @@
 - Flags: ADMIN
   Commands:
     - forcewar
+    - forcewarjoin

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -91,6 +91,8 @@
 - Flags: ADMIN
   Commands:
   - delete
+  - forcewar
+  - forcewarjoin
   - kick
   - listplayers
   - tp


### PR DESCRIPTION
## About the PR

Allows Compliance Officer+ to use the `forcewarjoin` command.

## Why / Balance

This lets lower-level staff with standard admin permissions force a player onto an existing faction war side when needed for moderation.

## Technical details

Added `forcewarjoin` to admin command permissions in both client and server command permission lists. Also added `forcewar` to server-side engine permissions to match its existing client-side admin permission entry.

# Changelog

:cl:
- tweak: Allowed Compliance Officers to use the force war join command.