### PR TITLE
Ppsh Buff, 180 to Loadouts and some Description Fixes

### DIFF
--- a/Resources/Locale/en-US/_Nuclear14/entities/objects/weapons/guns/smgs/smgs.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/entities/objects/weapons/guns/smgs/smgs.ftl
@@ -14,8 +14,8 @@ ent-N14WeaponSMGGreaseGun = M3A1 "Grease Gun"
 ent-N14WeaponSMGAmerican180 = American 180
     .desc = A .22 LR submachine gun fed by a 35-round drum with an integrated suppressor. Whisper-quiet and ferociously fast. What it lacks in stopping power it more than compensates for in round volume.
 
-ent-N14MagazineSMG9mmDrum = 9mm drum magazine (35)
+ent-N14MagazineSMG9mmDrum = smg drum magazine (9mm)
     .desc = A 71-round drum magazine loaded with 9mm Parabellum cartridges. Compatible with the PPSh-41.
 
-ent-N14MagazineAmerican180Drum = .22 LR drum magazine (35)
+ent-N14MagazineAmerican180Drum = smg drum magazine (.22lr)
     .desc = A 177-round drum magazine loaded with .22 Long Rifle cartridges. Fits the American 180 submachine gun.

--- a/Resources/Locale/en-US/_Nuclear14/entities/objects/weapons/guns/smgs/smgs.ftl
+++ b/Resources/Locale/en-US/_Nuclear14/entities/objects/weapons/guns/smgs/smgs.ftl
@@ -15,7 +15,7 @@ ent-N14WeaponSMGAmerican180 = American 180
     .desc = A .22 LR submachine gun fed by a 35-round drum with an integrated suppressor. Whisper-quiet and ferociously fast. What it lacks in stopping power it more than compensates for in round volume.
 
 ent-N14MagazineSMG9mmDrum = 9mm drum magazine (35)
-    .desc = A 35-round drum magazine loaded with 9mm Parabellum cartridges. Compatible with the PPSh-41.
+    .desc = A 71-round drum magazine loaded with 9mm Parabellum cartridges. Compatible with the PPSh-41.
 
 ent-N14MagazineAmerican180Drum = .22 LR drum magazine (35)
-    .desc = A 35-round drum magazine loaded with .22 Long Rifle cartridges. Fits the American 180 submachine gun.
+    .desc = A 177-round drum magazine loaded with .22 Long Rifle cartridges. Fits the American 180 submachine gun.

--- a/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/_Misfits/drums.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Objects/Weapons/Guns/Ammunition/Magazines/_Misfits/drums.yml
@@ -14,7 +14,7 @@
     whitelist:
       tags:
         - N14CartridgePistol9
-    capacity: 35
+    capacity: 71 # Misfits 
     proto: N14CartridgePistol9
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
+++ b/Resources/Prototypes/_Nuclear14/Loadouts/weapons.yml
@@ -570,25 +570,25 @@
   items:
     - N14WeaponSMGPPSh41
 
-#- type: loadout
-#  id: N14WeaponSMGAmerican180
-#  category: Weapons
-#  cost: 15
-#  requirements:
-#    - !type:CharacterItemGroupRequirement
-#      group: N14LoadoutGunsBig
-#    - !type:CharacterDepartmentRequirement
-#      inverted: true
-#      departments:
-#      - Vault
-#    - !type:CharacterJobRequirement
-#      inverted: true
-#      jobs:
-#      - BoSMidSerf
-#      - CaesarLegionSlave
-#      - NCRPrisoner
-#  items:
-#    - N14WeaponSMGAmerican180
+- type: loadout
+  id: N14WeaponSMGAmerican180
+  category: Weapons
+  cost: 15
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutGunsBig
+    - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+      - Vault
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14WeaponSMGAmerican180
 
 
 
@@ -1318,22 +1318,22 @@
   items:
     - N14MagazineSMG9mmDrum
     
-#- type: loadout
-#  id: N14MagazineAmerican180Drum
-#  category: Weapons
-#  cost: 3
-#  requirements:
-#    - !type:CharacterItemGroupRequirement
-#      group: N14LoadoutAmmoBig
-#    - !type:CharacterJobRequirement
-#      inverted: true
-#      jobs:
-#      - BoSMidSerf
-#      - CaesarLegionSlave
-#      - NCRPrisoner
-#  items:
-#    - N14MagazineAmerican180Drum
-# ARs
+- type: loadout
+  id: N14MagazineAmerican180Drum
+  category: Weapons
+  cost: 3
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: N14LoadoutAmmoBig
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - BoSMidSerf
+      - CaesarLegionSlave
+      - NCRPrisoner
+  items:
+    - N14MagazineAmerican180Drum
+ ARs
 
 
 - type: loadout


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Its a drum mag, why does it only have 35??? so I made it real life accurate of 71
Un-commented out the 180 from loadouts cause its 180, the gun with 22 lr 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added 180 to Loadouts
- tweak: 9mm drum mag now holds 71 shots
- fix: Wrong Description on 22lr Drum Mag
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
