### PR TITLE
Eighties Riding

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -2790,14 +2790,7 @@ namespace Content.Client.Lobby.UI
             var shotCrit = Math.Clamp(delta * tuning.LuckSingleShotCriticalChancePerPoint, 0f, 1f);
             var revolverCrit = Math.Clamp(shotCrit * 2f, 0f, 1f);
             var luckyLoot = Math.Clamp(delta * tuning.LuckLootChancePerPoint, 0f, 1f);
-            var clumsy = value switch
-            {
-                1 => 0.50f,
-                2 => 0.05f,
-                3 => 0.03f,
-                4 => 0.01f,
-                _ => 0f,
-            };
+            var clumsy = value == 1 ? 0.10f : 0f;
             var unlucky = value switch
             {
                 2 => 0.05f,

--- a/Content.Server/_Misfits/SpecialStats/SpecialPenaltySystem.cs
+++ b/Content.Server/_Misfits/SpecialStats/SpecialPenaltySystem.cs
@@ -16,10 +16,7 @@ public sealed class SpecialPenaltySystem : EntitySystem
 
     private const int LowCharismaThreshold = 5;
     private const int LowIntelligenceThreshold = 2;
-    private const float ClumsyLuckOneChance = 0.50f;
-    private const float ClumsyLuckTwoChance = 0.05f;
-    private const float ClumsyLuckThreeChance = 0.03f;
-    private const float ClumsyLuckFourChance = 0.01f;
+    private const float ClumsyLuckOneChance = 0.10f;
 
     public override void Initialize()
     {
@@ -62,9 +59,8 @@ public sealed class SpecialPenaltySystem : EntitySystem
         else
             ClearLowIntelligence(ent.Owner);
 
-        var luck = _special.GetEffective(ent.Owner, SpecialStat.Luck, ent.Comp);
-        if (TryGetLuckClumsyChance(luck, out var clumsyChance))
-            ApplyLuckClumsy(ent.Owner, clumsyChance);
+        if (_special.GetEffective(ent.Owner, SpecialStat.Luck, ent.Comp) == 1)
+            ApplyLuckClumsy(ent.Owner, ClumsyLuckOneChance);
         else
             ClearLuckClumsy(ent.Owner);
     }
@@ -88,20 +84,6 @@ public sealed class SpecialPenaltySystem : EntitySystem
     private void ClearLowIntelligence(EntityUid uid)
     {
         RemComp<LowIntelligenceAccentComponent>(uid);
-    }
-
-    private static bool TryGetLuckClumsyChance(int luck, out float chance)
-    {
-        chance = luck switch
-        {
-            1 => ClumsyLuckOneChance,
-            2 => ClumsyLuckTwoChance,
-            3 => ClumsyLuckThreeChance,
-            4 => ClumsyLuckFourChance,
-            _ => 0f,
-        };
-
-        return chance > 0f;
     }
 
     private void ApplyLuckClumsy(EntityUid uid, float chance)

--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
@@ -41,6 +41,8 @@
         factions:
           - PlayerRaider
           - Wastelander
+  - !type:AddTraitSpecial
+    traits: [ N14RidingPerk ]
 
 - type: startingGear
   id: EightiesTheBlockGear
@@ -103,6 +105,8 @@
         factions:
           - PlayerRaider
           - Wastelander
+  - !type:AddTraitSpecial
+    traits: [ N14RidingPerk ]
 
 - type: startingGear
   id: EightiesCylindersGear
@@ -163,6 +167,8 @@
         factions:
           - PlayerRaider
           - Wastelander
+  - !type:AddTraitSpecial
+    traits: [ N14RidingPerk ]
 
 - type: startingGear
   id: EightiesPistonsGear
@@ -223,6 +229,8 @@
         factions:
           - PlayerRaider
           - Wastelander
+  - !type:AddTraitSpecial
+    traits: [ N14RidingPerk ]
 
 - type: startingGear
   id: EightiesOilersGear
@@ -284,6 +292,8 @@
         factions:
           - PlayerRaider
           - Wastelander
+  - !type:AddTraitSpecial
+    traits: [ N14RidingPerk ]
 
 - type: startingGear
   id: EightiesRoadRashGear


### PR DESCRIPTION
## About the PR

Grants the Riding trait to all five active Eighties roles.

## Why / Balance

The Eighties are a motorbike-focused faction, so every rank should be able to use their mounts without spending trait points.

## Technical details

Added `N14RidingPerk` via `AddTraitSpecial` to The Block, Cylinders, Pistons, Oilers, and Road Rash jobs.

# Changelog

:cl:
- tweak: All Eighties roles now receive the Riding trait by default.