### PR TITLE
More 80's Nerfs, Brahdo Hitbox, Rash Cant Ride 

### DIFF
--- a/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
+++ b/Resources/Prototypes/_Misfits/Roles/Jobs/Eighties/eighties.yml
@@ -292,8 +292,6 @@
         factions:
           - PlayerRaider
           - Wastelander
-  - !type:AddTraitSpecial
-    traits: [ N14RidingPerk ]
 
 - type: startingGear
   id: EightiesRoadRashGear

--- a/Resources/Prototypes/_Misfits/Traits/mounts.yml
+++ b/Resources/Prototypes/_Misfits/Traits/mounts.yml
@@ -7,3 +7,8 @@
     - !type:TraitAddComponent
       components:
         - type: RidingPerk
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+    - EightiesRoadRash # you must learn to ride

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Vehicles/landvehicles.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Vehicles/landvehicles.yml
@@ -30,6 +30,16 @@
     friction: 0.1
     baseWalkSpeed: 8
     baseSprintSpeed: 8
+  - type: Fixtures # So they cant fit through 1 door.
+    fixtures:
+      fix1:
+        hard: true
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.75
+        density: 50
+        mask:
+        - MobMask
   - type: ItemSlots
     slots:
       key_slot:


### PR DESCRIPTION
🆑 


- tweak: Road Rash forgot how to ride bikes, oh no! They will have to learn ic  )also cant take it from perks.)
- tweak: Bikes cant fit through a single tile anymore. 
