### PR TITLE
Legion Weapon BP Overhaul.

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/entities/objects/weapons/guns/shotguns/shotguns.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/entities/objects/weapons/guns/shotguns/shotguns.ftl
@@ -4,4 +4,4 @@ ent-N14WeaponShotgunTrench = Trench Shotgun
     .desc = A WWI-era pump-action shotgun fitted with a heat shield and bayonet lug, holding 5 shells. Its design allows slam-firing — hold the trigger and pump the action repeatedly for a fearsome rate of fire. Justifiably banned by the Hague Convention.
 
 ent-N14WeaponShotgunNeostead = Neostead 2000
-    .desc = A South African bullpup pump-action shotgun with dual 6-round tubes for a total of 12 shells. Semi-automatic cycling and compact form factor provide exceptional firepower in a small package. Highly prized by anyone who values volume of fire.
+    .desc = A Brotherhood-issue semi-automatic shotgun fed from twin underbarrel tubes holding ten shells total. Technology well ahead of the pre-war mainstream — This one has the markings of Legion make.

--- a/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/legionneck.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Clothing/Legion/legionneck.yml
@@ -5,9 +5,9 @@
   description: The grey and black mantle with gold thread trimming shows the wearer is entrusted with matters of money and records.
   components:
   - type: Sprite
-    sprite: _Misfits\Clothing\Neck\treasurer.rsi
+    sprite: _Misfits/Clothing/Neck/treasurer.rsi
   - type: Clothing
-    sprite: _Misfits\Clothing\Neck\treasurer.rsi
+    sprite: _Misfits/Clothing/Neck/treasurer.rsi
 
 - type: entity
   parent: ClothingNeckBase
@@ -16,9 +16,9 @@
   description: Waxed cotton apron with a red bull on it. Marks the wearer as a healer following the wisdom of Caesar. Has pockets for some small medical equipment.
   components:
   - type: Sprite
-    sprite: _Misfits\Clothing\Neck\medicus.rsi
+    sprite: _Misfits/Clothing/Neck/medicus.rsi
   - type: Clothing
-    sprite: _Misfits\Clothing\Neck\medicus.rsi
+    sprite: _Misfits/Clothing/Neck/medicus.rsi
 
 - type: entity
   parent: ClothingNeckBase
@@ -27,6 +27,6 @@
   description: A heavy leather apron designed for protecting the user when metalforging and help carry some minor tools. Marked with a yellow bull.
   components:
   - type: Sprite
-    sprite: _Misfits\Clothing\Neck\forgemaster.rsi
+    sprite: _Misfits/Clothing/Neck/forgemaster.rsi
   - type: Clothing
-    sprite: _Misfits\Clothing\Neck\forgemaster.rsi
+    sprite: _Misfits/Clothing/Neck/forgemaster.rsi

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
@@ -294,7 +294,6 @@
     recipes:
     - N14BPLegionWeaponCeremonialSword
     - N14BPLegionWeaponRevolver44TribalExtra
-    - N14BPLegionWeaponLauncherGrenade
     - N14BPLegionWeaponRifle762SKS     # #Misfits Add - 7.62mm semi-auto rifle
     - N14BPLegionWeaponHandcannonUpgraded
     - N14BPLegionWeaponRipper
@@ -313,6 +312,7 @@
     recipes:
     - N14BPLegionWeaponSuperSledgeHammer
     - N14BPLegionWeaponTribalBigClubDecorated
+    - N14BPLegionWeaponLauncherGrenade
     - N14BPLegionWeaponPolearm
     - N14BPLegionWeaponLauncherMissile
     - N14BPLegionWeaponBren           # #Misfits Add - Bren LMG (.308 FullAuto)

--- a/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
+++ b/Resources/Prototypes/_Misfits/Entities/Objects/Blueprints/blueprints.yml
@@ -263,10 +263,7 @@
     recipes:
     - N14BPLegionWeaponTribalKnife
     - N14BPLegionWeaponTribalClub
-    - N14BPLegionWeaponBrokenPipe
-    - N14BPLegionWeaponNailBoard
     - N14BPLegionWeaponWastelandSpear
-    - N14BPLegionWeaponRevolver44Tribal
 
 - type: entity
   parent: N14BlueprintBase
@@ -276,14 +273,16 @@
   components:
   - type: Blueprint
     recipes:
+    - N14BPLegionWeaponRifle556EM2
     - N14BPLegionWeaponTribalMachete
     - N14BPLegionWeaponMachete
-    - N14BPLegionWeaponTribalHatchet
-    - N14BPLegionWeaponTribalSword
     - N14BPLegionWeaponRevolver44TribalUpgraded
-    - N14BPLegionWeaponShotgunDoubleBarrel
     - N14BPLegionWeaponShotgunPipe
     - N14BPLegionWeaponTrenchClub
+    - N14BPLegionWeaponLongSword
+    - N14BPLegionWeaponSledgeHammer
+    - N14BPLegionWeaponTribalBigClub
+    - N14BPLegionWeaponSMGGreaseGun #Misfits Add - .45 ACP SMG
 
 - type: entity
   parent: N14BlueprintBase
@@ -294,17 +293,15 @@
   - type: Blueprint
     recipes:
     - N14BPLegionWeaponCeremonialSword
-    - N14BPLegionWeaponLongSword
-    - N14BPLegionWeaponSledgeHammer
-    - N14BPLegionWeaponTribalBigClub
     - N14BPLegionWeaponRevolver44TribalExtra
-    - N14BPLegionWeaponHandcannon
-    - N14BPLegionWeaponRifleM1Garand
     - N14BPLegionWeaponLauncherGrenade
-    - N14BPLegionWeaponBaseballBat
-    - N14BPLegionWeaponShotgunNeostead  # #Misfits Add - Semi-auto shotgun
-    - N14BPLegionWeaponSMGGreaseGun    # #Misfits Add - .45 ACP SMG
     - N14BPLegionWeaponRifle762SKS     # #Misfits Add - 7.62mm semi-auto rifle
+    - N14BPLegionWeaponHandcannonUpgraded
+    - N14BPLegionWeaponRipper
+    - N14BPLegionWeaponShotgunAuto    # #Misfits Add - Auto Shotgun
+    - N14BPLegionWeaponRifle762Chinese
+    - N14BPLegionWeaponSMG10mmSuppressed
+    - N14BPLegionWeaponRifleSKS
 
 - type: entity
   parent: N14BlueprintBase
@@ -316,12 +313,10 @@
     recipes:
     - N14BPLegionWeaponSuperSledgeHammer
     - N14BPLegionWeaponTribalBigClubDecorated
-    - N14BPLegionWeaponHandcannonUpgraded
-    - N14BPLegionWeaponRipper
     - N14BPLegionWeaponPolearm
     - N14BPLegionWeaponLauncherMissile
     - N14BPLegionWeaponBren           # #Misfits Add - Bren LMG (.308 FullAuto)
-    - N14BPLegionWeaponShotgunAuto    # #Misfits Add - Auto Shotgun
+    - N14BPLegionWeaponShotgunNeostead  # #Misfits Add - Semi-auto shotgun
 
 # #Misfits Add - T5 Legion Weapons: Scorcher flamethrower (single apex incendiary)
 - type: entity

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -1449,35 +1449,6 @@
 
     Leather: 150
 
-
-- type: latheRecipe
-  id: N14BPLegionWeaponBrokenPipe
-  result: N14BrokenPipe
-  category: N14BlueprintLegionWeaponsT1
-  completetime: 2
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Scrap: 1000
-
-    ScrapSteel: 400
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponNailBoard
-  result: N14NailBoard
-  category: N14BlueprintLegionWeaponsT1
-  completetime: 2
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Wood: 1000
-
-    N14Iron: 200
-
-
 - type: latheRecipe
   id: N14BPLegionWeaponWastelandSpear
   result: N14WastelandSpear
@@ -1492,23 +1463,6 @@
     N14Iron: 700
 
     Leather: 100
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponRevolver44Tribal
-  result: N14WeaponRevolver44Tribal
-  category: N14BlueprintLegionWeaponsT1
-  completetime: 5
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    N14Iron: 500
-
-    Scrap: 100
-
-    Wood: 500
-
 
 # --- Legion Tier 2 Weapons (Legionnaire grade) ---
 - type: latheRecipe
@@ -1639,6 +1593,70 @@
     Leather: 20
 
 
+- type: latheRecipe
+  id: N14BPLegionWeaponSMGGreaseGun
+  result: N14WeaponSMGGreaseGun
+  category: N14BlueprintLegionWeaponsT2
+  completetime: 11
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 4500
+
+    N14Iron: 100
+
+    N14Brass: 150
+
+
+- type: latheRecipe
+  id: N14BPLegionWeaponLongSword
+  result: N14LongSword
+  category: N14BlueprintLegionWeaponsT2
+  completetime: 10
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 3000
+
+    N14Iron: 170
+
+    Leather: 70
+
+
+- type: latheRecipe
+  id: N14BPLegionWeaponSledgeHammer
+  result: N14SledgeHammer
+  category: N14BlueprintLegionWeaponsT2
+  completetime: 10
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 5000
+
+    Wood: 250
+
+    N14Iron: 120
+
+
+- type: latheRecipe
+  id: N14BPLegionWeaponTribalBigClub
+  result: N14TribalBigClub
+  category: N14BlueprintLegionWeaponsT2
+  completetime: 8
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Wood: 3500
+
+    N14Iron: 500
+
+    Leather: 100
+
+
 # --- Legion Tier 3 Weapons (Veteran grade) ---
 - type: latheRecipe
   id: N14BPLegionWeaponCeremonialSword
@@ -1659,54 +1677,6 @@
 
 
 - type: latheRecipe
-  id: N14BPLegionWeaponLongSword
-  result: N14LongSword
-  category: N14BlueprintLegionWeaponsT3
-  completetime: 10
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 3000
-
-    N14Iron: 170
-
-    Leather: 70
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponSledgeHammer
-  result: N14SledgeHammer
-  category: N14BlueprintLegionWeaponsT3
-  completetime: 10
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 5000
-
-    Wood: 250
-
-    N14Iron: 120
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponTribalBigClub
-  result: N14TribalBigClub
-  category: N14BlueprintLegionWeaponsT3
-  completetime: 8
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Wood: 3500
-
-    N14Iron: 500
-
-    Leather: 100
-
-
-- type: latheRecipe
   id: N14BPLegionWeaponRevolver44TribalExtra
   result: N14WeaponRevolver44TribalUpgradedExtra
   category: N14BlueprintLegionWeaponsT3
@@ -1724,101 +1694,7 @@
     N14Brass: 100
 
 
-- type: latheRecipe
-  id: N14BPLegionWeaponHandcannon
-  result: N14WeaponRevolver45-70Handcannon
-  category: N14BlueprintLegionWeaponsT3
-  completetime: 10
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 5000
-
-    N14Iron: 170
-
-    Scrap: 150
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponRifleM1Garand
-  result: N14WeaponRifleM1Garand
-  category: N14BlueprintLegionWeaponsT3
-  completetime: 12
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 6000
-
-    Wood: 2000
-
-    N14Iron: 150
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponLauncherGrenade
-  result: N14WeaponLauncherGrenade
-  category: N14BlueprintLegionWeaponsT3
-  completetime: 15
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 6000
-
-    N14Iron: 700
-
-    N14Brass: 150
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponBaseballBat
-  result: N14BaseBallBat
-  category: N14BlueprintLegionWeaponsT3
-  completetime: 5
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Wood: 450
-
-    Leather: 50
-
-
 # #Misfits Add - T3 firearm parity: semi-auto shotgun, SMG, and carbine rifle to close gap with NCR
-- type: latheRecipe
-  id: N14BPLegionWeaponShotgunNeostead
-  result: N14WeaponShotgunNeostead
-  category: N14BlueprintLegionWeaponsT3
-  completetime: 12
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 7500
-
-    N14Iron: 350
-
-    Leather: 100
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponSMGGreaseGun
-  result: N14WeaponSMGGreaseGun
-  category: N14BlueprintLegionWeaponsT3
-  completetime: 11
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 4500
-
-    N14Iron: 100
-
-    N14Brass: 150
-
-
 - type: latheRecipe
   id: N14BPLegionWeaponRifle762SKS
   result: N14WeaponRifle762SKS
@@ -1854,6 +1730,104 @@
     Leather: 50
 
 
+- type: latheRecipe
+  id: N14BPLegionWeaponHandcannonUpgraded
+  result: N14WeaponRevolver45-70HandcannonUpgraded
+  category: N14BlueprintLegionWeaponsT3
+  completetime: 14
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 6500
+
+    N14Iron: 1000
+
+    N14Brass: 150
+
+    N14Gold: 500
+
+    N14Silver: 500
+
+    Leather: 500
+
+
+- type: latheRecipe
+  id: N14BPLegionWeaponRipper
+  result: N14ripper
+  category: N14BlueprintLegionWeaponsT3
+  completetime: 20
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 3500
+
+    N14Iron: 300
+
+    Circuitry: 200
+
+    ScrapElectronic: 300
+
+
+- type: latheRecipe
+  id: N14BPLegionWeaponShotgunAuto
+  result: N14WeaponShotgunAuto
+  category: N14BlueprintLegionWeaponsT3
+  completetime: 14
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 5500
+
+    Wood: 2000
+
+    Scrap: 1500
+
+    N14Iron: 500
+
+
+- type: latheRecipe
+  id: N14BPLegionWeaponRifle762Chinese
+  result: N14WeaponRifle762Chinese
+  category: N14BlueprintLegionWeaponsT3
+  completetime: 12
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 6500
+
+    Wood: 2000
+
+    N14Iron: 1000
+
+    Plastic: 500
+
+    N14Brass: 300
+
+
+- type: latheRecipe
+  id: N14BPLegionWeaponRifleSKS
+  result: N14WeaponRifleSKS
+  category: N14BlueprintLegionWeaponsT3
+  completetime: 12
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 6500
+
+    Wood: 1500
+
+    N14Iron: 500
+
+    Leather: 300
+
+    N14Brass: 200
+
+
 # --- Legion Tier 4 Weapons (Legate's elite) ---
 - type: latheRecipe
   id: N14BPLegionWeaponSuperSledgeHammer
@@ -1882,49 +1856,17 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Wood: 4000
+    Steel: 3000
 
-    N14Iron: 950
+    Wood: 5000
 
-    Leather: 170
+    N14Iron: 1000
 
-    N14Gold: 100
+    Leather: 500
 
+    N14Gold: 300
 
-- type: latheRecipe
-  id: N14BPLegionWeaponHandcannonUpgraded
-  result: N14WeaponRevolver45-70HandcannonUpgraded
-  category: N14BlueprintLegionWeaponsT4
-  completetime: 14
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 10000
-
-    N14Iron: 300
-
-    N14Brass: 300
-
-    N14Gold: 50
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponRipper
-  result: N14ripper
-  category: N14BlueprintLegionWeaponsT4
-  completetime: 20
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 5500
-
-    N14Iron: 270
-
-    Circuitry: 200
-
-    ScrapElectronic: 150
+    N14Silver: 300
 
 
 - type: latheRecipe
@@ -1936,13 +1878,29 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 2000
+    Steel: 5000
 
-    N14Iron: 350
+    N14Iron: 1000
 
-    Wood: 2500
+    Wood: 3500
 
-    Leather: 120
+
+- type: latheRecipe
+  id: N14BPLegionWeaponLauncherGrenade
+  result: N14WeaponLauncherGrenade
+  category: N14BlueprintLegionWeaponsT4
+  completetime: 15
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 12000
+
+    N14Iron: 1000
+
+    N14Brass: 500
+
+    Wood: 2000
 
 
 - type: latheRecipe
@@ -1963,7 +1921,30 @@
     ScrapElectronic: 150
 
 
-# #Misfits Add - T4 firearm additions: Bren LMG (.308 FullAuto) and Auto Shotgun for DPS parity with NCR T4
+# #Misfits Add - T4 firearm additions: Bren LMG (.308 FullAuto) and Neostead for DPS parity with NCR T4
+- type: latheRecipe
+  id: N14BPLegionWeaponShotgunNeostead
+  result: N14WeaponShotgunNeostead
+  category: N14BlueprintLegionWeaponsT4
+  completetime: 12
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 8500
+
+    N14Iron: 500
+
+    Leather: 100
+
+    ScrapElectronic: 500
+
+    Circuitry: 200
+
+    N14Brass: 300
+
+
+
 - type: latheRecipe
   id: N14BPLegionWeaponBren
   result: N14WeaponLMGBren
@@ -1973,29 +1954,13 @@
   availableFaction:
   - CaesarLegion
   materials:
-    Steel: 11000
+    Steel: 13000
 
     N14Iron: 250
 
-    N14Brass: 300
+    N14Brass: 1000
 
     Wood: 2000
-
-
-- type: latheRecipe
-  id: N14BPLegionWeaponShotgunAuto
-  result: N14WeaponShotgunAuto
-  category: N14BlueprintLegionWeaponsT4
-  completetime: 14
-  requiresBlueprint: true
-  availableFaction:
-  - CaesarLegion
-  materials:
-    Steel: 7000
-
-    N14Iron: 150
-
-    N14Brass: 100
 
 
 # #Misfits Add - T5 Legion Weapons: Scorcher flamethrower (apex incendiary weapon)

--- a/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
+++ b/Resources/Prototypes/_Misfits/Recipes/Lathes/blueprint_recipes_ncr_legion.yml
@@ -1610,6 +1610,26 @@
 
 
 - type: latheRecipe
+  id: N14BPLegionWeaponRifle556EM2
+  result: N14WeaponRifle556EM2
+  category: N14BlueprintLegionWeaponsT2
+  completetime: 11
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 5000
+
+    N14Iron: 500
+
+    Scrap: 500
+
+    Wood: 2000
+
+    Glass: 500
+
+
+- type: latheRecipe
   id: N14BPLegionWeaponLongSword
   result: N14LongSword
   category: N14BlueprintLegionWeaponsT2
@@ -1709,6 +1729,24 @@
     Wood: 200
 
     N14Iron: 120
+
+
+- type: latheRecipe
+  id: N14BPLegionWeaponSMG10mmSuppressed
+  result: N14WeaponSMG10mmSuppressed
+  category: N14BlueprintLegionWeaponsT3
+  completetime: 12
+  requiresBlueprint: true
+  availableFaction:
+  - CaesarLegion
+  materials:
+    Steel: 5000
+
+    Scrap: 1000
+
+    N14Iron: 500
+
+    Plastic: 500
 
 
 # #Misfits Add - M240B GPMG for Tier 3 Legion crafting

--- a/Resources/Prototypes/_Nuclear14/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Markers/Spawners/jobs.yml
@@ -396,7 +396,7 @@
   - type: Sprite
     layers:
       - state: green
-      - state: veteran # Misfits Change - shutting up an error, TODO: we should get a platoonlead sprite for this
+      - state: lt # Misfits Change - shutting up an error, TODO: we should get a platoonlead sprite for this
 
 # Tribals
 - type: entity

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -710,7 +710,7 @@
     maxAngle: 50
     angleIncrease: 4
     angleDecay: 14
-    fireRate: 2
+    fireRate: 3
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto


### PR DESCRIPTION
## About the PR
Large overhaul to Legion Weapon BP's, including the removal of unused/excess weapon BP's, price changes, tier changes, and new weapons. Draft currently until further feedback/updates.

## Why / Balance
Legion BP's were noticeably lacking in substance compared to the other majors. This PR is part of a larger push to look at and update BP's and kits across most factions, Legion being first as they've got some of the most antiquated ones.

With one exception (Neostead), no weapons have had their actual stats changed.

**NEW BLUEPRINTS**

308 SKS: T3 BP. 65 Steel, 15 Wood, 5 Iron, 3 Leather, 2 Brass.

Chinese Assault Rifle: T3 BP. 65 Steel, 20 Wood, 10 Iron, 5 Plastic, 3 Brass.

Suppressed 10mm SMG: T3 BP. 50 Steel, 10 Scrap, 5 Iron, 5 Plastic.

EM2 Assault Rifle: T2 BP. 50 Steel, 5 Scrap, 5 Iron, 20 Wood, 5 Glass.

**REMOVED BP'S**

Broken Pipe, Nailboard, 4 round Tribal 44, Tribal Hatchet, Tribal Sword, Double Barrel Shotgun, M1 Garand, Tribal Handcannon (NOT Decorated, that's still in), Baseball Bat.

**ALTERED BP'S**

Numerous BP's had their tiers changed, tier changes are in the code but the most relevant price changes will be listed here.

Decorated Tribal Club: Extremely cheap for a weapon that was Super Sledge tier. Price boosted to 30 Steel, 50 Wood, 10 Iron, 5 Leather, 3 Silver, 3 Gold.

PoleAxe: Another extremely cheap weapon that still sits at the top of the melee weapon food chain. Price increased to 50 Steel, 10 Iron, 35 Wood.

Grenade Launcher: A 4 round GL that was extremely cheap at 60 steel. Has been boosted to T4 and now costs 120 Steel, 10 Iron, 5 Brass, and 20 Wood.

Bren Gun: Probably the strongest craftable machinegun in the game, still gets away with relatively minor cost increases. Now costs 130 Steel, 2.5 Iron, 10 Brass and 20 Wood.

Neostead 2000: The Neostead was extremely controversial in the past due to being dirt cheap and having great stats. The Neostead is being made a T4, having it's price increased to 85 Steel, 5 Iron, 1 Leather, 5 Scrap Electronics, 2 Circuitry, and 3 Brass, and is having it's ROF returned to 3.0.

Decorated Tribal Handcannon: Was extremely overpriced for what it offered. Costs reduced in exchange for more exotic materials. Weapon reduced to T3 and price changed to 65 Steel, 10 Iron, 1.5 Brass, 5 Gold, 5 Silver, 5 Leather. 

## Technical details
Largely .yml changes.

# Changelog

:cl:
- add: New Legion Blueprints have been sent in from the Augustus, and old designs have been changed.
