### PR TITLE
Vault Overseer Overwatch Terminal, Reagent Grinder Turned On

### DIFF
--- a/Resources/Maps/Misfits/Vault.yml
+++ b/Resources/Maps/Misfits/Vault.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 275.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/19/2026 03:22:30
+  time: 06/19/2026 03:32:24
   entityCount: 26805
 maps:
 - 1
@@ -39556,7 +39556,7 @@ entities:
       containers:
       - drink
     - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.6494287
+      sprayFizzinessThresholdRoll: 0.62781173
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -39892,7 +39892,7 @@ entities:
       containers:
       - drink
     - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.58509374
+      sprayFizzinessThresholdRoll: 0.47184741
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -40171,7 +40171,7 @@ entities:
       containers:
       - drink
     - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.20334697
+      sprayFizzinessThresholdRoll: 0.448793
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -44292,7 +44292,7 @@ entities:
       pos: -33.5,10.5
       parent: 2
     - type: Drain
-      accumulator: 0.076071285
+      accumulator: 0.71893626
     - type: Fixtures
       fixtures: {}
   - uid: 7040
@@ -44301,7 +44301,7 @@ entities:
       pos: 72.5,23.5
       parent: 2
     - type: Drain
-      accumulator: 0.31734005
+      accumulator: 0.04775869
     - type: Fixtures
       fixtures: {}
   - uid: 7041
@@ -44311,7 +44311,7 @@ entities:
       pos: 74.5,21.5
       parent: 2
     - type: Drain
-      accumulator: 0.25261042
+      accumulator: 0.8734095
     - type: Fixtures
       fixtures: {}
   - uid: 7042
@@ -44321,7 +44321,7 @@ entities:
       pos: 76.5,21.5
       parent: 2
     - type: Drain
-      accumulator: 0.19121452
+      accumulator: 0.82316226
     - type: Fixtures
       fixtures: {}
   - uid: 7043
@@ -44330,7 +44330,7 @@ entities:
       pos: 72.5,21.5
       parent: 2
     - type: Drain
-      accumulator: 0.52060276
+      accumulator: 0.352235
     - type: Fixtures
       fixtures: {}
   - uid: 7044
@@ -44340,7 +44340,7 @@ entities:
       pos: 76.5,23.5
       parent: 2
     - type: Drain
-      accumulator: 0.6015008
+      accumulator: 0.15043657
     - type: Fixtures
       fixtures: {}
   - uid: 7045
@@ -44349,7 +44349,7 @@ entities:
       pos: -209.5,-5.5
       parent: 2
     - type: Drain
-      accumulator: 0.45067862
+      accumulator: 0.385453
     - type: Fixtures
       fixtures: {}
   - uid: 7046
@@ -44358,7 +44358,7 @@ entities:
       pos: -214.5,-3.5
       parent: 2
     - type: Drain
-      accumulator: 0.2999402
+      accumulator: 0.38488445
     - type: Fixtures
       fixtures: {}
   - uid: 7047
@@ -44367,7 +44367,7 @@ entities:
       pos: -106.5,-9.5
       parent: 2
     - type: Drain
-      accumulator: 0.9531135
+      accumulator: 0.14454108
     - type: Fixtures
       fixtures: {}
   - uid: 7048
@@ -44376,7 +44376,7 @@ entities:
       pos: 37.5,-0.5
       parent: 2
     - type: Drain
-      accumulator: 0.31674778
+      accumulator: 0.31745526
     - type: Fixtures
       fixtures: {}
   - uid: 7049
@@ -44385,7 +44385,7 @@ entities:
       pos: 37.5,-2.5
       parent: 2
     - type: Drain
-      accumulator: 0.403107
+      accumulator: 0.35380706
     - type: Fixtures
       fixtures: {}
   - uid: 7050
@@ -44394,7 +44394,7 @@ entities:
       pos: -95.5,58.5
       parent: 2
     - type: Drain
-      accumulator: 0.1965334
+      accumulator: 0.4322809
     - type: Fixtures
       fixtures: {}
   - uid: 7051
@@ -44404,7 +44404,7 @@ entities:
       pos: -81.5,72.5
       parent: 2
     - type: Drain
-      accumulator: 0.88687676
+      accumulator: 0.7327667
     - type: Fixtures
       fixtures: {}
   - uid: 7052
@@ -44413,7 +44413,7 @@ entities:
       pos: 32.5,26.5
       parent: 2
     - type: Drain
-      accumulator: 0.53858835
+      accumulator: 0.30117497
     - type: Fixtures
       fixtures: {}
   - uid: 7053
@@ -44422,7 +44422,7 @@ entities:
       pos: 34.5,26.5
       parent: 2
     - type: Drain
-      accumulator: 0.9534032
+      accumulator: 0.5074324
     - type: Fixtures
       fixtures: {}
   - uid: 7054
@@ -44432,7 +44432,7 @@ entities:
       pos: 96.5,1.5
       parent: 2
     - type: Drain
-      accumulator: 0.61224085
+      accumulator: 0.91427606
     - type: Fixtures
       fixtures: {}
   - uid: 7055
@@ -44442,7 +44442,7 @@ entities:
       pos: 96.5,3.5
       parent: 2
     - type: Drain
-      accumulator: 0.5324394
+      accumulator: 0.09514059
     - type: Fixtures
       fixtures: {}
   - uid: 7056
@@ -44451,7 +44451,7 @@ entities:
       pos: 91.5,21.5
       parent: 2
     - type: Drain
-      accumulator: 0.57521915
+      accumulator: 0.12954704
     - type: Fixtures
       fixtures: {}
   - uid: 7057
@@ -44460,7 +44460,7 @@ entities:
       pos: 93.5,42.5
       parent: 2
     - type: Drain
-      accumulator: 0.98786443
+      accumulator: 0.13702291
     - type: Fixtures
       fixtures: {}
 - proto: FloorTileItemSteel
@@ -61790,7 +61790,7 @@ entities:
       pos: -40.5,56.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1156561.4
+      secondsUntilStateChange: -1156616.5
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 3
@@ -80940,7 +80940,7 @@ entities:
       pos: -92.5,67.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1176113.2
+      secondsUntilStateChange: -1176168.4
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -80996,7 +80996,7 @@ entities:
       pos: -1.5,15.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1921102.4
+      secondsUntilStateChange: -1921157.5
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -81225,7 +81225,7 @@ entities:
       pos: 2.5,26.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1063060.5
+      secondsUntilStateChange: -1063115.6
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -81918,7 +81918,7 @@ entities:
       pos: -85.5,-47.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -411825.9
+      secondsUntilStateChange: -411880.97
       canPry: False
       state: Opening
   - uid: 11875
@@ -82040,7 +82040,7 @@ entities:
       pos: -94.5,-48.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -411013.72
+      secondsUntilStateChange: -411068.78
       canPry: False
       state: Opening
   - uid: 11890
@@ -91410,7 +91410,7 @@ entities:
       pos: -80.5,4.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1178494.4
+      secondsUntilStateChange: -1178549.5
       state: Closing
   - uid: 13091
     components:
@@ -91423,7 +91423,7 @@ entities:
       pos: -171.5,-57.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -128696.28
+      secondsUntilStateChange: -128751.34
       state: Closing
 - proto: N14JunkDresser
   entities:
@@ -92828,7 +92828,7 @@ entities:
     - type: Openable
       opened: True
     - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.8349481
+      sprayFizzinessThresholdRoll: 0.9694594
     - type: ContainerContainer
       containers:
         solution@drink: !type:ContainerSlot
@@ -171935,7 +171935,7 @@ entities:
       solutions:
         output:
           temperature: 293.15
-          canReact: True
+          canReact: False
           maxVol: 1000
           name: null
           reagents: []

--- a/Resources/Maps/Misfits/Vault.yml
+++ b/Resources/Maps/Misfits/Vault.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 275.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/18/2026 00:01:35
+  time: 06/19/2026 03:22:30
   entityCount: 26805
 maps:
 - 1
@@ -39556,7 +39556,7 @@ entities:
       containers:
       - drink
     - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.1623765
+      sprayFizzinessThresholdRoll: 0.6494287
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -39892,7 +39892,7 @@ entities:
       containers:
       - drink
     - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.66247183
+      sprayFizzinessThresholdRoll: 0.58509374
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -40171,7 +40171,7 @@ entities:
       containers:
       - drink
     - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.4845425
+      sprayFizzinessThresholdRoll: 0.20334697
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -44292,7 +44292,7 @@ entities:
       pos: -33.5,10.5
       parent: 2
     - type: Drain
-      accumulator: 0.920517
+      accumulator: 0.076071285
     - type: Fixtures
       fixtures: {}
   - uid: 7040
@@ -44301,7 +44301,7 @@ entities:
       pos: 72.5,23.5
       parent: 2
     - type: Drain
-      accumulator: 0.9262642
+      accumulator: 0.31734005
     - type: Fixtures
       fixtures: {}
   - uid: 7041
@@ -44311,7 +44311,7 @@ entities:
       pos: 74.5,21.5
       parent: 2
     - type: Drain
-      accumulator: 0.7753609
+      accumulator: 0.25261042
     - type: Fixtures
       fixtures: {}
   - uid: 7042
@@ -44321,7 +44321,7 @@ entities:
       pos: 76.5,21.5
       parent: 2
     - type: Drain
-      accumulator: 0.83057576
+      accumulator: 0.19121452
     - type: Fixtures
       fixtures: {}
   - uid: 7043
@@ -44330,7 +44330,7 @@ entities:
       pos: 72.5,21.5
       parent: 2
     - type: Drain
-      accumulator: 0.7735782
+      accumulator: 0.52060276
     - type: Fixtures
       fixtures: {}
   - uid: 7044
@@ -44340,7 +44340,7 @@ entities:
       pos: 76.5,23.5
       parent: 2
     - type: Drain
-      accumulator: 0.6480938
+      accumulator: 0.6015008
     - type: Fixtures
       fixtures: {}
   - uid: 7045
@@ -44349,7 +44349,7 @@ entities:
       pos: -209.5,-5.5
       parent: 2
     - type: Drain
-      accumulator: 0.2602837
+      accumulator: 0.45067862
     - type: Fixtures
       fixtures: {}
   - uid: 7046
@@ -44358,7 +44358,7 @@ entities:
       pos: -214.5,-3.5
       parent: 2
     - type: Drain
-      accumulator: 0.15032446
+      accumulator: 0.2999402
     - type: Fixtures
       fixtures: {}
   - uid: 7047
@@ -44367,7 +44367,7 @@ entities:
       pos: -106.5,-9.5
       parent: 2
     - type: Drain
-      accumulator: 0.61250454
+      accumulator: 0.9531135
     - type: Fixtures
       fixtures: {}
   - uid: 7048
@@ -44376,7 +44376,7 @@ entities:
       pos: 37.5,-0.5
       parent: 2
     - type: Drain
-      accumulator: 0.45859587
+      accumulator: 0.31674778
     - type: Fixtures
       fixtures: {}
   - uid: 7049
@@ -44385,7 +44385,7 @@ entities:
       pos: 37.5,-2.5
       parent: 2
     - type: Drain
-      accumulator: 0.038489383
+      accumulator: 0.403107
     - type: Fixtures
       fixtures: {}
   - uid: 7050
@@ -44394,7 +44394,7 @@ entities:
       pos: -95.5,58.5
       parent: 2
     - type: Drain
-      accumulator: 0.66377956
+      accumulator: 0.1965334
     - type: Fixtures
       fixtures: {}
   - uid: 7051
@@ -44404,7 +44404,7 @@ entities:
       pos: -81.5,72.5
       parent: 2
     - type: Drain
-      accumulator: 0.4094761
+      accumulator: 0.88687676
     - type: Fixtures
       fixtures: {}
   - uid: 7052
@@ -44413,7 +44413,7 @@ entities:
       pos: 32.5,26.5
       parent: 2
     - type: Drain
-      accumulator: 0.91030014
+      accumulator: 0.53858835
     - type: Fixtures
       fixtures: {}
   - uid: 7053
@@ -44422,7 +44422,7 @@ entities:
       pos: 34.5,26.5
       parent: 2
     - type: Drain
-      accumulator: 0.30581436
+      accumulator: 0.9534032
     - type: Fixtures
       fixtures: {}
   - uid: 7054
@@ -44432,7 +44432,7 @@ entities:
       pos: 96.5,1.5
       parent: 2
     - type: Drain
-      accumulator: 0.6040603
+      accumulator: 0.61224085
     - type: Fixtures
       fixtures: {}
   - uid: 7055
@@ -44442,7 +44442,7 @@ entities:
       pos: 96.5,3.5
       parent: 2
     - type: Drain
-      accumulator: 0.42587382
+      accumulator: 0.5324394
     - type: Fixtures
       fixtures: {}
   - uid: 7056
@@ -44451,7 +44451,7 @@ entities:
       pos: 91.5,21.5
       parent: 2
     - type: Drain
-      accumulator: 0.522602
+      accumulator: 0.57521915
     - type: Fixtures
       fixtures: {}
   - uid: 7057
@@ -44460,7 +44460,7 @@ entities:
       pos: 93.5,42.5
       parent: 2
     - type: Drain
-      accumulator: 0.89217454
+      accumulator: 0.98786443
     - type: Fixtures
       fixtures: {}
 - proto: FloorTileItemSteel
@@ -61790,7 +61790,7 @@ entities:
       pos: -40.5,56.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1156324.1
+      secondsUntilStateChange: -1156561.4
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 3
@@ -67677,12 +67677,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 19.5,37.5
       parent: 2
-  - uid: 9977
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,41.5
-      parent: 2
   - uid: 9978
     components:
     - type: Transform
@@ -67851,6 +67845,14 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 53.5,10.5
+      parent: 2
+- proto: N14ComputerVaultOverwatch
+  entities:
+  - uid: 9977
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,41.5
       parent: 2
 - proto: N14ComputerVDU
   entities:
@@ -80938,7 +80940,7 @@ entities:
       pos: -92.5,67.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1175876
+      secondsUntilStateChange: -1176113.2
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -80994,7 +80996,7 @@ entities:
       pos: -1.5,15.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1920865.1
+      secondsUntilStateChange: -1921102.4
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -81223,7 +81225,7 @@ entities:
       pos: 2.5,26.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1062823.2
+      secondsUntilStateChange: -1063060.5
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -81363,6 +81365,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -32.5,15.5
       parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        26291:
+        - - DoorStatus
+          - Forward
   - uid: 11792
     components:
     - type: Transform
@@ -81911,7 +81918,7 @@ entities:
       pos: -85.5,-47.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -411588.6
+      secondsUntilStateChange: -411825.9
       canPry: False
       state: Opening
   - uid: 11875
@@ -82033,7 +82040,7 @@ entities:
       pos: -94.5,-48.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -410776.4
+      secondsUntilStateChange: -411013.72
       canPry: False
       state: Opening
   - uid: 11890
@@ -91403,7 +91410,7 @@ entities:
       pos: -80.5,4.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1178257.1
+      secondsUntilStateChange: -1178494.4
       state: Closing
   - uid: 13091
     components:
@@ -91416,7 +91423,7 @@ entities:
       pos: -171.5,-57.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -128458.984
+      secondsUntilStateChange: -128696.28
       state: Closing
 - proto: N14JunkDresser
   entities:
@@ -92821,7 +92828,7 @@ entities:
     - type: Openable
       opened: True
     - type: PressurizedSolution
-      sprayFizzinessThresholdRoll: 0.9650389
+      sprayFizzinessThresholdRoll: 0.8349481
     - type: ContainerContainer
       containers:
         solution@drink: !type:ContainerSlot
@@ -171924,6 +171931,20 @@ entities:
     - type: Transform
       pos: -37.5,11.5
       parent: 2
+    - type: SolutionContainerManager
+      solutions:
+        output:
+          temperature: 293.15
+          canReact: True
+          maxVol: 1000
+          name: null
+          reagents: []
+    - type: MaterialReclaimer
+      enabled: True
+    - type: DeviceLinkSink
+      invokeCounter: 1
+      links:
+      - 11791
 - proto: ReinforcedWindow
   entities:
   - uid: 26292


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
Replaces existing overseer terminal with the new overwatch one
Makes the reagent grinder turned on by default, increases its capacity to stop it spilling reagents everywhere 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added the overseer overwatch terminal to their office
