### PR TITLE
TINY Tweaks

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/545.yml
+++ b/Resources/Prototypes/Corvax/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/545.yml
@@ -8,3 +8,11 @@
     damage:
       types:
         Piercing: 21
+  # Misfits Add - 5.45mm intermediate rifle round; good range retention
+  - type: BallisticDamageFalloff
+    falloffStartTiles: 8.0
+    maxFalloffTiles: 16.0
+    minDamageMultiplier: 0.60
+  # #Misfits Add: 5.45mm is a medium-caliber rifle round; power armor has a low chance to glance it.
+  - type: Reflective
+    reflective: MediumCaliber

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/12.7.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/12.7.yml
@@ -13,3 +13,5 @@
     falloffStartTiles: 8.0
     maxFalloffTiles: 18.0
     minDamageMultiplier: 0.65
+  - type: Reflective
+    reflective: MediumCaliber


### PR DESCRIPTION
## About the PR
Gave 5.45 the proper falloff comp and reflect, for later use in a special tool that will help us later :godo:
made 12.7 SMG reflect off PA with medium caliber level reflect. Previously it didn't reflect at all.

## Why / Balance
12.7 was once rare, now the PA mulcher 9000 is not. 
Im doing evil shit with 5.45 and want this to be functional and fair.

## Technical details
Yaml

## Media

https://github.com/user-attachments/assets/8cc95636-6de8-41f7-b829-a3798fd5152c

# Changelog

:cl: Bill
- add: Added ricochet to 12.7, it now bounces off PA at the same chances as full rifle calibers have.
- tweak: Tooled up the 5.45 caliber round for potential evil-maxxing later.