### PR TITLE
Adds NCR MP Comms

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -89,8 +89,8 @@
       - EncryptionKeyPBS
       - EncryptionKeyNCRMPRecruit # Misfits Add — NCRMP Comms
       - EncryptionKeyNCRMPSergeant
-      - EncryptionKeyNCRMPCaptain
-      - EncryptionKeyNCRCO
+      - EncryptionKeyNCRMPLieutenant
+      - EncryptionKeyNCRSeniorOfficer
 
 - type: entity
   parent: TelecomServer

--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -87,6 +87,10 @@
       - EncryptionKeyLegion # #Misfits Change /Fix/: Legion headsets require telecom support for :l to relay.
       - EncryptionKeyVault
       - EncryptionKeyPBS
+      - EncryptionKeyNCRMPRecruit # Misfits Add — NCRMP Comms
+      - EncryptionKeyNCRMPSergeant
+      - EncryptionKeyNCRMPCaptain
+      - EncryptionKeyNCRCO
 
 - type: entity
   parent: TelecomServer

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/MilitaryPolice/ncr_military_police_captain.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/MilitaryPolice/ncr_military_police_captain.yml
@@ -43,7 +43,7 @@
     shoes: N14ClothingBootsCombatFilled
     belt: ClothingBeltNCR
     eyes: ClothingEyesGlassesSunglasses
-    ears: MisfitsClothingHeadsetNCRMPCaptain
+    ears: MisfitsClothingHeadsetNCRMPLieutenant
     pocket1: NCRMPKit_Set
     id: N14IDNCRDogtagMPCaptain
   innerClothingSkirt: N14ClothingOfficerUniformNCRDesert

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/MilitaryPolice/ncr_military_police_captain.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/MilitaryPolice/ncr_military_police_captain.yml
@@ -43,7 +43,7 @@
     shoes: N14ClothingBootsCombatFilled
     belt: ClothingBeltNCR
     eyes: ClothingEyesGlassesSunglasses
-    ears: N14ClothingHeadsetNCR
+    ears: MisfitsClothingHeadsetNCRMPCaptain
     pocket1: NCRMPKit_Set
     id: N14IDNCRDogtagMPCaptain
   innerClothingSkirt: N14ClothingOfficerUniformNCRDesert

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/MilitaryPolice/ncr_military_police_recruit.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/MilitaryPolice/ncr_military_police_recruit.yml
@@ -43,7 +43,7 @@
     shoes: N14ClothingBootsCombatFilled
     belt: ClothingBeltNCR
     eyes: ClothingEyesGlassesSunglasses
-    ears: N14ClothingHeadsetNCR
+    ears: MisfitsClothingHeadsetNCRMPRecruit
     pocket1: NCRMPKit_Set
     id: N14IDNCRDogtagMPRecruit
   innerClothingSkirt: N14ClothingOfficerUniformNCRDesert

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/MilitaryPolice/ncr_military_police_sergeant.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/MilitaryPolice/ncr_military_police_sergeant.yml
@@ -42,7 +42,7 @@
     shoes: N14ClothingBootsCombatFilled
     belt: ClothingBeltNCR
     eyes: ClothingEyesGlassesSunglasses
-    ears: N14ClothingHeadsetNCR
+    ears: MisfitsClothingHeadsetNCRMPSergeant
     pocket1: NCRMPKit_Set
     id: N14IDNCRDogtagMPSergeant
   innerClothingSkirt: N14ClothingOfficerUniformNCRDesert

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
@@ -48,7 +48,7 @@
 
     belt: ClothingBeltNCR
     eyes: ClothingEyesGlassesSunglasses
-    ears: MisfitsClothingHeadsetNCRCO
+    ears: MisfitsClothingHeadsetNCROfficer
     pocket1: NCRcaptainloadoutkits
     pocket2: TrainingManualPowerArmorOperation
     id: N14IDNCRDogtagCaptain

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_captain.yml
@@ -48,7 +48,7 @@
 
     belt: ClothingBeltNCR
     eyes: ClothingEyesGlassesSunglasses
-    ears: N14ClothingHeadsetNCR
+    ears: MisfitsClothingHeadsetNCRCO
     pocket1: NCRcaptainloadoutkits
     pocket2: TrainingManualPowerArmorOperation
     id: N14IDNCRDogtagCaptain

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_major.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/NCR/ncr_major.yml
@@ -57,7 +57,7 @@
     neck: ClothingNeckPinNCRMajor
     belt: ClothingBeltNCR
     eyes: ClothingEyesGlassesSunglasses
-    ears: N14ClothingHeadsetNCR
+    ears: MisfitsClothingHeadsetNCROfficer
     pocket1: NCRcaptainloadoutkits
     pocket2: RadioHandheld
     id: N14IDNCRDogtagMajor

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
@@ -267,6 +267,22 @@
 
 - type: entity
   parent: N14ClothingHeadsetAlt
+  id: MisfitsClothingHeadsetNCRMPLieutenant
+  name: NCR MP Lieutenant radio earpiece
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyNCR
+      - EncryptionKeyNCRMPLieutenant
+      - EncryptionKeyWastelandGlobal
+  - type: Sprite
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+  - type: Clothing
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+
+- type: entity
+  parent: N14ClothingHeadsetAlt
   id: MisfitsClothingHeadsetNCROfficer
   name: NCR Senior Officer radio earpiece
   components:

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
@@ -231,3 +231,69 @@
     sprite: Clothing/Ears/Headsets/security.rsi
   - type: Clothing
     sprite: Clothing/Ears/Headsets/security.rsi
+
+# Misfits Add — NCR Military Police headsets
+- type: entity
+  parent: N14ClothingHeadsetAlt
+  id: MisfitsClothingHeadsetNCRMPRecruit
+  name: NCR MP Recruit radio earpiece
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyNCR
+      - EncryptionKeyNCRMPRecruit
+      - EncryptionKeyWastelandGlobal
+  - type: Sprite
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+  - type: Clothing
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+
+- type: entity
+  parent: N14ClothingHeadsetAlt
+  id: MisfitsClothingHeadsetNCRMPSergeant
+  name: NCR MP Sergeant radio earpiece
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyNCR
+      - EncryptionKeyNCRMPSergeant
+      - EncryptionKeyWastelandGlobal
+  - type: Sprite
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+  - type: Clothing
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+
+- type: entity
+  parent: N14ClothingHeadsetAlt
+  id: MisfitsClothingHeadsetNCRMPCaptain
+  name: NCR MP Captain radio earpiece
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyNCR
+      - EncryptionKeyNCRMPCaptain
+      - EncryptionKeyWastelandGlobal
+  - type: Sprite
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+  - type: Clothing
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+
+- type: entity
+  parent: N14ClothingHeadsetAlt
+  id: MisfitsClothingHeadsetNCRCO
+  name: NCR CO radio earpiece
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyNCR
+      - EncryptionKeyNCRCO
+      - EncryptionKeyWastelandGlobal
+  - type: Sprite
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+  - type: Clothing
+    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
+

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
@@ -267,24 +267,8 @@
 
 - type: entity
   parent: N14ClothingHeadsetAlt
-  id: MisfitsClothingHeadsetNCRMPCaptain
-  name: NCR MP Captain radio earpiece
-  components:
-  - type: ContainerFill
-    containers:
-      key_slots:
-      - EncryptionKeyNCR
-      - EncryptionKeyNCRMPCaptain
-      - EncryptionKeyWastelandGlobal
-  - type: Sprite
-    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
-  - type: Clothing
-    sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi
-
-- type: entity
-  parent: N14ClothingHeadsetAlt
-  id: MisfitsClothingHeadsetNCRCO
-  name: NCR CO radio earpiece
+  id: MisfitsClothingHeadsetNCROfficer
+  name: NCR Senior Officer radio earpiece
   components:
   - type: ContainerFill
     containers:

--- a/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Clothing/Ears/headsets_alt.yml
@@ -290,7 +290,7 @@
     containers:
       key_slots:
       - EncryptionKeyNCR
-      - EncryptionKeyNCRCO
+      - EncryptionKeyNCRSeniorOfficer
       - EncryptionKeyWastelandGlobal
   - type: Sprite
     sprite: _Misfits/Clothing/Ears/Headsets/ncr.rsi

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
@@ -218,7 +218,7 @@
 - type: entity
   parent: EncryptionKey
   id: EncryptionKeyNCRMPCaptain
-  name: NCR MP Officer encryption key
+  name: NCR MP Lieutenant encryption key
   description: An encryption key used by NCR Military Police Lieutenants.
   components:
   - type: EncryptionKey

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
@@ -217,7 +217,7 @@
 
 - type: entity
   parent: EncryptionKey
-  id: EncryptionKeyNCRMPCaptain
+  id: EncryptionKeyNCRMPLieutenant
   name: NCR MP Lieutenant encryption key
   description: An encryption key used by NCR Military Police Lieutenants.
   components:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
@@ -232,9 +232,9 @@
 
 - type: entity
   parent: EncryptionKey
-  id: EncryptionKeyNCRCO
-  name: NCR CO encryption key
-  description: An encryption key used by NCR Commanding Officers.
+  id: EncryptionKeyNCRSeniorOfficer
+  name: NCR Senior Officer encryption key
+  description: An encryption key used by NCR Senior Officers.
   components:
   - type: EncryptionKey
     channels:

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Devices/encryption_keys.yml
@@ -183,3 +183,65 @@
     layers:
     - state: crypt_gray
     - state: com_label
+
+# NCR Military Police encryption keys
+- type: entity
+  parent: EncryptionKey
+  id: EncryptionKeyNCRMPRecruit
+  name: NCR MP Recruit encryption key
+  description: An encryption key used by NCR Military Police Recruits.
+  components:
+  - type: EncryptionKey
+    channels:
+    - NCRMP
+    defaultChannel: NCRMP
+  - type: Sprite
+    layers:
+    - state: crypt_gray
+    - state: sec_label
+
+- type: entity
+  parent: EncryptionKey
+  id: EncryptionKeyNCRMPSergeant
+  name: NCR MP Sergeant encryption key
+  description: An encryption key used by NCR Military Police Sergeants.
+  components:
+  - type: EncryptionKey
+    channels:
+    - NCRMP
+    defaultChannel: NCRMP
+  - type: Sprite
+    layers:
+    - state: crypt_gray
+    - state: sec_label
+
+- type: entity
+  parent: EncryptionKey
+  id: EncryptionKeyNCRMPCaptain
+  name: NCR MP Officer encryption key
+  description: An encryption key used by NCR Military Police Lieutenants.
+  components:
+  - type: EncryptionKey
+    channels:
+    - NCRMP
+    defaultChannel: NCRMP
+  - type: Sprite
+    layers:
+    - state: crypt_gray
+    - state: sec_label
+
+- type: entity
+  parent: EncryptionKey
+  id: EncryptionKeyNCRCO
+  name: NCR CO encryption key
+  description: An encryption key used by NCR Commanding Officers.
+  components:
+  - type: EncryptionKey
+    channels:
+    - NCRMP
+    defaultChannel: NCRMP
+  - type: Sprite
+    layers:
+    - state: crypt_gray
+    - state: com_label
+

--- a/Resources/Prototypes/_Nuclear14/radio_channels.yml
+++ b/Resources/Prototypes/_Nuclear14/radio_channels.yml
@@ -151,6 +151,14 @@
   # # long range since otherwise it'd defeat the point of a handheld radio independent of telecomms
   # longRange: true
 
+# Misfits Add — NCRMP radio channel for NCR Military Police, accessible to all MPs and the NCR CO via headsets.
+- type: radioChannel
+  id: NCRMP
+  name: NCRMP
+  keycode: 'm'
+  frequency: 1551
+  color: "#4a5fa5"
+
 # - type: radioChannel
   # id: Freelance
   # name: chat-radio-freelance


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
Adds a new NCRMP Channel for MPs, and Senior Officers (Captain and Major COs, XOs can also be included if maints want)
Adds new headsets and encryption keys for MPs and Senior Officers, mostly for futureproofing and code sanity.

## Why / Balance
As it stands, the second someone deserts or comms get compromised, you basically cannot organize a decent field arrest without making a bunch of hand radios. This should allow MPs to organize efforts without having to sift through the clutter that is normal comms.

## Technical details
New Encryption Keys, and Headset alongside new MP comms to compliment.

## Media
<img width="525" height="27" alt="image" src="https://github.com/user-attachments/assets/515583ca-04f5-434c-8df3-5503606edc0a" />

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added a new NCRMP Channel for MPs, and Senior Officers.
- add: Added new headsets and encryption keys for MPs and Senior Officers.
