### PR TITLE
Adds Chemist Trait that Lets You See Solution Contents on Examine

### DIFF
--- a/Content.Server/_Nuclear14/Chemistry/ChemistTrainingComponent.cs
+++ b/Content.Server/_Nuclear14/Chemistry/ChemistTrainingComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Server._Nuclear14.Chemistry;
+
+[RegisterComponent]
+public sealed partial class ChemistTrainingComponent : Component { }

--- a/Content.Server/_Nuclear14/Chemistry/ChemistTraitSystem.cs
+++ b/Content.Server/_Nuclear14/Chemistry/ChemistTraitSystem.cs
@@ -1,0 +1,59 @@
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Examine;
+using Robust.Shared.Prototypes;
+using System.Linq;
+
+namespace Content.Server._Nuclear14.Chemistry;
+
+public sealed class ChemistTraitSystem : EntitySystem
+{
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionSystem = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SolutionContainerManagerComponent, ExaminedEvent>(OnExamineSolutionContainer);
+    }
+
+    private void OnExamineSolutionContainer(Entity<SolutionContainerManagerComponent> entity, ref ExaminedEvent args)
+    {
+        if (HasComp<ExaminableSolutionComponent>(entity))
+            return;
+
+        if (!HasComp<SolutionScannerComponent>(args.Examiner))
+            return;
+
+        var reagentLines = new List<string>();
+        foreach (var (_, solutionEntity) in _solutionSystem.EnumerateSolutions(entity))
+        {
+            var solution = solutionEntity.Comp.Solution;
+            if (solution.Volume <= 0)
+                continue;
+
+            var sorted = solution.GetReagentPrototypes(_prototype)
+                .OrderByDescending(pair => pair.Value.Value)
+                .ThenBy(pair => pair.Key.LocalizedName);
+
+            foreach (var (proto, quantity) in sorted)
+            {
+                reagentLines.Add(Loc.GetString("scannable-solution-chemical",
+                    ("type", proto.LocalizedName),
+                    ("color", proto.SubstanceColor.ToHexNoAlpha()),
+                    ("amount", quantity)));
+            }
+        }
+
+        if (reagentLines.Count == 0)
+            return;
+
+        using (args.PushGroup(nameof(ChemistTraitSystem)))
+        {
+            args.PushMarkup(Loc.GetString("scannable-solution-main-text"));
+            foreach (var line in reagentLines)
+                args.PushMarkup(line);
+        }
+    }
+}

--- a/Content.Server/_Nuclear14/Chemistry/ChemistTraitSystem.cs
+++ b/Content.Server/_Nuclear14/Chemistry/ChemistTraitSystem.cs
@@ -27,7 +27,7 @@ public sealed class ChemistTraitSystem : EntitySystem
             return;
 
         var reagentLines = new List<string>();
-        foreach (var (_, solutionEntity) in _solutionSystem.EnumerateSolutions(entity))
+        foreach (var (_, solutionEntity) in _solutionSystem.EnumerateSolutions((Entity<SolutionContainerManagerComponent?>) entity))
         {
             var solution = solutionEntity.Comp.Solution;
             if (solution.Volume <= 0)

--- a/Content.Server/_Nuclear14/Chemistry/ChemistTraitSystem.cs
+++ b/Content.Server/_Nuclear14/Chemistry/ChemistTraitSystem.cs
@@ -23,7 +23,7 @@ public sealed class ChemistTraitSystem : EntitySystem
         if (HasComp<ExaminableSolutionComponent>(entity))
             return;
 
-        if (!HasComp<SolutionScannerComponent>(args.Examiner))
+        if (!HasComp<ChemistTrainingComponent>(args.Examiner))
             return;
 
         var reagentLines = new List<string>();

--- a/Content.Server/_Nuclear14/Chemistry/ChemistTraitSystem.cs
+++ b/Content.Server/_Nuclear14/Chemistry/ChemistTraitSystem.cs
@@ -27,7 +27,7 @@ public sealed class ChemistTraitSystem : EntitySystem
             return;
 
         var reagentLines = new List<string>();
-        foreach (var (_, solutionEntity) in _solutionSystem.EnumerateSolutions((Entity<SolutionContainerManagerComponent?>) entity))
+        foreach (var (_, solutionEntity) in _solutionSystem.EnumerateSolutions((entity.Owner, (SolutionContainerManagerComponent?) entity.Comp)))
         {
             var solution = solutionEntity.Comp.Solution;
             if (solution.Volume <= 0)

--- a/Resources/Locale/en-US/_Nuclear14/traits.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/traits.ftl
@@ -89,6 +89,11 @@ trait-description-N14CPRTraining =
    Using this you can remove Airloss damage from people and have a chance to restart their heart.
    (This trait is automatically given for free to medical doctors, and is intended for non-medical characters)
 
+trait-name-N14ChemistTraining = Chemist Training
+trait-description-N14ChemistTraining =
+    Years of mixing & brewing & identifying substances have honed your eyes for chemistry.
+    You examine containers to identify all reagents within & their quantities, as well as the temp of the solution.
+
 trait-name-N14SelfAware = Self-Aware
 trait-description-N14SelfAware =
     You possess a keen intuition of your body and senses.

--- a/Resources/Prototypes/_Nuclear14/Traits/mental.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/mental.yml
@@ -130,7 +130,7 @@
 - type: trait
   id: N14ChemistTraining
   category: Mental
-  points: -6
+  points: -8
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/_Nuclear14/Traits/mental.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/mental.yml
@@ -134,6 +134,7 @@
   functions:
     - !type:TraitAddComponent
       components:
+        - type: SolutionScanner
         - type: ChemistTraining
 
 - type: trait

--- a/Resources/Prototypes/_Nuclear14/Traits/mental.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/mental.yml
@@ -134,7 +134,7 @@
   functions:
     - !type:TraitAddComponent
       components:
-        - type: SolutionScanner
+        - type: ChemistTraining
 
 - type: trait
   id: N14SelfAware

--- a/Resources/Prototypes/_Nuclear14/Traits/mental.yml
+++ b/Resources/Prototypes/_Nuclear14/Traits/mental.yml
@@ -128,6 +128,15 @@
         - type: CPRTraining
 
 - type: trait
+  id: N14ChemistTraining
+  category: Mental
+  points: -6
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: SolutionScanner
+
+- type: trait
   id: N14SelfAware
   category: Mental
   points: -4


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->
adds chemist trait that lets you see solution contents on examine for 8 points (works on everything not just beakers like the upstream scanner thing)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
 
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="842" height="432" alt="image" src="https://github.com/user-attachments/assets/41cb6c66-bf83-4274-b2d3-93226635a530" />

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added chemist trait that lets you see solution contents on examine for 8 points (This is not the same as 10 int, you can see the contents of a mob for example)